### PR TITLE
[FIX] account_check: manual operation creation

### DIFF
--- a/account_check/models/account_check.py
+++ b/account_check/models/account_check.py
@@ -394,7 +394,7 @@ class AccountCheck(models.Model):
     )
     def _compute_state(self):
         for rec in self:
-            if rec.operation_ids:
+            if rec.operation_ids.sorted():
                 operation = rec.operation_ids.sorted()[0].operation
                 rec.state = operation
             else:


### PR DESCRIPTION
When creating manually a first manual operation on checks the sorted was returning empty recordset, and then we get this error.
We fix by checking ame condition on the if
  File "/home/odoo/custom/repositories/ingadhoc-account-payment/account_check/models/account_check.py", line 398, in _compute_state
    operation = rec.operation_ids.sorted()[0].operation
  File "/home/odoo/.local/lib/python3.7/site-packages/odoo/models.py", line 5614, in __getitem__
    return self.browse((self._ids[key],))
IndexError: tuple index out of range