### PR TITLE
[12.0][FIX] account_payment_group: Sorted the payments

### DIFF
--- a/account_payment_group/models/account_payment_group.py
+++ b/account_payment_group/models/account_payment_group.py
@@ -627,7 +627,7 @@ class AccountPaymentGroup(models.Model):
             # al crear desde website odoo crea primero el pago y lo postea
             # y no debemos re-postearlo
             if not create_from_website and not create_from_expense:
-                rec.payment_ids.filtered(lambda x: x.state == 'draft').post()
+                rec.payment_ids.sorted(key=lambda l: l.signed_amount).filtered(lambda x: x.state == 'draft').post()
 
             counterpart_aml = rec.payment_ids.mapped('move_line_ids').filtered(
                 lambda r: not r.reconciled and r.account_id.internal_type in (


### PR DESCRIPTION
To avoid an error when you validate a payment with an amount that complete the balance of then invoice an the payment have an payment with some diffent of the amount that you pay an the amount of the invoice that you paid.

