### PR TITLE
[FIX] account_payment_group: proper manage counterpart_aml_dicts

### DIFF
--- a/account_payment_group/models/account_payment.py
+++ b/account_payment_group/models/account_payment.py
@@ -196,7 +196,7 @@ class AccountPayment(models.Model):
             'counterpart_aml_dicts', 'new_aml_dicts', 'payment_aml_rec')
          :return: account move line recorset
         """
-        counterpart_aml_data = self._context.get('counterpart_aml_dicts', [])
+        counterpart_aml_data = self._context.get('counterpart_aml_dicts', [{}])
         new_aml_data = self._context.get('new_aml_dicts', [])
         amls = self.env['account.move.line']
         if counterpart_aml_data:
@@ -256,7 +256,7 @@ class AccountPayment(models.Model):
         # Si viene counterpart_aml entonces estamos viniendo de una
         # conciliacion desde el wizard
         new_aml_dicts = self._context.get('new_aml_dicts', [])
-        counterpart_aml_data = self._context.get('counterpart_aml_dicts', [])
+        counterpart_aml_data = self._context.get('counterpart_aml_dicts', [{}])
         if counterpart_aml_data or new_aml_dicts:
             vals.update(self.infer_partner_info(vals))
 


### PR DESCRIPTION
counterpart_aml_dicts is a list of dictionaries, for that reason when we try to iterate in this value, we need to set as  [{}] when this one does not came in the context, so when we iterate we can be able to manage the dict info.