### PR TITLE
[IMP] account_payment_group: date field when adding debit note

### DIFF
--- a/account_payment_group/wizards/account_payment_group_invoice_wizard.py
+++ b/account_payment_group/wizards/account_payment_group_invoice_wizard.py
@@ -199,7 +199,7 @@ class AccountPaymentGroupInvoiceWizard(models.TransientModel):
 
         return {
             'ref': self.description,
-            'date': self.date,
+            'date': self.date or self.invoice_date or fields.Date.context_today(self),
             'invoice_date': self.invoice_date,
             'invoice_origin': _('Payment id %s') % payment_group.id,
             'journal_id': self.journal_id.id,


### PR DESCRIPTION
Ticket: 60687
Si no se carga fecha contable (campo date) en el wizard de creación de nota de débito en el grupo de pagos entonces se carga la fecha del día ya que es un campo obligatorio para el asiento del pago