### PR TITLE
[13.0] [FIX] account_payment_group: revert this commit because they crash the translations

### DIFF
--- a/account_payment_group/i18n/es.po
+++ b/account_payment_group/i18n/es.po
@@ -403,7 +403,6 @@ msgstr "Si marca nuevos mensajes requieren su atención"
 
 #. module: account_payment_group
 #: model:ir.model.fields,help:account_payment_group.field_account_payment_group__message_needaction
-#: model:ir.model.fields,help:account_payment_group.field_account_payment_group__message_unread
 msgid "If checked, new messages require your attention."
 msgstr "Si marca, nuevos mensajes requieren su atención."
 


### PR DESCRIPTION

Revert "Correccion en la traduccion."

This reverts commit e44ec3d795d28e942053ad290626d7b8d3a74eb8.