### PR TITLE
[REF] account_payment_group: add open button on aml lines

### DIFF
--- a/account_payment_group/__manifest__.py
+++ b/account_payment_group/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Account Payment with Multiple methods",
-    "version": "13.0.1.5.0",
+    "version": "13.0.1.6.0",
     "category": "Accounting",
     "website": "www.adhoc.com.ar",
     "author": "ADHOC SA, AITIC S.A.S",
@@ -17,6 +17,7 @@
         "account_financial_amount",
         # for fixes related to domains and company_id field on form view
         "account_payment_fix",
+        "account_ux",
     ],
     "data": [
         'security/security.xml',

--- a/account_payment_group/views/account_move_line_view.xml
+++ b/account_payment_group/views/account_move_line_view.xml
@@ -23,6 +23,7 @@
             <field name="currency_id" invisible="1"/>
             <field name="company_currency_id" invisible="1"/>
             <field name="company_id" invisible="1"/>
+            <button type="object" string="Open Document" icon="fa-external-link" help="Open Related Document" name="action_open_related_document"/>
         </tree>
     </field>
 </record>


### PR DESCRIPTION
We change the dependency between account_ux and account_payment_group because it's more common the usage of account_ux without  account_payment_group than account_payment_group without account_ux
We wont to avoid adding a new glue module on v13
In v15 account_payment_group may be deprecated