### PR TITLE
[IMP] payment_group: inherability default payment date

### DIFF
--- a/account_payment_group/models/account_payment_group.py
+++ b/account_payment_group/models/account_payment_group.py
@@ -65,7 +65,6 @@ class AccountPaymentGroup(models.Model):
     )
     payment_date = fields.Date(
         string='Payment Date',
-        default=fields.Date.context_today,
         required=True,
         copy=False,
         readonly=True,
@@ -491,9 +490,10 @@ class AccountPaymentGroup(models.Model):
         self.to_pay_move_line_ids = False
 
     @api.model
-    def default_get(self, fields):
+    def default_get(self, defaul_fields):
         # TODO si usamos los move lines esto no haria falta
-        rec = super().default_get(fields)
+        rec = super().default_get(defaul_fields)
+        rec['payment_date'] = fields.Date.context_today(self)
         to_pay_move_line_ids = self._context.get('to_pay_move_line_ids')
         to_pay_move_lines = self.env['account.move.line'].browse(
             to_pay_move_line_ids).filtered(lambda x: (


### PR DESCRIPTION
With this change, payment date default value can be overwritten correctly.
Without this change, if inherited and updating account_payment_group, the original default value was applied. (use case: sipreco)