### PR TITLE
[FIX] account_payment_group: method support multiple records

### DIFF
--- a/account_payment_group/models/account_payment.py
+++ b/account_payment_group/models/account_payment.py
@@ -245,6 +245,7 @@ class AccountPayment(models.Model):
             return super()._compute_is_internal_transfer()
 
     def _create_paired_internal_transfer_payment(self):
-        super(AccountPayment, self.with_context(
-            default_force_amount_company_currency=self.force_amount_company_currency
-        ))._create_paired_internal_transfer_payment()
+        for rec in self:
+            super(AccountPayment, rec.with_context(
+                default_force_amount_company_currency=rec.force_amount_company_currency
+            ))._create_paired_internal_transfer_payment()


### PR DESCRIPTION
ticket 55460
--

Using self.field name throws singleton error. iterating in the records solves the problem