### PR TITLE
[FIX] account_check: Be able to validate detailed check's transfer

### DIFF
--- a/account_check/__manifest__.py
+++ b/account_check/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Account Check Management',
-    'version': '11.0.1.6.0',
+    'version': '11.0.1.6.1',
     'category': 'Accounting',
     'summary': 'Accounting, Payment, Check, Third, Issue',
     'author': 'ADHOC SA',

--- a/account_check/models/account_payment.py
+++ b/account_check/models/account_payment.py
@@ -609,7 +609,7 @@ class AccountPayment(models.Model):
         """
         self.ensure_one()
         res = self.env['account.move.line']
-        move.button_cancel()
+        move.write({'state': 'draft'})
         checks = self.check_ids
         aml = move.line_ids.with_context(check_move_validity=False).filtered(
             lambda x: x.name != self.name)


### PR DESCRIPTION
Currentlty this was throwing an error when the diary was not configured to
allow cancel entries. Now we change the code that separate the entries into
one line per check in order to work no matter the journal configuration (this
is an internal and needed change and does not affect the other entries)