### PR TITLE
[15.0][ADD] account_payment_group, l10n_latam_check es_AR translations.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ docs/_build/
 #
 .idea/
 .history/
+
+# MacOS Folder attributes
+.DS_Store

--- a/account_payment_group/i18n/es_AR.po
+++ b/account_payment_group/i18n/es_AR.po
@@ -1,0 +1,1310 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* account_payment_group
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 15.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-03-30 21:53+0000\n"
+"PO-Revision-Date: 2022-03-30 21:53+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_payment_group
+#: code:addons/account_payment_group/models/account_chart_template.py:0
+#, python-format
+msgid "%s Customer Receipts"
+msgstr "Pagos del cliente %s"
+
+#. module: account_payment_group
+#: code:addons/account_payment_group/models/account_chart_template.py:0
+#, python-format
+msgid "%s Supplier Payments"
+msgstr "Pagos del proveedor %s"
+
+#. module: account_payment_group
+#: model:ir.actions.report,print_report_name:account_payment_group.action_report_payment_group
+msgid ""
+"(object.partner_type == 'supplier' and 'Orden de pago' or 'Recibo') + ' ' + "
+"object.document_number"
+msgstr ""
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_form
+msgid "(on company currency)"
+msgstr "(en la moneda de la compañía)"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_form
+msgid "+ Credit Note"
+msgstr "+ Nota de Crédito"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_form
+msgid "+ Debit Note"
+msgstr "+ Nota de Débito"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_form
+msgid "- Next Number:"
+msgstr "- Siguiente Número:"
+
+#. module: account_payment_group
+#: model:mail.template,body_html:account_payment_group.email_template_edi_payment_group
+msgid ""
+"<div style=\"margin: 0px; padding: 0px;\">\n"
+"    <p style=\"margin: 0px; padding: 0px; font-size: 13px;\">\n"
+"        Dear <t t-out=\"object.partner_id.name or ''\">Azure Interior</t><br/><br/>\n"
+"        Thank you for your payment.\n"
+"        Here is your <t t-out=\"object.partner_type == 'supplier' and 'Payment order' or 'Receipt'\"/> <strong t-out=\"(object.name or '').replace('/','-') or ''\">BNK1-2021-05-0002</strong> amounting\n"
+"        to <strong t-out=\"format_amount(object.payments_amount, object.currency_id) or ''\">$ 10.00</strong> from <t t-out=\"object.company_id.name or ''\">YourCompany</t>.\n"
+"        <br/><br/>\n"
+"        Do not hesitate to contact us if you have any questions.\n"
+"        <br/><br/>\n"
+"        Best regards,\n"
+"        <t t-if=\"user.signature\">\n"
+"            <br/>\n"
+"            <t t-out=\"user.signature or ''\">--<br/>Mitchell Admin</t>\n"
+"        </t>\n"
+"    </p>\n"
+"</div>\n"
+msgstr ""
+"<div style=\"margin: 0px; padding: 0px;\">\n"
+"    <p style=\"margin: 0px; padding: 0px; font-size: 13px;\">\n"
+"        Estimado <t t-out=\"object.partner_id.name or ''\">Azure Interior</t><br/><br/>\n"
+"        Gracias por su pago.\n"
+"        Aquí está su <t t-out=\"object.partner_type == 'supplier' and 'Orden de pago' or 'Recibo'\"/> <strong t-out=\"(object.name or '').replace('/','-') or ''\">BNK1-2021-05-0002</strong> que vale\n"
+"        <strong t-out=\"format_amount(object.payments_amount, object.currency_id) or ''\">$ 10.00</strong> de <t t-out=\"object.company_id.name or ''\">YourCompany</t>.\n"
+"        <br/><br/>\n"
+"        No dude en contactarnos si tiene alguna pregunta.\n"
+"        <br/><br/>\n"
+"        Saludos,\n"
+"        <t t-if=\"user.signature\">\n"
+"            <br/>\n"
+"            <t t-out=\"user.signature or ''\">--<br/>Mitchell Admin</t>\n"
+"        </t>\n"
+"    </p>\n"
+"</div>\n"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.res_config_settings_view_form
+msgid ""
+"<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-"
+"specific.\" groups=\"base.group_multi_company\"/>"
+msgstr ""
+"<span class=\"fa fa-lg fa-building-o\" title=\"Valores establecidos aquí son "
+"específicos de la compañía.\" groups=\"base.group_multi_company\"/>"
+
+#. module: account_payment_group
+#: model:ir.model,name:account_payment_group.model_account_chart_template
+msgid "Account Chart Template"
+msgstr "Plantilla de Plan de Cuenta"
+
+#. module: account_payment_group
+#: model:ir.model,name:account_payment_group.model_account_payment_receiptbook
+msgid "Account payment Receiptbook"
+msgstr "Libro de Recibos de Pago"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group_invoice_wizard__date
+msgid "Accounting Date"
+msgstr "Fecha Contable"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__message_needaction
+msgid "Action Needed"
+msgstr "Se Necesita Acción"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_receiptbook__active
+msgid "Active"
+msgstr "Activo"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_receiptbook__next_number
+msgid "Actual Next Number"
+msgstr "Siguiente Número Actual"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_form
+msgid "Add All / Refresh"
+msgstr "Añadir Todo / Refrescar"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__unreconciled_amount
+msgid "Adjustment / Advance"
+msgstr "Ajuste / Avance"
+
+#. module: account_payment_group
+#: code:addons/account_payment_group/models/account_payment_group.py:0
+#, python-format
+msgid "All to pay lines must be of the same partner"
+msgstr "Todas las líneas a pagar deben ser del mismo Cliente/Proveedor"
+
+#. module: account_payment_group
+#: model:res.groups,name:account_payment_group.group_pay_now_customer_invoices
+msgid "Allow pay now on customer invoices"
+msgstr "Permitir pago directo en facturas de cliente"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_res_config_settings__group_pay_now_customer_invoices
+msgid "Allow pay now on customer invoices?"
+msgstr "Permitir pago directo en facturas de cliente?"
+
+#. module: account_payment_group
+#: model:res.groups,name:account_payment_group.group_pay_now_vendor_invoices
+msgid "Allow pay now on vendor invoices"
+msgstr "Permitir pago directo en facturas de proveedor"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_res_config_settings__group_pay_now_vendor_invoices
+msgid "Allow pay now on vendor invoices?"
+msgstr "Permitir pago directo en facturas de proveedor?"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.res_config_settings_view_form
+msgid "Allow to choose inbound/outbound on payment lines."
+msgstr "Permitir elegir entrada / salida en líneas de pago."
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.res_config_settings_view_form
+msgid "Allow to pay customer invoices automatically on invoice validation."
+msgstr ""
+"Permitir pagar facturas de clientes automáticamente en la validación de "
+"facturas."
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.res_config_settings_view_form
+msgid "Allow to pay vendor invoices automatically on invoice validation."
+msgstr ""
+"Permitir pagar facturas de proveedores automáticamente en la validación de "
+"facturas."
+
+#. module: account_payment_group
+#: model:ir.model.fields,help:account_payment_group.field_res_config_settings__group_pay_now_vendor_invoices
+#: model_terms:ir.ui.view,arch_db:account_payment_group.res_config_settings_view_form
+msgid ""
+"Allow users to choose a payment journal on invoices so that invoice is "
+"automatically paid after invoice validation. A payment will be created using"
+" choosen journal"
+msgstr ""
+"Permitir a los usuarios elegir un diario de pagos en las facturas así la "
+"misma es automáticamente pagada luego de la validación. Un pago se va a "
+"crear usando el diario seleccionado"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__payments_amount
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_from_group_tree
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_move_line_tree
+msgid "Amount"
+msgstr "Importe"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment__amount_company_currency
+msgid "Amount on Company Currency"
+msgstr "Valor de la Moneda de la Empresa"
+
+#. module: account_payment_group
+#: model:ir.model.fields,help:account_payment_group.field_l10n_latam_document_type__internal_type
+msgid ""
+"Analog to odoo account.move.move_type but with more options allowing to "
+"identify the kind of document we are working with. (not only related to "
+"account.move, could be for documents of other models like stock.picking)"
+msgstr ""
+"Análogo a account.move.type de Odoo pero con más opciones, permitiendo "
+"identificar el tipo de documento sobre el que estamos trabajando. (no "
+"solamente relativo a account.move, podría ser relativo a otros modelos, como"
+" por ejemplo stock.picking)"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group_invoice_wizard__account_analytic_id
+msgid "Analytic Account"
+msgstr "Cuenta Analitica"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__message_attachment_count
+msgid "Attachment Count"
+msgstr "Cuenta de Adjuntos"
+
+#. module: account_payment_group
+#: code:addons/account_payment_group/models/account_chart_template.py:0
+#: model:ir.model.fields.selection,name:account_payment_group.selection__account_payment_receiptbook__sequence_type__automatic
+#, python-format
+msgid "Automatic"
+msgstr "Automático"
+
+#. module: account_payment_group
+#: model:ir.ui.menu,name:account_payment_group.menu_finance_bank_and_cash
+msgid "Bank and Cash"
+msgstr "Bancos y Cajas"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_form
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_invoice_wizard
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: account_payment_group
+#: model:ir.model.fields.selection,name:account_payment_group.selection__account_payment_group__state__cancel
+msgid "Cancelled"
+msgstr "Cancelado"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_res_config_settings__group_choose_payment_type
+#: model:res.groups,name:account_payment_group.group_choose_payment_type
+msgid "Choose Payment Type on Payments"
+msgstr "Elegir Tipo de Pago en Pagos"
+
+#. module: account_payment_group
+#: model_terms:ir.actions.act_window,help:account_payment_group.action_account_payments_group
+#: model_terms:ir.actions.act_window,help:account_payment_group.action_account_payments_group_payable
+msgid "Click to register a payment"
+msgstr "Clic para registrar un pago"
+
+#. module: account_payment_group
+#: model_terms:ir.actions.act_window,help:account_payment_group.action_account_payments_transfer
+msgid "Click to register a transfer between liquidity journals"
+msgstr ""
+"Hacer click para registrar una transferencia entre diarios de liquidez"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__commercial_partner_id
+msgid "Commercial Entity"
+msgstr "Entidad Comercial"
+
+#. module: account_payment_group
+#: model:ir.model,name:account_payment_group.model_res_company
+msgid "Companies"
+msgstr "Compañías"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__company_id
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group_invoice_wizard__company_id
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_receiptbook__company_id
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_search
+msgid "Company"
+msgstr "Compañía"
+
+#. module: account_payment_group
+#: code:addons/account_payment_group/models/account_payment_group.py:0
+#, python-format
+msgid "Compose Email"
+msgstr "Escribir correo"
+
+#. module: account_payment_group
+#: model:ir.model,name:account_payment_group.model_res_config_settings
+msgid "Config Settings"
+msgstr "Opciones de configuración"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_form
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_invoice_wizard
+msgid "Confirm"
+msgstr "Confirmar"
+
+#. module: account_payment_group
+#: model:res.groups,name:account_payment_group.account_confirm_payment
+msgid "Confirm payments (only if double validation is enabled)"
+msgstr "Confirmar pagos (solo si esta habilitada la doble validación)"
+
+#. module: account_payment_group
+#: model:ir.actions.server,name:account_payment_group.action_account__payment_confirm_payments
+msgid "Confirmar pagos"
+msgstr ""
+
+#. module: account_payment_group
+#: model:ir.model.fields.selection,name:account_payment_group.selection__account_payment_group__state__confirmed
+msgid "Confirmed"
+msgstr "Confirmado"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_l10n_latam_document_type__country_id
+msgid "Country"
+msgstr "País"
+
+#. module: account_payment_group
+#: model:ir.model.fields,help:account_payment_group.field_l10n_latam_document_type__country_id
+msgid "Country in which this type of document is valid"
+msgstr "País donde el tipo de documento es valido"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__create_uid
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group_invoice_wizard__create_uid
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_receiptbook__create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__create_date
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group_invoice_wizard__create_date
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_receiptbook__create_date
+msgid "Created on"
+msgstr "Creado el"
+
+#. module: account_payment_group
+#: model:ir.actions.act_window,name:account_payment_group.action_account_payment_group_invoice_wizard
+msgid "Credit / Debit Note"
+msgstr "Nota de Débito / Crédito"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_invoice_wizard
+msgid "Credit Note"
+msgstr "Nota de Crédito"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__currency_id
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group_invoice_wizard__currency_id
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_search
+msgid "Currency"
+msgstr "Moneda"
+
+#. module: account_payment_group
+#: model:ir.model.fields.selection,name:account_payment_group.selection__account_payment_group__partner_type__customer
+#: model:ir.model.fields.selection,name:account_payment_group.selection__account_payment_receiptbook__partner_type__customer
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_form
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_search
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_tree
+msgid "Customer"
+msgstr "Cliente"
+
+#. module: account_payment_group
+#: model:ir.model.fields.selection,name:account_payment_group.selection__l10n_latam_document_type__internal_type__customer_payment
+msgid "Customer Receipt"
+msgstr "Recibo de Cliente"
+
+#. module: account_payment_group
+#: model:ir.actions.act_window,name:account_payment_group.action_account_payments_group
+#: model:ir.ui.menu,name:account_payment_group.menu_action_account_payments_group_receivable
+msgid "Customer Receipts"
+msgstr "Recibos de Cliente"
+
+#. module: account_payment_group
+#: model:mail.template,name:account_payment_group.email_template_edi_payment_group
+msgid "Customer/Supplier Payment - Send by Email"
+msgstr "Pago de Cliente/Proveedor - Enviar por correo"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_form
+msgid "Debts"
+msgstr "Deudas"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_search
+msgid "Description"
+msgstr "Descripción"
+
+#. module: account_payment_group
+#: model:ir.model.fields,help:account_payment_group.field_account_payment_group__payment_difference
+msgid ""
+"Difference between selected debt (or to pay amount) and payments amount"
+msgstr ""
+"Diferencia entre la deuda seleccionada (o cantidad a pagar) y monto del pago"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__display_name
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group_invoice_wizard__display_name
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_receiptbook__display_name
+msgid "Display Name"
+msgstr "Nombre mostrado"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__document_number
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group_invoice_wizard__document_number
+msgid "Document Number"
+msgstr "Número de Documento"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group_invoice_wizard__document_sequence_id
+msgid "Document Sequence"
+msgstr "Secuencia de Documento"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__document_type_id
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group_invoice_wizard__journal_document_type_id
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_receiptbook__document_type_id
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_invoice_wizard
+msgid "Document Type"
+msgstr "Tipo de Documento"
+
+#. module: account_payment_group
+#: model:ir.model.constraint,message:account_payment_group.constraint_account_payment_group_name_uniq
+msgid "Document number must be unique per receiptbook!"
+msgstr "El número de documento debe ser único por recibo!"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_res_company__double_validation
+#: model:ir.model.fields,field_description:account_payment_group.field_res_config_settings__double_validation
+msgid "Double Validation on Payments?"
+msgstr "¿Doble validación en los Pagos?"
+
+#. module: account_payment_group
+#: model:ir.model.fields.selection,name:account_payment_group.selection__account_payment_group__state__draft
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_search
+msgid "Draft"
+msgstr "Borrador"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_receiptbook__mail_template_id
+msgid "Email Template"
+msgstr "Plantilla de Correo"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__document_sequence_id
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_receiptbook__sequence_id
+msgid "Entry Sequence"
+msgstr "Secuencia de Entrada"
+
+#. module: account_payment_group
+#: code:addons/account_payment_group/models/account_payment_group.py:0
+#, python-format
+msgid ""
+"Error!. Please define sequence on the receiptbook related documents to this "
+"payment or set the document number."
+msgstr ""
+"Error!. Por favor defina la secuencia en los documentos relacionados al "
+"recibo o establezca el número de documento."
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment__exchange_rate
+msgid "Exchange Rate"
+msgstr "Tipo de cambio"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__message_follower_ids
+msgid "Followers"
+msgstr "Seguidores"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__message_partner_ids
+msgid "Followers (Partners)"
+msgstr "Seguidores (Contactos)"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment__force_amount_company_currency
+msgid "Forced Amount on Company Currency"
+msgstr "Forzar valor de la Moneda de la Empresa"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__has_message
+msgid "Has Message"
+msgstr "Tiene Mensaje"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__has_outstanding
+msgid "Has Outstanding"
+msgstr "Tiene Cuenta por Pagar"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_form
+msgid ""
+"Hay <b>créditos pendientes</b> de imputar en la deuda seleccionada, se "
+"intentará imputar dichos créditos a otros comprobantes seleccionados pero "
+"dicha información <b>no quedará registrada en el pago</b>. Si no desea que "
+"se imputen automáticamente puede borrarlos de la lista."
+msgstr ""
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__id
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group_invoice_wizard__id
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_receiptbook__id
+msgid "ID"
+msgstr ""
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_from_group_form
+msgid ""
+"IMPORTANTE: La validación de la línea de pago se debe hacer desde el recibo."
+" La cancelación manual de una línea de pago se usa solo para correcciones y "
+"usos avanzados. Seguro desea continuar?"
+msgstr ""
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_from_group_form
+msgid ""
+"IMPORTANTE: La validación de la línea de pago se debe hacer desde el recibo."
+" La validación manual de una línea de pago se usa solo para correcciones y "
+"usos avanzados. Seguro desea continuar?"
+msgstr ""
+
+#. module: account_payment_group
+#: model:ir.model.fields,help:account_payment_group.field_account_payment_group_invoice_wizard__use_documents
+msgid ""
+"If active: will be using for legal invoicing (invoices, debit/credit notes)."
+" If not set means that will be used to register accounting entries not "
+"related to invoicing legal documents. For Example: Receipts, Tax Payments, "
+"Register journal entries"
+msgstr ""
+"Si está activo: se usará para facturación legal (facturas, notas de crédito/débito)."
+" Si no está establecido significa que se usará para registrar entradas de "
+"contabilidad no relacionadas con documentos legales. Por ejemplo: Recibos, "
+"Pagos de impuestos, Entradas de diario"
+
+#. module: account_payment_group
+#: model:ir.model.fields,help:account_payment_group.field_account_payment_group__message_needaction
+#: model:ir.model.fields,help:account_payment_group.field_account_payment_group__message_unread
+msgid "If checked, new messages require your attention."
+msgstr "Si marca, nuevos mensajes requieren su atención."
+
+#. module: account_payment_group
+#: model:ir.model.fields,help:account_payment_group.field_account_payment_group__message_has_error
+#: model:ir.model.fields,help:account_payment_group.field_account_payment_group__message_has_sms_error
+msgid "If checked, some messages have a delivery error."
+msgstr "Si está marcado, algunos mensajes tienen un error de envío."
+
+#. module: account_payment_group
+#: model:ir.model.fields,help:account_payment_group.field_account_payment_receiptbook__mail_template_id
+msgid ""
+"If set an email will be sent to the customer when the related "
+"account.payment.group has been posted."
+msgstr ""
+"Si está establecido, un correo electrónico será enviado al cliente cuando "
+"el recibo relacionado a la cuenta por pagar ha sido publicado."
+
+#. module: account_payment_group
+#: model:ir.model.fields,help:account_payment_group.field_account_bank_statement_line__pay_now_journal_id
+#: model:ir.model.fields,help:account_payment_group.field_account_move__pay_now_journal_id
+#: model:ir.model.fields,help:account_payment_group.field_account_payment__pay_now_journal_id
+msgid ""
+"If you set a journal here, after invoice validation, the invoice will be "
+"automatically paid with this journal. As manual paymentmethod is used, only "
+"journals with manual method are shown."
+msgstr ""
+"Si establece un diario aquí, luego de la validación de la factura, la misma "
+"va a ser automáticamente pagada con este diario. Como en el pago se fuerza "
+"método de pago manual, solo diarios con método de pago manual son mostrados."
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_l10n_latam_document_type__internal_type
+msgid "Internal Type"
+msgstr "Tipo interno"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__message_is_follower
+msgid "Is Follower"
+msgstr "Es Seguidor"
+
+#. module: account_payment_group
+#: model:ir.model.fields,help:account_payment_group.field_account_payment_group__sent
+msgid "It indicates that the receipt has been sent."
+msgstr "Indica que el recibo se ha enviado."
+
+#. module: account_payment_group
+#: model:ir.model,name:account_payment_group.model_account_journal
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group_invoice_wizard__journal_id
+msgid "Journal"
+msgstr "Libro diario"
+
+#. module: account_payment_group
+#: model:ir.model,name:account_payment_group.model_account_move
+msgid "Journal Entry"
+msgstr "Asiento contable"
+
+#. module: account_payment_group
+#: model:ir.model,name:account_payment_group.model_account_move_line
+msgid "Journal Item"
+msgstr "Apunte contable"
+
+#. module: account_payment_group
+#: code:addons/account_payment_group/models/account_payment_group.py:0
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_form
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_move_line_tree
+#, python-format
+msgid "Journal Items"
+msgstr "Apuntes Contables"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment__l10n_ar_amount_company_currency_signed
+msgid "L10N Ar Amount Company Currency Signed"
+msgstr "L10N Ar Monto en Moneda de la Compañía"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group____last_update
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group_invoice_wizard____last_update
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_receiptbook____last_update
+msgid "Last Modified on"
+msgstr "Última Modificación el"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__write_uid
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group_invoice_wizard__write_uid
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_receiptbook__write_uid
+msgid "Last Updated by"
+msgstr "Última Actualización por"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__write_date
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group_invoice_wizard__write_date
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_receiptbook__write_date
+msgid "Last Updated on"
+msgstr "Última actualización el"
+
+#. module: account_payment_group
+#: model:ir.model,name:account_payment_group.model_l10n_latam_document_type
+msgid "Latam Document Type"
+msgstr "Tipo de Documento Latam"
+
+#. module: account_payment_group
+#: model:ir.model.fields,help:account_payment_group.field_account_payment_group__matched_move_line_ids
+msgid ""
+"Lines that has been matched to payments, only available after payment "
+"validation"
+msgstr ""
+"Líneas que fueron imputadas a pagos, solo disponibles después de la "
+"validación del pago"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__message_main_attachment_id
+msgid "Main Attachment"
+msgstr "Adjunto Principal"
+
+#. module: account_payment_group
+#: code:addons/account_payment_group/models/account_chart_template.py:0
+#: model:ir.model.fields.selection,name:account_payment_group.selection__account_payment_receiptbook__sequence_type__manual
+#, python-format
+msgid "Manual"
+msgstr "Manual"
+
+#. module: account_payment_group
+#: code:addons/account_payment_group/models/account_payment.py:0
+#, python-format
+msgid ""
+"Manual payments should not be created manually but created from Customer "
+"Receipts / Supplier Payments menus"
+msgstr ""
+"Los pagos manuales no deberían ser creados manualmente, sino desde los menús de "
+"Recibos de Clientes / Pagos a Proveedores"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__matched_amount
+msgid "Matched Amount"
+msgstr "Monto Conciliado"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__matched_move_line_ids
+msgid "Matched Move Line"
+msgstr "Apunte contable conciliado"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__communication
+msgid "Memo"
+msgstr "Memo"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__message_has_error
+msgid "Message Delivery error"
+msgstr "Error de Envío del Mensaje"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__message_ids
+msgid "Messages"
+msgstr "Mensajes"
+
+#. module: account_payment_group
+#: code:addons/account_payment_group/wizards/account_validate_account_move.py:0
+#, python-format
+msgid "Missing 'active_model' in context."
+msgstr "Falta 'active_model' en el contexto."
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__move_line_ids
+msgid "Move Line"
+msgstr "Apunte contable"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_receiptbook__name
+msgid "Name"
+msgstr "Nombre"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__next_number
+msgid "Next Number"
+msgstr "Siguiente Número"
+
+#. module: account_payment_group
+#: model:ir.model.fields,help:account_payment_group.field_account_payment_receiptbook__next_number
+msgid ""
+"Next number that will be used. This number can be incremented frequently so "
+"the displayed value might already be obsolete"
+msgstr ""
+"El siguiente número que será utilizado. Este número puede ser incrementado "
+"frecuentemente, por lo que el valor mostrado podría ya estar obsoleto"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_search
+msgid "Not Cancelled"
+msgstr "No cancelado"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__notes
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_form
+msgid "Notes"
+msgstr "Notas"
+
+#. module: account_payment_group
+#: code:addons/account_payment_group/models/account_move.py:0
+#, python-format
+msgid "Nothing to be paid on selected entries"
+msgstr "Nada que pagar en las entradas seleccionadas"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__name
+msgid "Number"
+msgstr "Número"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_receiptbook__padding
+msgid "Number Padding"
+msgstr "Relleno del Número"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__message_needaction_counter
+msgid "Number of Actions"
+msgstr "Número de Acciones"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__message_has_error_counter
+msgid "Number of errors"
+msgstr "Número de error"
+
+#. module: account_payment_group
+#: model:ir.model.fields,help:account_payment_group.field_account_payment_group__message_needaction_counter
+msgid "Number of messages which requires an action"
+msgstr "Número de mensajes que requieren una acción"
+
+#. module: account_payment_group
+#: model:ir.model.fields,help:account_payment_group.field_account_payment_group__message_has_error_counter
+msgid "Number of messages with delivery error"
+msgstr "Número de mensajes con error de envío"
+
+#. module: account_payment_group
+#: model:ir.model.fields,help:account_payment_group.field_account_payment_group__message_unread_counter
+msgid "Number of unread messages"
+msgstr "Número de mensajes sin leer"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_bank_statement_line__open_move_line_ids
+#: model:ir.model.fields,field_description:account_payment_group.field_account_move__open_move_line_ids
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment__open_move_line_ids
+msgid "Open Move Line"
+msgstr "Apunte contable no conciliado"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_move_line_tree
+msgid "Open Related Document"
+msgstr "Documento abierto relacionado"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment__other_currency
+msgid "Other Currency"
+msgstr "Otra Moneda"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_form
+msgid "Paid"
+msgstr "Comp. Imputados"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_move_line_with_matched_tree
+msgid "Paid Amount"
+msgstr "Importe imputado"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__partner_id
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_search
+msgid "Partner"
+msgstr ""
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__partner_type
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_receiptbook__partner_type
+msgid "Partner Type"
+msgstr "Tipo de Empresa"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_bank_statement_line__pay_now_journal_id
+#: model:ir.model.fields,field_description:account_payment_group.field_account_move__pay_now_journal_id
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment__pay_now_journal_id
+msgid "Pay now Journal"
+msgstr "Diario de Pago Directo"
+
+#. module: account_payment_group
+#: code:addons/account_payment_group/models/account_move.py:0
+#, python-format
+msgid "Pay now journal must have manual method!"
+msgstr "El diario de pago directo debe tener método manual!"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__payment_date
+msgid "Payment Date"
+msgstr "Fecha de Pago"
+
+#. module: account_payment_group
+#: model:ir.model,name:account_payment_group.model_account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment__payment_group_id
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group_invoice_wizard__payment_group_id
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_form
+msgid "Payment Group"
+msgstr "Grupo de Pago"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_move_line__payment_group_matched_amount
+msgid "Payment Group Matched Amount"
+msgstr "Grupo de pago conciliado"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_bank_statement_line__payment_group_ids
+#: model:ir.model.fields,field_description:account_payment_group.field_account_move__payment_group_ids
+#: model:ir.model.fields,field_description:account_payment_group.field_account_move_line__payment_group_ids
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment__payment_group_ids
+msgid "Payment Groups"
+msgstr "Grupos de Pago"
+
+#. module: account_payment_group
+#: code:addons/account_payment_group/models/account_payment.py:0
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__payment_ids
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_form
+#, python-format
+msgid "Payment Lines"
+msgstr "Líneas del Pago"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_from_group_tree
+msgid "Payment Method"
+msgstr "Método de Pago"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment__payment_method_description
+msgid "Payment Method Desc."
+msgstr "Desc. Método de Pago"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__payment_methods
+msgid "Payment Methods"
+msgstr "Métodos de pago"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__payment_subtype
+msgid "Payment Subtype"
+msgstr "Subtipo de pago"
+
+#. module: account_payment_group
+#: code:addons/account_payment_group/models/account_payment_group.py:0
+#, python-format
+msgid "Payment group for partner %s but payment lines are of partner %s"
+msgstr "Grupo de pago para el partner %s pero las líneas de pago son del partner %s"
+
+#. module: account_payment_group
+#: code:addons/account_payment_group/wizards/account_payment_group_invoice_wizard.py:0
+#, python-format
+msgid "Payment id %s"
+msgstr "Id del Pago %s"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_form
+msgid ""
+"Payment will be automatically matched with the oldest lines of this list (by"
+" maturity date). You can remove any line you dont want to be matched."
+msgstr ""
+"El pago será automáticamente igualado con las líneas más antiguas de esta "
+"lista (por fecha de vencimiento). Puede quitar cualquier línea que no quiera"
+" que sea igualada."
+
+#. module: account_payment_group
+#: model:ir.model,name:account_payment_group.model_account_payment
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_graph
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_search
+msgid "Payments"
+msgstr "Pagos"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_form
+msgid "Payments Amount"
+msgstr "Importe de los Pagos"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__payment_difference
+msgid "Payments Difference"
+msgstr "Diferencia de Pagos"
+
+#. module: account_payment_group
+#: model_terms:ir.actions.act_window,help:account_payment_group.action_account_payments_group
+#: model_terms:ir.actions.act_window,help:account_payment_group.action_account_payments_group_payable
+msgid ""
+"Payments are used to register liquidity movements (send or collect).\n"
+"          You can then process those payments by your own means or by using installed facilities."
+msgstr ""
+"Los pagos se utilizan para registrar movimientos de líquido (enviar, recibir o transferir dinero).\n"
+"Puede procesar esos pagos por sus propios medios o utilizando los servicios instalados."
+
+#. module: account_payment_group
+#: model:ir.model.fields.selection,name:account_payment_group.selection__account_payment_group__state__posted
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_search
+msgid "Posted"
+msgstr "Publicado"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_receiptbook__prefix
+msgid "Prefix"
+msgstr "Prefijo"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_form
+msgid "Print"
+msgstr "Imprimir"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group_invoice_wizard__product_id
+msgid "Product"
+msgstr "Producto"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group_invoice_wizard__description
+msgid "Reason"
+msgstr "Razón"
+
+#. module: account_payment_group
+#: model:ir.actions.report,name:account_payment_group.action_report_payment_group
+msgid "Receipt / Payment Order"
+msgstr "Recibo / Orden de Pago"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_receipt_receiptbook_form
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_receipt_receiptbook_search
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_receipt_receiptbook_tree
+msgid "Receipt Books"
+msgstr "Libros de Recibos"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__receiptbook_id
+msgid "ReceiptBook"
+msgstr "Libro de Recibos"
+
+#. module: account_payment_group
+#: model:ir.actions.act_window,name:account_payment_group.action_receiptbook_form
+#: model:ir.ui.menu,name:account_payment_group.menu_receiptbook_form
+msgid "Receiptbooks"
+msgstr "Libros de Recibos"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.account_journal_dashboard_kanban_view
+msgid "Received Money"
+msgstr "Dinero Recibido"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group_invoice_wizard__invoice_date
+msgid "Refund Date"
+msgstr "Fecha de Devolución"
+
+#. module: account_payment_group
+#: code:addons/account_payment_group/models/account_move.py:0
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_form
+#, python-format
+msgid "Register Payment"
+msgstr "Registrar Pago"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_form
+msgid "Remove All"
+msgstr "Eliminar Todo"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_receiptbook__report_partner_id
+msgid "Report Partner"
+msgstr ""
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__message_has_sms_error
+msgid "SMS Delivery error"
+msgstr "Error de entrega de SMS"
+
+#. module: account_payment_group
+#: model:res.groups,name:account_payment_group.account_see_payment_menu
+msgid "See Payments Menu"
+msgstr "Ver Menú de Pagos"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__selected_debt
+msgid "Selected Debt"
+msgstr "Deuda Seleccionada"
+
+#. module: account_payment_group
+#: code:addons/account_payment_group/models/account_move.py:0
+#, python-format
+msgid "Selected recrods must be of the same partner"
+msgstr "Los registros seleccionados deben pertenecer al mismo cliente/proveedor"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_form
+msgid "Send by Email"
+msgstr "Enviar por Correo"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.account_journal_dashboard_kanban_view
+msgid "Sended Money"
+msgstr "Dinero Enviado"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__sent
+msgid "Sent"
+msgstr "Enviado"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_receiptbook__sequence
+msgid "Sequence"
+msgstr "Secuencia"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_receiptbook__sequence_type
+msgid "Sequence Type"
+msgstr "Tipo de Secuencia"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_form
+msgid "Set to Draft"
+msgstr "Establecer como Borrador"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_search
+msgid "State"
+msgstr "Estado"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__state
+msgid "Status"
+msgstr "Estado"
+
+#. module: account_payment_group
+#: model:ir.model.fields.selection,name:account_payment_group.selection__l10n_latam_document_type__internal_type__supplier_payment
+msgid "Supplier Payment"
+msgstr "Pago de Proveedor"
+
+#. module: account_payment_group
+#: model:ir.actions.act_window,name:account_payment_group.action_account_payments_group_payable
+#: model:ir.ui.menu,name:account_payment_group.menu_action_account_payments_group_payable
+msgid "Supplier Payments"
+msgstr "Pagos de Proveedor"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group_invoice_wizard__tax_ids
+msgid "Taxes"
+msgstr "Impuestos"
+
+#. module: account_payment_group
+#: model:ir.model.fields,help:account_payment_group.field_account_payment_group__document_sequence_id
+#: model:ir.model.fields,help:account_payment_group.field_account_payment_receiptbook__sequence_id
+msgid ""
+"This field contains the information related to the numbering of the receipt "
+"entries of this receiptbook."
+msgstr ""
+"Este campo contiene la información relacionada con la numeración de las "
+"entradas de recibo de este libro de recibos."
+
+#. module: account_payment_group
+#: model:ir.model.fields,help:account_payment_group.field_account_payment_group__to_pay_move_line_ids
+msgid "This lines are the ones the user has selected to be paid."
+msgstr "Estas son las líneas que fueron seleccionadas para pagarse."
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__to_pay_amount
+msgid "To Pay Amount"
+msgstr "Importe a pagar"
+
+#. module: account_payment_group
+#: code:addons/account_payment_group/models/account_payment_group.py:0
+#, python-format
+msgid "To Pay Amount and Payment Amount must be equal!"
+msgstr "¡El Importe a pagar y el Importe de Pago deben ser iguales!"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__to_pay_move_line_ids
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_form
+msgid "To Pay Lines"
+msgstr "Líneas a Pagar"
+
+#. module: account_payment_group
+#: code:addons/account_payment_group/models/account_payment.py:0
+#: code:addons/account_payment_group/models/account_payment_group.py:0
+#, python-format
+msgid "To Pay Lines must be of the same account!"
+msgstr "Las líneas a pagar deben ser de la misma cuenta!"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_from_group_tree
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_tree
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_move_line_tree
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_move_line_with_matched_tree
+msgid "Total"
+msgstr "Total"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group_invoice_wizard__amount_total
+msgid "Total Amount"
+msgstr "Importe total"
+
+#. module: account_payment_group
+#: model:ir.actions.act_window,name:account_payment_group.action_account_payments_transfer
+#: model:ir.ui.menu,name:account_payment_group.menu_action_account_payments_transfer
+msgid "Transfers"
+msgstr "Transferencias"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__unmatched_amount
+msgid "Unmatched Amount"
+msgstr "Monto no conciliado"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__message_unread
+msgid "Unread Messages"
+msgstr "Mensajes sin leer"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__message_unread_counter
+msgid "Unread Messages Counter"
+msgstr "Contador de mensajes sin leer"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group_invoice_wizard__amount_untaxed
+msgid "Untaxed Amount"
+msgstr "Importe sin impuestos"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group_invoice_wizard__use_documents
+msgid "Use Documents?"
+msgstr "¿Usar Documentos?"
+
+#. module: account_payment_group
+#: model:ir.model.fields,help:account_payment_group.field_res_company__double_validation
+#: model:ir.model.fields,help:account_payment_group.field_res_config_settings__double_validation
+msgid "Use two steps validation on payments to suppliers"
+msgstr "Usar 2 pasos de validación en pagos a proveedores"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.res_config_settings_view_form
+msgid "Use two steps validation on payments to suppliers."
+msgstr "Utilice 2 pasos de validación en los pagos a proveedores."
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.res_config_settings_view_form
+msgid ""
+"Used if you want let user choose payment type (inbound or outbound) when "
+"registering a payment from a payment group"
+msgstr ""
+"Utilizado si desea permitir al usuario elegir tipo de pago (entrante o "
+"saliente) cuando este registrando un pago desde un grupo de pagos"
+
+#. module: account_payment_group
+#: model:ir.model.fields,help:account_payment_group.field_account_payment_receiptbook__sequence
+msgid "Used to order the receiptbooks"
+msgstr "Se utiliza para ordenar los libros de recibos"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_form
+msgid "Validate"
+msgstr "Validar"
+
+#. module: account_payment_group
+#: model:ir.model,name:account_payment_group.model_validate_account_move
+msgid "Validate Account Move"
+msgstr "Validar Asiento Contable"
+
+#. module: account_payment_group
+#: model:ir.model.fields.selection,name:account_payment_group.selection__account_payment_group__partner_type__supplier
+#: model:ir.model.fields.selection,name:account_payment_group.selection__account_payment_receiptbook__partner_type__supplier
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_form
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_search
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_account_payment_group_tree
+msgid "Vendor"
+msgstr "Proveedor"
+
+#. module: account_payment_group
+#: model_terms:ir.ui.view,arch_db:account_payment_group.view_move_form
+msgid "View Payments"
+msgstr "Ver pagos"
+
+#. module: account_payment_group
+#: model:ir.model.fields,field_description:account_payment_group.field_account_payment_group__website_message_ids
+msgid "Website Messages"
+msgstr "Mensajes del sitio web"
+
+#. module: account_payment_group
+#: model:ir.model.fields,help:account_payment_group.field_account_payment_group__website_message_ids
+msgid "Website communication history"
+msgstr "Historial de comunicación del sitio web"
+
+#. module: account_payment_group
+#: code:addons/account_payment_group/models/account_payment_group.py:0
+#, python-format
+msgid "You can not confirm a payment group without payment lines!"
+msgstr "¡No puede confirmar un grupo de pagos sin líneas de pago!"
+
+#. module: account_payment_group
+#: code:addons/account_payment_group/models/account_payment_group.py:0
+#, python-format
+msgid "You can not delete posted payment groups. Payment group ids: %s"
+msgstr "¡No puede eliminar grupos de pagos ya publicados. Ids de grupo de pagos: %s"
+
+#. module: account_payment_group
+#: code:addons/account_payment_group/wizards/account_payment_group_invoice_wizard.py:0
+#, python-format
+msgid "You can only set amount total if taxes are of type percentage"
+msgstr ""
+"Solo puede establecer el importe total si los impuestos son de tipo "
+"porcentaje"
+
+#. module: account_payment_group
+#: code:addons/account_payment_group/models/account_payment_group.py:0
+#, python-format
+msgid ""
+"You can't create payments for entries belonging to different companies."
+msgstr ""
+"No puede crear pagos para entradas pertenecientes a diferentes "
+"compañías."
+
+#. module: account_payment_group
+#: code:addons/account_payment_group/models/account_payment_group.py:0
+#, python-format
+msgid ""
+"You can't make a payment/receipt to your same company, create an internal "
+"transfer instead"
+msgstr ""
+"No puede hacer un pago/recibo a su misma compañía, cree una transferencia "
+"interna en su lugar"
+
+#. module: account_payment_group
+#: code:addons/account_payment_group/models/account_payment_group.py:0
+#, python-format
+msgid "You can't post and already posted payment group. Payment group ids: %s"
+msgstr "¡No puede publicar un grupo de pagos ya publicado. Ids de grupo de "
+
+#. module: account_payment_group
+#: model:ir.model,name:account_payment_group.model_account_payment_group_invoice_wizard
+msgid "account.payment.group.invoice.wizard"
+msgstr ""
+
+#. module: account_payment_group
+#: model:ir.model.fields,help:account_payment_group.field_account_payment_receiptbook__padding
+msgid ""
+"automatically adds some '0' on the left of the 'Number' to get the required "
+"padding size."
+msgstr ""
+"Agrega automáticamente algunos '0' a la izquierda del 'Número' para obtener "
+"el tamaño de relleno requerido."
+
+#. module: account_payment_group
+#: model:mail.template,report_name:account_payment_group.email_template_edi_payment_group
+msgid ""
+"{{(object.partner_type == 'supplier' and 'Payment_order_' or 'Receipt_' + "
+"object.display_name or '').replace('/','_')}}"
+msgstr ""
+
+#. module: account_payment_group
+#: model:mail.template,subject:account_payment_group.email_template_edi_payment_group
+msgid ""
+"{{object.company_id.name}} {{object.partner_type == 'supplier' and 'Payment "
+"Order' or 'Receipt'}} {{object.display_name or 'n/a'}}"
+msgstr ""

--- a/l10n_latam_check/i18n/es_AR.po
+++ b/l10n_latam_check/i18n/es_AR.po
@@ -1,0 +1,515 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_latam_check
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 15.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-03-30 21:36+0000\n"
+"PO-Revision-Date: 2022-03-30 21:36+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_latam_check
+#: code:addons/l10n_latam_check/models/l10n_latam_checkbook.py:0
+#, python-format
+msgid " up to %s"
+msgstr " hasta %s"
+
+#. module: l10n_latam_check
+#: code:addons/l10n_latam_check/models/account_payment.py:0
+#, python-format
+msgid "(Check %s)"
+msgstr "(Cheque %s)"
+
+#. module: l10n_latam_check
+#: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_form_inherited
+msgid ""
+"<span attrs=\"{'invisible': [('l10n_latam_check_current_journal_id', '!=', "
+"False)]}\">Not on Wallet</span>"
+msgstr ""
+"<span attrs=\"{'invisible': [('l10n_latam_check_current_journal_id', '!=', "
+"False)]}\">No en Billetera</span>"
+
+#. module: l10n_latam_check
+#: model:ir.model,name:l10n_latam_check.model_account_chart_template
+msgid "Account Chart Template"
+msgstr "Plantilla de Plan de Cuentas"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,field_description:l10n_latam_check.field_l10n_latam_checkbook__active
+msgid "Active"
+msgstr "Activo"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,field_description:l10n_latam_check.field_l10n_latam_checkbook__next_number
+msgid "Actual Next Number"
+msgstr "Siguiente Numero Actual"
+
+#. module: l10n_latam_check
+#: code:addons/l10n_latam_check/wizards/account_payment_mass_transfer.py:0
+#, python-format
+msgid "All selected checks must be on the same journal"
+msgstr "Todos los cheques seleccionados deben estar en el mismo diario"
+
+#. module: l10n_latam_check
+#: code:addons/l10n_latam_check/wizards/account_payment_mass_transfer.py:0
+#, python-format
+msgid "All the selected checks must be posted"
+msgstr "Todos los cheques seleccionados deben estar publicados"
+
+#. module: l10n_latam_check
+#: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_mass_transfer_form
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment__l10n_latam_check_id
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment_register__l10n_latam_check_id
+msgid "Check"
+msgstr "Cheque"
+
+#. module: l10n_latam_check
+#: code:addons/l10n_latam_check/models/account_payment.py:0
+#, python-format
+msgid ""
+"Check \"%s\" is not anymore in journal \"%s\", it seems it has been moved by"
+" another payment."
+msgstr ""
+"Cheque \"%s\" no esta mas en el diario \"%s\", parece que ha sido movido por"
+" otro pago."
+
+#. module: l10n_latam_check
+#: code:addons/l10n_latam_check/models/account_payment.py:0
+#, python-format
+msgid "Check %s delivered"
+msgstr "Cheque %s entregado"
+
+#. module: l10n_latam_check
+#: code:addons/l10n_latam_check/models/account_payment.py:0
+#, python-format
+msgid "Check %s received"
+msgstr "Cheque %s recibido"
+
+#. module: l10n_latam_check
+#: code:addons/l10n_latam_check/models/account_payment.py:0
+#, python-format
+msgid "Check '%s' is on journal '%s', we can't receive it again"
+msgstr "Cheque '%s' esta en el diario '%s', no podemos recibirlo de nuevo"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment__l10n_latam_check_bank_id
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment_register__l10n_latam_check_bank_id
+#: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_form_inherited
+#: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_register_form
+msgid "Check Bank"
+msgstr "Banco del Cheque"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment__l10n_latam_check_current_journal_id
+#: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_form_inherited
+msgid "Check Current Journal"
+msgstr "Diario Actual del Cheque"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment__l10n_latam_check_issuer_vat
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment_register__l10n_latam_check_issuer_vat
+msgid "Check Issuer VAT"
+msgstr "NIF del Emisor del Cheque"
+
+#. module: l10n_latam_check
+#: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_form_inherited
+#: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_register_form
+msgid "Check Issuer Vat"
+msgstr "NIF del Emisor del Cheque"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment__check_number
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment_register__l10n_latam_check_number
+msgid "Check Number"
+msgstr "Número de cheque"
+
+#. module: l10n_latam_check
+#: code:addons/l10n_latam_check/models/account_payment.py:0
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment__l10n_latam_check_operation_ids
+#, python-format
+msgid "Check Operations"
+msgstr "Operaciones del Cheque"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment__l10n_latam_check_payment_date
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment_register__l10n_latam_check_payment_date
+#: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_search
+msgid "Check Payment Date"
+msgstr "Fecha de Pago del Cheque"
+
+#. module: l10n_latam_check
+#: model:ir.actions.act_window,name:l10n_latam_check.action_view_account_payment_mass_transfer
+msgid "Check Transfer"
+msgstr "Transferencia de Cheques"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment__l10n_latam_checkbook_type
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment_register__l10n_latam_checkbook_type
+#: model:ir.model.fields,field_description:l10n_latam_check.field_l10n_latam_checkbook__type
+msgid "Check type"
+msgstr "Tipo de Cheque"
+
+#. module: l10n_latam_check
+#: model:ir.model,name:l10n_latam_check.model_l10n_latam_checkbook
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment__l10n_latam_checkbook_id
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment_register__l10n_latam_checkbook_id
+msgid "Checkbook"
+msgstr "Libro de Cheques"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_journal__l10n_latam_checkbook_ids
+#: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_checkbook_tree
+msgid "Checkbooks"
+msgstr "Libros de Cheques"
+
+#. module: l10n_latam_check
+#: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_journal_tree
+msgid "Checks Management"
+msgstr "Gestión de Cheques"
+
+#. module: l10n_latam_check
+#: model:ir.model,name:l10n_latam_check.model_account_payment_mass_transfer
+msgid "Checks Mass Transfers"
+msgstr "Transferencias Masivas de Cheques"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,help:l10n_latam_check.field_l10n_latam_checkbook__sequence_id
+msgid "Checks numbering sequence."
+msgstr "Secuencia de numeración de cheques."
+
+#. module: l10n_latam_check
+#: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_search
+msgid "Checks on hand"
+msgstr "Cheques en mano"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment_mass_transfer__company_id
+msgid "Company"
+msgstr "Compañía"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,help:l10n_latam_check.field_account_payment_mass_transfer__company_id
+msgid "Company related to this journal"
+msgstr "Compañía relacionada con este diario"
+
+#. module: l10n_latam_check
+#: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_mass_transfer_form
+msgid "Create Transfers"
+msgstr "Crear Transferencias"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment_mass_transfer__create_uid
+#: model:ir.model.fields,field_description:l10n_latam_check.field_l10n_latam_checkbook__create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment_mass_transfer__create_date
+#: model:ir.model.fields,field_description:l10n_latam_check.field_l10n_latam_checkbook__create_date
+msgid "Created on"
+msgstr "Creado el"
+
+#. module: l10n_latam_check
+#: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_third_check_tree
+msgid "Current Journal"
+msgstr "Diario Actual"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields.selection,name:l10n_latam_check.selection__l10n_latam_checkbook__type__currents
+msgid "Currents"
+msgstr "Corrientes"
+
+#. module: l10n_latam_check
+#: code:addons/l10n_latam_check/models/l10n_latam_checkbook.py:0
+#, python-format
+msgid "Currents Checks"
+msgstr "Cheques Corrientes"
+
+#. module: l10n_latam_check
+#: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_third_check_operations_tree
+msgid "Customer"
+msgstr "Cliente"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields.selection,name:l10n_latam_check.selection__l10n_latam_checkbook__type__deferred
+msgid "Deferred"
+msgstr "Diferidos"
+
+#. module: l10n_latam_check
+#: code:addons/l10n_latam_check/models/l10n_latam_checkbook.py:0
+#, python-format
+msgid "Deferred Checks"
+msgstr "Cheques Diferidos"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment_mass_transfer__destination_journal_id
+msgid "Destination Journal"
+msgstr "Diario de Destino"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment_mass_transfer__display_name
+#: model:ir.model.fields,field_description:l10n_latam_check.field_l10n_latam_checkbook__display_name
+msgid "Display Name"
+msgstr "Nombre a Mostrar"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields.selection,name:l10n_latam_check.selection__l10n_latam_checkbook__type__electronic
+msgid "Electronic"
+msgstr "Electrónico"
+
+#. module: l10n_latam_check
+#: code:addons/l10n_latam_check/models/l10n_latam_checkbook.py:0
+#, python-format
+msgid "Electronic Checks"
+msgstr "Cheques Electrónicos"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment_mass_transfer__id
+#: model:ir.model.fields,field_description:l10n_latam_check.field_l10n_latam_checkbook__id
+msgid "ID"
+msgstr "ID"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,help:l10n_latam_check.field_l10n_latam_checkbook__range_to
+msgid ""
+"If you set a number here, this checkbook will be automatically set as used "
+"when this number is raised."
+msgstr ""
+"Si se establece un número aquí, este chequera se establecerá automáticamente "
+"como usada cuando se alcance este número."
+
+#. module: l10n_latam_check
+#: code:addons/l10n_latam_check/models/account_payment.py:0
+#, python-format
+msgid ""
+"It seems you're receiving back a check from '%s' with a different payment "
+"type than when sending it. It is advisable to use the same payment type "
+"(customer payment / supplier payment) so that the same receivable / payable "
+"account is used"
+msgstr ""
+"Parece que estás recibiendo un cheque de '%s' con un tipo de pago diferente "
+"que el que lo enviaste. Es aconsejable usar el mismo tipo de pago "
+"(pago al cliente / pago al proveedor) para que se use la misma cuenta "
+"de cobro / pago."
+
+#. module: l10n_latam_check
+#: code:addons/l10n_latam_check/models/account_payment.py:0
+#, python-format
+msgid ""
+"It seems you're trying to move a check with a date (%s) prior to last "
+"operation done with the check (%s). This may be wrong, please double check "
+"it. If continue, last operation on the check will remain being %s"
+msgstr ""
+"Parece que estás intentando mover un cheque con una fecha (%s) anterior a la "
+"última operación realizada con el cheque (%s). Esto puede ser incorrecto, "
+"por favor, revísalo. Si continúas, la última operación del cheque permanecerá "
+"como %s"
+
+#. module: l10n_latam_check
+#: model:ir.model,name:l10n_latam_check.model_account_journal
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment_mass_transfer__journal_id
+#: model:ir.model.fields,field_description:l10n_latam_check.field_l10n_latam_checkbook__journal_id
+msgid "Journal"
+msgstr "Diario"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment__l10n_latam_check_warning_msg
+msgid "L10N Latam Check Warning Msg"
+msgstr "L10N Latam Check Warning Msg"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment_mass_transfer____last_update
+#: model:ir.model.fields,field_description:l10n_latam_check.field_l10n_latam_checkbook____last_update
+msgid "Last Modified on"
+msgstr "Última Modificación en"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment_mass_transfer__write_uid
+#: model:ir.model.fields,field_description:l10n_latam_check.field_l10n_latam_checkbook__write_uid
+msgid "Last Updated by"
+msgstr "Última Actualización por"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment_mass_transfer__write_date
+#: model:ir.model.fields,field_description:l10n_latam_check.field_l10n_latam_checkbook__write_date
+msgid "Last Updated on"
+msgstr "Última Actualización en"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment_mass_transfer__communication
+msgid "Memo"
+msgstr "Memo"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,field_description:l10n_latam_check.field_l10n_latam_checkbook__name
+msgid "Name"
+msgstr "Nombre"
+
+#. module: l10n_latam_check
+#: model:account.payment.method,name:l10n_latam_check.account_payment_method_new_third_checks
+msgid "New Third Checks"
+msgstr "Nuevos Cheques Terceros"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,help:l10n_latam_check.field_l10n_latam_checkbook__next_number
+msgid ""
+"Next number that will be used. This number can be incremented frequently so "
+"the displayed value might already be obsolete"
+msgstr ""
+"El siguiente número que será usado. Este número puede ser incrementado "
+"frecuentemente, por lo que el valor mostrado podría ser obsoleto"
+
+#. module: l10n_latam_check
+#: code:addons/l10n_latam_check/models/account_payment.py:0
+#, python-format
+msgid ""
+"Other checks where found with same number, issuer and bank. Please double "
+"check you're not encoding the same check more than once<br/>List of other "
+"payments/checks: %s"
+msgstr ""
+"Otros cheques que se encontraron con el mismo número, emisor y banco. Por "
+"favor, revísalo que no estás codificando el mismo cheque más de una vez<br/>"
+"Lista de otros pagos/cheques: %s"
+
+#. module: l10n_latam_check
+#: model:ir.actions.act_window,name:l10n_latam_check.action_own_check
+#: model:ir.ui.menu,name:l10n_latam_check.menu_own_check
+msgid "Own Checks"
+msgstr "Cheques Propios"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment_mass_transfer__payment_date
+#: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_own_check_tree
+msgid "Payment Date"
+msgstr "Fecha de Pago"
+
+#. module: l10n_latam_check
+#: model:ir.model,name:l10n_latam_check.model_account_payment_method
+msgid "Payment Methods"
+msgstr "Métodos de pago"
+
+#. module: l10n_latam_check
+#: code:addons/l10n_latam_check/wizards/account_payment_mass_transfer.py:0
+#: model:ir.model,name:l10n_latam_check.model_account_payment
+#, python-format
+msgid "Payments"
+msgstr "Pagos"
+
+#. module: l10n_latam_check
+#: model:ir.model,name:l10n_latam_check.model_account_payment_register
+msgid "Register Payment"
+msgstr "Registrar pago"
+
+#. module: l10n_latam_check
+#: code:addons/l10n_latam_check/models/account_chart_template.py:0
+#, python-format
+msgid "Rejected Third Checks"
+msgstr "Cheques Terceros Rechazados"
+
+#. module: l10n_latam_check
+#: code:addons/l10n_latam_check/models/account_payment.py:0
+#, python-format
+msgid "Selected check \"%s\" is not posted"
+msgstr "El cheque \"%s\" seleccionado no está publicado"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,field_description:l10n_latam_check.field_l10n_latam_checkbook__sequence_id
+msgid "Sequence"
+msgstr "Secuencia"
+
+#. module: l10n_latam_check
+#: code:addons/l10n_latam_check/models/account_payment.py:0
+#, python-format
+msgid ""
+"The amount of the payment (%s) does not match the amount of the selected check (%s).\n"
+"Please try to deselect and select check again."
+msgstr ""
+
+#. module: l10n_latam_check
+#: code:addons/l10n_latam_check/wizards/account_payment_mass_transfer.py:0
+#, python-format
+msgid ""
+"The register payment wizard should only be called on account.payment "
+"records."
+msgstr ""
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,help:l10n_latam_check.field_account_payment__check_number
+msgid ""
+"The selected journal is configured to print check numbers. If your pre-"
+"printed check paper already has numbers or if the current numbering is "
+"wrong, you can change it in the journal configuration page."
+msgstr ""
+"El diario seleccionado está configurado para imprimir números de cheque. Si "
+"sus cheques pre-impresos ya tienen números o si la numeración actual es "
+"incorrecta, puedes cambiarla en la página de configuración del diario."
+
+#. module: l10n_latam_check
+#: code:addons/l10n_latam_check/wizards/account_payment_mass_transfer.py:0
+#, python-format
+msgid "There is no 'out_third_checks' payment method configured on journal %s"
+msgstr "No hay un método de pago 'out_third_checks' configurado en el diario %s"
+
+#. module: l10n_latam_check
+#: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_search
+msgid "Third Check Current Journal"
+msgstr "Diario de Cheques Terceros Actual"
+
+#. module: l10n_latam_check
+#: code:addons/l10n_latam_check/models/account_chart_template.py:0
+#: model:account.payment.method,name:l10n_latam_check.account_payment_method_in_third_checks
+#: model:account.payment.method,name:l10n_latam_check.account_payment_method_out_third_checks
+#: model:ir.actions.act_window,name:l10n_latam_check.action_third_check
+#: model:ir.ui.menu,name:l10n_latam_check.menu_third_check
+#, python-format
+msgid "Third Checks"
+msgstr "Cheques Terceros"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,field_description:l10n_latam_check.field_l10n_latam_checkbook__range_to
+msgid "To Number"
+msgstr "Al Número"
+
+#. module: l10n_latam_check
+#: code:addons/l10n_latam_check/models/account_payment.py:0
+#, python-format
+msgid "Unmark sent is not implemented for checks that use checkbooks"
+msgstr "Desmarcar enviado no está implementado para cheques que usan libros de cheques"
+
+#. module: l10n_latam_check
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_journal__l10n_latam_use_checkbooks
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment__l10n_latam_use_checkbooks
+#: model:ir.model.fields,field_description:l10n_latam_check.field_account_payment_register__l10n_latam_use_checkbooks
+msgid "Use checkbooks?"
+msgstr "¿Usar libros de cheques?"
+
+#. module: l10n_latam_check
+#: code:addons/l10n_latam_check/models/account_payment.py:0
+#, python-format
+msgid "You can't use New Third Checks on a transfer"
+msgstr "No puedes usar Cheques Terceros Nuevos en una transferencia"
+
+#. module: l10n_latam_check
+#: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_register_form
+msgid ""
+"You can't use checks when paying invoices of different partners or same "
+"partner without grouping"
+msgstr ""
+"No puedes usar cheques cuando se pagan facturas de distintos Clientes/Proveedores o "
+"mismo Cliente/Proveedor sin agrupar"
+
+#. module: l10n_latam_check
+#: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_form_inherited
+msgid "⇒ Check Operations"
+msgstr "⇒ Operaciones de Cheque"


### PR DESCRIPTION
Buenas, agregué traducciones para Spanish (AR) / Español (AR) en  account_payment_group y l10n_latam_check pero veo que ningún módulo de la localización usa es_AR.po. 
Debería agregar estas traducciones a es.po y luego es_AR.po las hereda? Disculpen mi desconocimiento. Si es así hago los cambios. No encontré ninguna documentación en referencia a traducciones.
Saludos!