### PR TITLE
[FIX] payment_group: no transfer + residual amount

### DIFF
--- a/l10n_latam_check/views/account_payment_view.xml
+++ b/l10n_latam_check/views/account_payment_view.xml
@@ -88,6 +88,7 @@
     <record model="ir.ui.view" id="view_account_third_check_operations_tree">
         <field name="name">account.check.operations.tree</field>
         <field name="model">account.payment</field>
+        <field name="priority" eval="99"/>
         <field name="arch" type="xml">
             <tree default_order="date desc, id desc, name desc">
                 <field name="date"/>


### PR DESCRIPTION
1. don't allow to choose partner of company for a payment group, use transfers for that
2. compute correctly the residual amount