### PR TITLE
[13.0] [FIX] account_payment_group: Avoid rights bugs for sales users.

### DIFF
--- a/account_payment_group/__manifest__.py
+++ b/account_payment_group/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Account Payment with Multiple methods",
-    "version": "13.0.1.2.0",
+    "version": "13.0.1.3.0",
     "category": "Accounting",
     "website": "www.adhoc.com.ar",
     "author": "ADHOC SA, AITIC S.A.S",

--- a/account_payment_group/models/account_move.py
+++ b/account_payment_group/models/account_move.py
@@ -25,6 +25,7 @@ class AccountMove(models.Model):
         'account.payment.group',
         compute='_compute_payment_groups',
         string='Payment Groups',
+        compute_sudo=True,
     )
 
     def _compute_payment_groups(self):

--- a/account_payment_group/views/account_move_line_view.xml
+++ b/account_payment_group/views/account_move_line_view.xml
@@ -64,6 +64,7 @@
             <button type="object"  name="action_view_payment_groups"
                     class="oe_link" string="View Payments"
                     colspan="2"
+                    groups="account.group_account_invoice"
                     attrs="{'invisible':[('payment_group_ids','=',[])]}"/>
         </field>
     </field>


### PR DESCRIPTION
For  a sale user without accounting rights, this user need to see the invoice who has payments entries that is related to the sale order. This way the user can load the invoice.