### PR TITLE
[fix] Los campos computados deben devolver un valor

### DIFF
--- a/account_payment_group/models/account_move_line.py
+++ b/account_payment_group/models/account_move_line.py
@@ -31,6 +31,7 @@ class AccountMoveLine(models.Model):
         """
         payment_group_id = self._context.get('payment_group_id')
         if not payment_group_id:
+            self.payment_group_matched_amount = 0.0
             return False
         payments = self.env['account.payment.group'].browse(
             payment_group_id).payment_ids


### PR DESCRIPTION
No se puede  utilizar account_payment_group + pos + algunos módulos de terceros que crean account.move.line  (por ejemplo wk_pos_partial_payment) porque pos no crea el payment group cuando concilia un pago. Este workarround deja operativos los módulos pero no es una solución total al problema. 

Las soluciones mas lógicas  podrían ser :

- Que se cree el payment group automáticamente cuando  creo un account.payment sin ningún valor en el campo payment_group_id (no se si generaría conflictos cuando se cargan pagos) 

- O crear un modulo que cree el payment group cuando concilio desde el pos. (pos_account_payment_group_fix)

