### PR TITLE
[FIX] payment post on multicurrency and multicompany

### DIFF
--- a/account_payment_group/models/account_payment_group.py
+++ b/account_payment_group/models/account_payment_group.py
@@ -606,8 +606,8 @@ class AccountPaymentGroup(models.Model):
         create_from_statement = self._context.get(
             'create_from_statement', False)
         create_from_expense = self._context.get('create_from_expense', False)
-        self = self.with_context({})
         for rec in self:
+            rec = rec.with_context({'company_id': rec.company_id.id})
             # TODO if we want to allow writeoff then we can disable this
             # constrain and send writeoff_journal_id and writeoff_acc_id
             if not rec.payment_ids:


### PR DESCRIPTION
On payment post this method is called to get amounts: https://github.com/odoo/odoo/blob/47f176f5d8e66d9de5a829983bee94e328237115/addons/account/models/account_payment.py#L725
And that method call this one that uses company on the context to compute the right amount: https://github.com/odoo/odoo/blob/a230690d947be2095ad1ec7ccca170f9faa222dc/addons/account/models/account_move.py#L1365
We need payment company on the context to make it consistent.