### PR TITLE
[FIX] _payment_group: checks migration

### DIFF
--- a/account_payment_group/models/account_payment_group.py
+++ b/account_payment_group/models/account_payment_group.py
@@ -365,6 +365,9 @@ class AccountPaymentGroup(models.Model):
 
     @api.depends('partner_id', 'partner_type', 'company_id')
     def _compute_to_pay_move_lines(self):
+        # if payment group is being created from a payment we dont want to compute to_pay_move_lines
+        if self._context.get('created_automatically'):
+            return
         for rec in self:
             rec.add_all()
 


### PR DESCRIPTION
Al migrar cheques creamos dinamicamente pagos que a su vez crean por arriba un payment group. Esos llevo a detectar un error que es que la creación de payment_group automática no deberia computar lineas a pagar porque ese dato no se va a usar, y si de hecho hay deuda en mas de una cuenta contable va a fallar