### PR TITLE
[REF] financial_surcharge: fix case when first journal has card

### DIFF
--- a/account_payment_financial_surcharge/__manifest__.py
+++ b/account_payment_financial_surcharge/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Payments with Financial Surchange",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.1.0",
     "author": "ADHOC SA",
     "license": "AGPL-3",
     "category": "Payment",

--- a/account_payment_financial_surcharge/views/account_payment_views.xml
+++ b/account_payment_financial_surcharge/views/account_payment_views.xml
@@ -14,15 +14,16 @@
                         name="card_id"
                         options="{'no_create': True, 'no_open': True}"
                         domain="[('id', 'in', available_card_ids)]"
-                        invisible="not available_card_ids or payment_type != 'inbound'"
                         required="available_card_ids != [] and payment_type == 'inbound'"
+                        readonly= "state != 'draft'"
                     />
                     <field
                         name="installment_id"
                         options="{'no_create': True, 'no_open': True}"
                         domain="[('card_id', '=', card_id)]"
-                        invisible="not card_id or payment_type !='inbound'"
-                        required="card_id and payment_type =='inbound'"/>
+                        required="card_id and payment_type =='inbound'"
+                        readonly= "state != 'draft'"
+                    />
                 </div>
 
                 <label for="net_amount" invisible="not financing_surcharge"/>


### PR DESCRIPTION
Con esto hacemos que se elija a mano la card sin usar por defecto la primera (el usuario la tiene que elegir a mano). Esto hace que sea igual que en la versión anterior y además arregla el caso donde el primer metodo de pago que se use tenga recargos (al pagar desde una factura no se llamaba el inverse de net amount)