### PR TITLE
[FIX] account_withholding: remove tuple to join recordsets

### DIFF
--- a/account_withholding/models/account_payment.py
+++ b/account_withholding/models/account_payment.py
@@ -39,7 +39,7 @@ class AccountPayment(models.Model):
                 [('company_id', '=', self.company_id.id), '|',
                     ('invoice_tax_id.type_tax_use', 'in', ['supplier', 'customer']),
                     ('refund_tax_id.type_tax_use', 'in', ['supplier', 'customer'])])
-            res += tuple(rep_lines.mapped('account_id'))
+            res |= tuple(rep_lines.mapped('account_id'))
 
         return res
 


### PR DESCRIPTION
Due this change in [odoo](https://github.com/odoo/odoo/commit/0d1f4c166cc2663027fa963173dc7a73ecc8c6ff) now change the tuple to recordset 