### PR TITLE
[FIX] _pay_pro: payments without debt

### DIFF
--- a/account_payment_pro/models/account_move_line.py
+++ b/account_payment_pro/models/account_move_line.py
@@ -36,6 +36,7 @@ class AccountMoveLine(models.Model):
         if not to_pay_move_lines:
             partner_type = self._context.get('default_partner_type')
             to_pay_partner_id = self._context.get('default_partner_id')
+            company_id = self._context.get('default_company_id')
             if not partner_type or not to_pay_partner_id:
                 raise UserError(_('Nothing to be paid on selected entries'))
         else:
@@ -44,6 +45,7 @@ class AccountMoveLine(models.Model):
                 raise UserError(_('Selected recrods must be of the same partner'))
             to_pay_partner_id = to_pay_partners.id
             partner_type = 'customer' if to_pay_move_lines[0].account_id.account_type == 'asset_receivable' else 'supplier'
+            company_id = self.company_id.id
         return {
             'name': _('Register Payment'),
             'res_model': 'account.payment',
@@ -59,9 +61,8 @@ class AccountMoveLine(models.Model):
                 # We set this because if became from other view and in the context has 'create=False'
                 # you can't crate payment lines (for ej: subscription)
                 'create': True,
-                'default_amount': abs(sum(line.amount_residual for line in to_pay_move_lines)),
-                'default_company_id': self.company_id.id,
-                'pop_up': True,
+                'default_to_pay_amount': abs(sum(line.amount_residual for line in to_pay_move_lines)),
+                'default_company_id': company_id,
             },
             'target': 'current',
             'type': 'ir.actions.act_window',

--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -447,8 +447,10 @@ class AccountPayment(models.Model):
         self.action_post()
         return self.to_pay_move_line_ids.with_context(
             force_payment_pro=True,
+            default_move_journal_types=('bank', 'cash'),
             default_to_pay_amount=self.payment_difference,
             default_partner_type=self.partner_type,
+            default_company_id=self.company_id.id,
             default_partner_id=self.partner_id.id).action_register_payment()
 
     @api.depends('to_pay_move_line_ids', 'to_pay_move_line_ids.amount_residual')


### PR DESCRIPTION
Arreglamos no mandar amount y si to pay amount para que el calculo inverso mediante el onchange se compute bien También arreglamos caso de "post and new" cuando es con adelanto (la company estaba vacía)