### PR TITLE
[15.0] [PORT] From 13.0

### DIFF
--- a/account_check/__manifest__.py
+++ b/account_check/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Account Check Management',
-    'version': "13.0.1.3.0",
+    'version': "13.0.1.4.0",
     'category': 'Accounting',
     'summary': 'Accounting, Payment, Check, Third, Issue',
     'author': 'ADHOC SA, AITIC S.A.S',

--- a/account_check/views/account_payment_view.xml
+++ b/account_check/views/account_payment_view.xml
@@ -73,7 +73,7 @@
             </group>
             </group>
             <xpath expr="//div[@name='amount_div']//field[@name='amount']" position="attributes">
-                <attribute name="attrs">{'readonly': [('payment_method_code', '=', 'delivered_third_check')]}</attribute>
+                <attribute name="attrs">{'readonly': ['|',('state', '!=', 'draft'),('payment_method_code', '=', 'delivered_third_check')]}</attribute>
                 <attribute name="force_save">1</attribute>
             </xpath>
             <field name="payment_method_id" position="after">


### PR DESCRIPTION
[13.0] [FIX] account_check: Restore the readonly for amount in payments

Add for amount of the payment the readonly for all states except draft, as odoo has in the field definition https://github.com/odoo/odoo/blob/13.0/addons/account/models/account_payment.py#L69