### PR TITLE
[FIX]account_withholding: fix view error runbot adhoc

### DIFF
--- a/account_withholding/__manifest__.py
+++ b/account_withholding/__manifest__.py
@@ -34,5 +34,5 @@
     'installable': True,
     'name': 'Withholdings on Payments',
     'test': [],
-    'version': "16.0.1.0.0",
+    'version': "16.0.1.1.0",
 }

--- a/account_withholding/views/account_journal_views.xml
+++ b/account_withholding/views/account_journal_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account.view_account_journal_form"/>
         <field name="arch" type="xml">
             <!-- make default_account_id optional if withholdings journal -->
-            <xpath expr="//field[@name='default_account_id'][2]" position="attributes">
+            <xpath expr="//field[@name='default_account_id']" position="attributes">
                 <attribute name="attrs">{'required': [('id', '!=', False), ('type', '=', 'cash'), '!', ('selected_payment_method_codes', 'like', 'withholding')], 'invisible': [('type', '!=', 'cash'),]}</attribute>
             </xpath>
         </field>

--- a/account_withholding/views/account_journal_views.xml
+++ b/account_withholding/views/account_journal_views.xml
@@ -6,9 +6,10 @@
         <field name="inherit_id" ref="account.view_account_journal_form"/>
         <field name="arch" type="xml">
             <!-- make default_account_id optional if withholdings journal -->
-            <xpath expr="//field[@name='default_account_id']" position="attributes">
-                <attribute name="attrs">{'required': [('id', '!=', False), ('type', '=', 'cash'), '!', ('selected_payment_method_codes', 'like', 'withholding')], 'invisible': [('type', '!=', 'cash'),]}</attribute>
-            </xpath>
+            <field name="default_account_id" position="attributes">
+                <attribute name="attrs">{'required': ['|', '&amp;', '&amp;', ('id', '!=', False), ('type', 'in', ('bank', 'cash')), '!', ('selected_payment_method_codes', 'like', 'withholding'), ('type', 'in', ('sale', 'purchase'))],
+                                                       'invisible': [('type', '=', False)]}</attribute>
+            </field>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Commit that cause the problem: https://github.com/odoo/odoo/commit/7628888d61843ed9e9b76039884572e923ba382f

Error on runbot:
odoo.service.server:1326
Failed to initialize database `38468-16-0-all`.
Traceback (most recent call last):
  File "/data/build/adhoc-cicd/odoo/odoo/service/server.py", line 1289, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "<decorator-gen-14>", line 2, in new
  File "/data/build/adhoc-cicd/odoo/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "/data/build/adhoc-cicd/odoo/odoo/modules/registry.py", line 91, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/data/build/adhoc-cicd/odoo/odoo/modules/loading.py", line 482, in load_modules
    processed_modules += load_marked_modules(cr, graph,
  File "/data/build/adhoc-cicd/odoo/odoo/modules/loading.py", line 371, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/data/build/adhoc-cicd/odoo/odoo/modules/loading.py", line 230, in load_module_graph
    load_data(cr, idref, mode, kind='data', package=package)
  File "/data/build/adhoc-cicd/odoo/odoo/modules/loading.py", line 71, in load_data
    tools.convert_file(cr, package.name, filename, idref, mode, noupdate, kind)
  File "/data/build/adhoc-cicd/odoo/odoo/tools/convert.py", line 763, in convert_file
    convert_xml_import(cr, module, fp, idref, mode, noupdate)
  File "/data/build/adhoc-cicd/odoo/odoo/tools/convert.py", line 829, in convert_xml_import
    obj.parse(doc.getroot())
  File "/data/build/adhoc-cicd/odoo/odoo/tools/convert.py", line 749, in parse
    self._tag_root(de)
  File "/data/build/adhoc-cicd/odoo/odoo/tools/convert.py", line 709, in _tag_root
    raise ParseError(msg) from None  # Restart with "--log-handler odoo.tools.convert:DEBUG" for complete traceback
odoo.tools.convert.ParseError: while parsing /data/build/ingadhoc/account-payment/account_withholding/views/account_journal_views.xml:3 Error while validating view:

Element '<xpath expr="//field[@name=&#39;default_account_id&#39;][2]">' cannot be located in parent view

View error context:
{'file': '/data/build/ingadhoc/account-payment/account_withholding/views/account_journal_views.xml',
 'line': 3,
 'name': 'account.journal.form',
 'view': ir.ui.view(1577,),
 'view.model': 'account.journal',
 'view.parent': ir.ui.view(785,),
 'xmlid': 'view_account_journal_form'}