### PR TITLE
[FIX] account_payment_group: search view

### DIFF
--- a/account_payment_group/__manifest__.py
+++ b/account_payment_group/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Account Payment with Multiple methods",
-    "version": "16.0.1.2.0",
+    "version": "16.0.1.3.0",
     "category": "Accounting",
     "website": "www.adhoc.com.ar",
     "author": "ADHOC SA, AITIC S.A.S",

--- a/account_payment_group/views/account_payment_group_view.xml
+++ b/account_payment_group/views/account_payment_group_view.xml
@@ -31,8 +31,8 @@
             <field name="display_name" filter_domain="['|', ('name','ilike',self), ('communication','ilike',self)]" string="Description"/>
             <separator/>
             <field name="payment_methods"/>
-            <field name="partner_id" invisible="context.get('default_partner_type') == 'supplier'" string="Vendor"/>
-            <field name="partner_id" invisible="context.get('default_partner_type') == 'customer'" string="Customer"/>
+            <field name="partner_id" invisible="context.get('default_partner_type') == 'supplier'" string="Customer"/>
+            <field name="partner_id" invisible="context.get('default_partner_type') == 'customer'" string="Vendor"/>
             <field name="company_id" groups="base.group_multi_company" />
             <separator/>
             <filter string="Draft" domain="[('state','=','draft')]" name='state_draft'/>


### PR DESCRIPTION
Now 'Customer' display in customer receipts search view and 'Vendor' display in provider payments search view