### PR TITLE
[FIX] account_payment_group: back port from version 11.0

### DIFF
--- a/account_check/models/account_check.py
+++ b/account_check/models/account_check.py
@@ -98,7 +98,7 @@ class AccountCheckOperation(models.Model):
         for rec in self:
             try:
                 if rec.origin:
-                    id, name = rec.origin.name_get()[0]
+                    _id, name = rec.origin.name_get()[0]
                     origin_name = name
                     # origin_name = rec.origin.display_name
                 else:

--- a/account_check/models/res_company.py
+++ b/account_check/models/res_company.py
@@ -29,18 +29,18 @@ class ResCompany(models.Model):
     )
 
     @api.multi
-    def _get_check_account(self, type):
+    def _get_check_account(self, check_type):
         self.ensure_one()
-        if type == 'holding':
+        if check_type == 'holding':
             account = self.holding_check_account_id
-        elif type == 'rejected':
+        elif check_type == 'rejected':
             account = self.rejected_check_account_id
-        elif type == 'deferred':
+        elif check_type == 'deferred':
             account = self.deferred_check_account_id
         else:
-            raise UserError(_("Type %s not implemented!"))
+            raise UserError(_("Check type %s not implemented!") % check_type)
         if not account:
             raise UserError(_(
                 'No checks %s account defined for company %s'
-            ) % (type, self.name))
+            ) % (check_type, self.name))
         return account

--- a/account_payment_group/models/account_payment.py
+++ b/account_payment_group/models/account_payment.py
@@ -172,7 +172,10 @@ class AccountPayment(models.Model):
         if self.env.registry.in_test_mode():
             return True
         for rec in self:
-            if rec.partner_type and rec.partner_id and \
+            receivable_payable = all([
+                x['move_line'].account_id.internal_type in ['receivable', 'payable']
+                for x in self._context.get('counterpart_aml_dicts', [])])
+            if rec.partner_type and rec.partner_id and receivable_payable and \
                not rec.payment_group_id:
                 raise ValidationError(_(
                     'Payments with partners must be created from '
@@ -246,27 +249,28 @@ class AccountPayment(models.Model):
 
     @api.model
     def create(self, vals):
-        """
-        When payments are created from bank reconciliation create the
-        Payment group before creating payment to avoid raising error
-        """
+        """ When payments are created from bank reconciliation create the
+        Payment group before creating payment to avoid raising error, only
+        apply when the all the counterpart account are receivable/payable """
         # Si viene counterpart_aml entonces estamos viniendo de una
         # conciliacion desde el wizard
-        create_from_statement = self._context.get(
-            'create_from_statement', False)
-        create_from_expense = self._context.get('create_from_expense', False)
         new_aml_dicts = self._context.get('new_aml_dicts', [])
         counterpart_aml_data = self._context.get('counterpart_aml_dicts', [])
         if counterpart_aml_data or new_aml_dicts:
             vals.update(self.infer_partner_info(vals))
 
+        create_from_statement = self._context.get(
+            'create_from_statement', False) and vals.get('partner_type') \
+            and vals.get('partner_id') and all([
+                x['move_line'].account_id.internal_type in [
+                    'receivable', 'payable']
+                for x in counterpart_aml_data])
+        create_from_expense = self._context.get('create_from_expense', False)
         create_from_website = self._context.get('create_from_website', False)
         # NOTE: This is required at least from POS when we do not have
         # partner_id and we do not want a payment group in tha case.
-        create_payment_group = (
-            create_from_statement and vals.get('partner_type')
-            and vals.get('partner_id')) or create_from_website or \
-            create_from_expense
+        create_payment_group = \
+            create_from_statement or create_from_website or create_from_expense
         if create_payment_group:
             company_id = self.env['account.journal'].browse(
                 vals.get('journal_id')).company_id.id

--- a/account_payment_group/models/account_payment.py
+++ b/account_payment_group/models/account_payment.py
@@ -173,7 +173,8 @@ class AccountPayment(models.Model):
             return True
         for rec in self:
             receivable_payable = all([
-                x['move_line'].account_id.internal_type in ['receivable', 'payable']
+                x['move_line'].account_id.internal_type in [
+                    'receivable', 'payable']
                 for x in self._context.get('counterpart_aml_dicts', [])])
             if rec.partner_type and rec.partner_id and receivable_payable and \
                not rec.payment_group_id:

--- a/account_payment_group/models/payment_transaction.py
+++ b/account_payment_group/models/payment_transaction.py
@@ -4,7 +4,9 @@
 ##############################################################################
 from odoo import api, models
 
+
 class PaymentTransaction(models.Model):
+
     _inherit = 'payment.transaction'
 
     @api.multi

--- a/account_withholding_automatic/models/account_tax.py
+++ b/account_withholding_automatic/models/account_tax.py
@@ -2,7 +2,7 @@ from odoo import models, fields, api, _
 import odoo.addons.decimal_precision as dp
 from odoo.exceptions import UserError, ValidationError
 from ast import literal_eval
-from odoo.tools.safe_eval import safe_eval as eval
+from odoo.tools.safe_eval import safe_eval
 from dateutil.relativedelta import relativedelta
 import datetime
 
@@ -322,7 +322,7 @@ result = withholdable_base_amount * 0.10
                 'partner': payment_group.commercial_partner_id,
                 'withholding_tax': self,
             }
-            eval(
+            safe_eval(
                 self.withholding_python_compute, localdict,
                 mode="exec", nocopy=True)
             period_withholding_amount = localdict['result']


### PR DESCRIPTION
[FIX] account_payment_group: create payment group only when involves receivavle/payable move lines.

Do not create payment group for payments that have not receivavle payable accounts (in move lines). This case was applied because we found and error that happens when try to reconcile a check payment with a bank statement line, it was creating a new payment group and this one is not required.