### PR TITLE
[FIX] account_payment_group: mapping states from account.payment

### DIFF
--- a/account_payment_group/hooks.py
+++ b/account_payment_group/hooks.py
@@ -21,6 +21,8 @@ def post_init_hook(cr, registry):
     for payment in payments:
 
         _logger.info('creating payment group for payment %s' % payment.id)
+        _state = payment.state in ['sent', 'reconciled'] and 'posted' or payment.state
+        _state = _state if _state != 'cancelled' else 'cancel'
         env['account.payment.group'].create({
             'company_id': payment.company_id.id,
             'partner_type': payment.partner_type,
@@ -31,7 +33,5 @@ def post_init_hook(cr, registry):
             # name es la secuencia
             'communication': payment.communication,
             'payment_ids': [(4, payment.id, False)],
-            'state': (
-                payment.state in ['sent', 'reconciled'] and
-                'posted' or payment.state),
+            'state': _state,
         })


### PR DESCRIPTION
Buenas.
Encontre un detalle al querer instalar account_payment_group a una base con datos. 
Estaba mapeando mal los estados de accout.payment a account.payment.group, en uno es cancel y en otro cancelled
Esta arreglado y probado, 
Saludos !!

    account.payment
    state = fields.Selection([
        ('draft', 'Draft'), 
        ('posted', 'Validated'), 
        ('sent', 'Sent'), 
        ('reconciled', 'Reconciled'), 
        ('cancelled', 'Cancelled')], 
    
    account.payment.group
    state = fields.Selection([
        ('draft', 'Draft'),
        ('confirmed', 'Confirmed'),
        ('posted', 'Posted'),
        # ('sent', 'Sent'),
        # ('reconciled', 'Reconciled')
        ('cancel', 'Cancelled'),

