### PR TITLE
[FIX] _payment_group: add_all not editing aml on m2m

### DIFF
--- a/account_payment_group/__manifest__.py
+++ b/account_payment_group/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Account Payment with Multiple methods",
-    "version": "16.0.1.6.0",
+    "version": "16.0.1.7.0",
     "category": "Accounting",
     "website": "www.adhoc.com.ar",
     "author": "ADHOC SA, AITIC S.A.S",

--- a/account_payment_group/views/account_move_line_view.xml
+++ b/account_payment_group/views/account_move_line_view.xml
@@ -8,21 +8,21 @@
     <field eval="99" name="priority"/>
     <field name="arch" type="xml">
          <tree string="Journal Items" edit="0">
-            <field name="date"/>
-            <field name="date_maturity"/>
-            <field name="move_id" required="0"/>
-            <field name="journal_id" options='{"no_open":True}'/>
-            <field name="name"/>
-            <field name="ref"/>
-            <field name="statement_id" invisible="1"/>
-            <field name="account_id" options='{"no_open":True}' domain="[('company_id', '=', company_id)]"/>
-            <field name="balance" string="Amount"/>
-            <field name="amount_residual" sum="Total"/>
-            <field name="amount_currency" groups="base.group_multi_currency"/>
-            <field name="amount_residual_currency" groups="base.group_multi_currency"/>
-            <field name="currency_id" invisible="1"/>
-            <field name="company_currency_id" invisible="1"/>
-            <field name="company_id" invisible="1"/>
+            <field name="date" readonly="True"/>
+            <field name="date_maturity" readonly="True"/>
+            <field name="move_id" required="0" readonly="True"/>
+            <field name="journal_id" options='{"no_open":True}' readonly="True"/>
+            <field name="name" readonly="True"/>
+            <field name="ref" readonly="True"/>
+            <field name="statement_id" invisible="1" readonly="True"/>
+            <field name="account_id" options='{"no_open":True}' domain="[('company_id', '=', company_id)]" readonly="True"/>
+            <field name="balance" string="Amount" readonly="True"/>
+            <field name="amount_residual" sum="Total" readonly="True"/>
+            <field name="amount_currency" groups="base.group_multi_currency" readonly="True"/>
+            <field name="amount_residual_currency" groups="base.group_multi_currency" readonly="True"/>
+            <field name="currency_id" invisible="1" readonly="True"/>
+            <field name="company_currency_id" invisible="1" readonly="True"/>
+            <field name="company_id" invisible="1" readonly="True"/>
             <!--button type="object" icon="fa-external-link" help="Open Related Document" name="action_open_related_document"/-->
         </tree>
     </field>


### PR DESCRIPTION
Por lo que parece un bug del framework, cuando el método computado _compute_to_pay_move_lines agrega las lineas Luego la interfaz trata de hacer un write en los amls lo que termina siendo malo a nivel performance pero además peligroso porque termina corriendo update de cosas que no queremos (y eventualmente dando error).

Si se usan los botones add_all esto no pasa, es un tema del compute. En v13 lo teníamos como onchange, tal vez por eso no pasaba.

Resolvemos forzando que en la vista todo sea redonly