### PR TITLE
[IMP] l10n_latam_check: update account_payment

### DIFF
--- a/l10n_latam_check/models/account_payment.py
+++ b/l10n_latam_check/models/account_payment.py
@@ -95,8 +95,7 @@ class AccountPayment(models.Model):
         new_third_party_checks = self.filtered(lambda x: x.payment_method_line_id.code == 'new_third_party_checks')
         for rec in new_third_party_checks:
             rec.update({
-                'l10n_latam_check_bank_id': rec.partner_id.bank_ids and rec.partner_id.bank_ids[0].bank_id or False,
-                'l10n_latam_check_issuer_vat': rec.partner_id.vat,
+                'l10n_latam_check_issuer_vat': rec.l10n_latam_check_issuer_vat or rec.partner_id.vat,
             })
 
     @api.depends(


### PR DESCRIPTION
The computed method for latam checks only updates issuer vat if this is modified, improve related to ticket 59785