### PR TITLE
[IMP] views: do not allow to open aml on selected debt

### DIFF
--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -442,8 +442,7 @@ class AccountPayment(models.Model):
             #     factor = -1
             # rec.selected_debt = sum(rec.to_pay_move_line_ids._origin.mapped('amount_residual')) * factor
 
-    @api.depends(
-        'selected_debt', 'unreconciled_amount')
+    @api.depends('selected_debt', 'unreconciled_amount')
     def _compute_to_pay_amount(self):
         for rec in self:
             rec.to_pay_amount = rec.selected_debt + rec.unreconciled_amount

--- a/account_payment_pro/views/account_payment_view.xml
+++ b/account_payment_pro/views/account_payment_view.xml
@@ -120,7 +120,7 @@
     <field name="model">account.move.line</field>
     <field eval="99" name="priority"/>
     <field name="arch" type="xml">
-        <list string="Journal Items" edit="1">
+        <list string="Journal Items" edit="0" create="0" editable="bottom">
             <field name="date" readonly="True"/>
             <field name="date_maturity" optional="hide" readonly="True"/>
             <field name="move_id" required="0" readonly="True"/>


### PR DESCRIPTION
Anteriormente un click lo abría y esto no aportaba mucho valor. además en algunos casos usuarios modificaban datos del aml sin coinciencia de lo que estaban haciendo