### PR TITLE
[12.0] [FIX] account_check: Be able to confirm transference without the allow to cancel entry's.

### DIFF
--- a/account_check/models/account_payment.py
+++ b/account_check/models/account_payment.py
@@ -604,7 +604,7 @@ class AccountPayment(models.Model):
         """
         self.ensure_one()
         res = self.env['account.move.line']
-        move.button_cancel()
+        move.write({'state': 'draft'})
         checks = self.check_ids
         aml = move.line_ids.with_context(check_move_validity=False).filtered(
             lambda x: x.name != self.name)


### PR DESCRIPTION

Not cancel the entry, only set to draft before generate the new lines.