### PR TITLE
[FIX] payment_group: hide the tow partner fields

### DIFF
--- a/account_payment_group/views/account_payment_view.xml
+++ b/account_payment_group/views/account_payment_view.xml
@@ -82,6 +82,9 @@
             <field name="partner_id" position="attributes">
                 <attribute name="invisible">1</attribute>
             </field>
+            <xpath expr="//field[@name='partner_id'][2]" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
             <field name="is_internal_transfer" position="attributes">
                 <attribute name="invisible">1</attribute>
             </field>


### PR DESCRIPTION
On payments, there are two partner fields (on for vendor and another for customer)