### PR TITLE
[FIX] account_payment_group: Print draft payment group

### DIFF
--- a/account_payment_group/__manifest__.py
+++ b/account_payment_group/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Account Payment with Multiple methods",
-    "version": "13.0.1.8.0",
+    "version": "13.0.1.9.0",
     "category": "Accounting",
     "website": "www.adhoc.com.ar",
     "author": "ADHOC SA, AITIC S.A.S",

--- a/account_payment_group/views/report_payment_group.xml
+++ b/account_payment_group/views/report_payment_group.xml
@@ -26,7 +26,7 @@
         report_type="qweb-pdf"
         name="account_payment_group.report_payment_group"
         file="account_payment_group.report_payment_group"
-        print_report_name="(object.partner_type == 'supplier' and 'Orden de pago' or 'Recibo') + ' ' + object.document_number"
+        print_report_name="(object.partner_type == 'supplier' and 'Orden de pago' or 'Recibo') + ' ' + (object.document_number or 'Borrador')"
     />
 
 </odoo>


### PR DESCRIPTION
ticket 54036
---

If we try to print a draft payment group we receive a traceback error because we have not set the document number yet. With this change we are able to prind draft payments without error.