### PR TITLE
[FIX] account_payment_group: tipo de documento en pagos

### DIFF
--- a/account_payment_group/models/account_move.py
+++ b/account_payment_group/models/account_move.py
@@ -211,3 +211,7 @@ class AccountMove(models.Model):
                             AND payment_group_id IS NULL;
         """)
 
+    def _compute_l10n_latam_document_type(self):
+        """ No queremos que el campo l10n_latam_document_type_id se setee en False si el payment group tiene asignado tipo de documento """
+        payments = self.filtered(lambda x: x.journal_id.type in ['bank', 'cash'] or x.move_type == 'entry')
+        return super(AccountMove, self - payments)._compute_l10n_latam_document_type()


### PR DESCRIPTION
Ticket: 64791
No queremos que el campo l10n_latam_document_type_id se setee en False si el payment group tiene asignado tipo de documento