### PR TITLE
[8.0][IMP][account_voucher_withholding] Exportación a SICORE

### DIFF
--- a/account_voucher_withholding/__openerp__.py
+++ b/account_voucher_withholding/__openerp__.py
@@ -43,5 +43,5 @@ Add withholding management on vouchers
     'installable': True,
     'name': 'Voucher Voucher Withholding',
     'test': [],
-    'version': '8.0.1.9.0',
+    'version': '8.0.1.10.0',
 }

--- a/account_voucher_withholding/views/account_withholding_view.xml
+++ b/account_voucher_withholding/views/account_withholding_view.xml
@@ -77,6 +77,7 @@
             </field>
         </record>   
 
+        <!-- Left for convenience. TODO: Remove in a future version -->
         <record model="ir.actions.act_window" id="action_account_voucher_withholding">
             <field name="name">Withholding Vouchers</field>
             <field name="res_model">account.voucher.withholding</field>
@@ -85,7 +86,45 @@
             <field name="context">{'search_default_state': 'posted'}</field>
         </record>
 
+        <!-- Left for convenience. TODO: Remove in a future version -->
         <menuitem action="action_account_voucher_withholding" id="menu_account_voucher_withholding" parent="account.menu_finance_bank_and_cash" sequence="11"/>
+
+
+        <record model="ir.actions.act_window" id="action_account_voucher_withholding_suffered">
+            <field name="name">Suffered Withholdings</field>
+            <field name="res_model">account.voucher.withholding</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+            <field name="domain">[('type', '=', 'receipt')]</field>
+            <field name="context">{'search_default_state': 'posted'}</field>
+        </record>
+
+        <record model="ir.actions.act_window" id="action_account_voucher_withholding_applied">
+            <field name="name">Applied Withholdings</field>
+            <field name="res_model">account.voucher.withholding</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+            <field name="domain">[('type', '=', 'payment')]</field>
+            <field name="context">{'search_default_state': 'posted'}</field>
+        </record>
+
+        <menuitem
+            name="Tax Withholdings"
+            id="menu_account_withholding"
+            parent="account.menu_finance_periodical_processing"
+            sequence="31" />
+
+        <menuitem
+            action="action_account_voucher_withholding_suffered"
+            id="menu_account_voucher_withholding_suffered"
+            parent="menu_account_withholding"
+            sequence="10" />
+
+        <menuitem
+            action="action_account_voucher_withholding_applied"
+            id="menu_account_voucher_withholding_applied"
+            parent="menu_account_withholding"
+            sequence="11" />
 
     </data>
 </openerp>


### PR DESCRIPTION
Implementación de un Wizard para exportar las retenciones de ganancias a SICORE.
## 

~~Es todavía un WIP~~.
Favor de probar y sugerir cambios donde sea necesario.
- [x] Los filtros de fechas y compañia están siendo ignorados (a modo testing). Falta agregarlos al domain.
- [x] Sugerir rango de fechas por defecto (quincena anterior a la actual)
- [ ] ~~Traducciones~~
- [x] cambio de versión a "8.0.1.10.0".
- [x] Separar modificaciones en módulos "account_voucher_withholding" y "l10n_ar_account_withholding"
  En el nuevo pr modificando "l10n_ar_account_withholding" tener en cuenta:
- [x] valor por defecto en cia y hacer requerido
- [ ] al menú de exportar a SICORE (que llama al wizard) agregarle el grupo
## 

**Notas:**

Para que funcione, es necesario configurar el SICORE con estos parámetros de importación:
![sin titulo](https://cloud.githubusercontent.com/assets/1914185/19703846/bffdeecc-9adb-11e6-9789-ed4444950c74.png)

Además, se debe configurar el código de impuestos según la tabla de AFIP
![sin titulo2](https://cloud.githubusercontent.com/assets/1914185/19703910/0a7d8836-9adc-11e6-8400-fd8b97af2e48.png)
