### PR TITLE
[MERGE] port-forward from 9.0

### DIFF
--- a/account_payment_group/models/account_invoice.py
+++ b/account_payment_group/models/account_invoice.py
@@ -179,3 +179,10 @@ class AccountInvoice(models.Model):
     @api.onchange('company_id')
     def _onchange_company_id(self):
         self.pay_now_journal_id = False
+
+    @api.multi
+    def action_cancel(self):
+        self.filtered(
+            lambda x: x.state == 'open' and x.pay_now_journal_id).write(
+                {'pay_now_journal_id': False})
+        return super(AccountInvoice, self).action_cancel()


### PR DESCRIPTION
* [IMP] clean the field pay_now_journal_id if cancel an validate invoice. (#115)

We celan de pay_now_journal_id because the invoice would be already paid and we are going to make a second payment upon validation.