### PR TITLE
[11.0] [FIX] account_payment_group: use sudo to read value

### DIFF
--- a/account_payment_group/models/account_payment_group.py
+++ b/account_payment_group/models/account_payment_group.py
@@ -407,7 +407,7 @@ class AccountPaymentGroup(models.Model):
     @api.depends('payment_ids.signed_amount_company_currency')
     def _compute_payments_amount(self):
         for rec in self:
-            rec.payments_amount = sum(rec.payment_ids.mapped(
+            rec.payments_amount = sum(rec.sudo().payment_ids.mapped(
                 'signed_amount_company_currency'))
             # payments_amount = sum([
             #     x.payment_type == 'inbound' and


### PR DESCRIPTION
For an cache error who occurs with an user not admin, we use sudo to read the value of signed_amount_company_currency