### PR TITLE
[FIX] doble payment on inv cancel due to pay now

### DIFF
--- a/account_payment_group/models/account_invoice.py
+++ b/account_payment_group/models/account_invoice.py
@@ -186,7 +186,5 @@ class AccountInvoice(models.Model):
 
     @api.multi
     def action_cancel(self):
-        self.filtered(
-            lambda x: x.state == 'open' and x.pay_now_journal_id).write(
-                {'pay_now_journal_id': False})
+        self.filtered(lambda x: x.state != 'draft' and x.pay_now_journal_id).write({'pay_now_journal_id': False})
         return super(AccountInvoice, self).action_cancel()


### PR DESCRIPTION
With this change odoo now allows to cancel paid invoices https://github.com/odoo/odoo/commit/5cca55dac7b56a176f8cad046e0a089dabd0db6f
So we only leave pay_now_journal_id if invoice was on draft state