### PR TITLE
[IMP] _pro_receiptbook: archived receiptboks use cases

### DIFF
--- a/account_payment_pro_receiptbook/__manifest__.py
+++ b/account_payment_pro_receiptbook/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Account Payment receiptbook",
-    "version": "17.0.1.2.0",
+    "version": "17.0.1.3.0",
     "category": "Payment",
     "website": "www.adhoc.com.ar",
     "author": "ADHOC SA",

--- a/account_payment_pro_receiptbook/models/account_payment.py
+++ b/account_payment_pro_receiptbook/models/account_payment.py
@@ -20,9 +20,13 @@ class AccountPayment(models.Model):
         # si no tengo nombre y tengo talonario de recibo, numeramos con el talonario
         for rec in self.filtered(
                 lambda x: x.receiptbook_id and (not x.name or x.name == '/' or not x.move_id._get_last_sequence())):
+            if not rec.receiptbook_id.active:
+                raise ValidationError(_(
+                    'Error! The receiptbook "%s" is archived. Please use a differente receipbook.'
+                ) % rec.receiptbook_id.name)
             if not rec.receiptbook_id.sequence_id:
                 raise ValidationError(_(
-                    'Error!. Please define sequence on the receiptbook related documents to this payment.'))
+                    'Error! Please define sequence on the receiptbook related documents to this payment.'))
 
             rec.l10n_latam_document_type_id = rec.receiptbook_id.document_type_id.id
             name = rec.receiptbook_id.with_context(ir_sequence_date=rec.date).sequence_id.next_by_id()

--- a/account_payment_pro_receiptbook/views/account_payment.xml
+++ b/account_payment_pro_receiptbook/views/account_payment.xml
@@ -5,7 +5,7 @@
         <field name="inherit_id" ref="account.view_account_payment_form"/>
         <field name="arch" type="xml">
             <field name="ref" position="after">
-                <field name="receiptbook_id" invisible="is_internal_transfer or not use_payment_pro" readonly="state != 'draft'" required="state == 'draft'" options='{"no_open": True, "no_create": True}'/>
+                <field name="receiptbook_id" invisible="is_internal_transfer or not use_payment_pro" readonly="state != 'draft'" required="state == 'draft'" options='{"no_create": True}'/>
             </field>
         </field>
     </record>

--- a/account_payment_pro_receiptbook/views/account_payment_receipt_group.xml
+++ b/account_payment_pro_receiptbook/views/account_payment_receipt_group.xml
@@ -11,6 +11,9 @@
                 <field name="partner_type"/>
                 <field name="document_type_id"/>
                 <field name="company_id" widget="selection" groups="base.group_multi_company"/>
+                <separator/>
+                    <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
+                <separator/>
             </search>
         </field>
     </record>
@@ -37,6 +40,8 @@
             <form string="Receipt Books">
                 <field name="company_id" invisible="True"/>
                 <sheet string="Receipt Books">
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
+                    <field name="active" invisible="1"/>
                     <group>
                         <group>
                             <field name="name"/>
@@ -50,7 +55,6 @@
                             <field name="sequence_id"/>
                             <field name="next_number"/>
                             <field name="company_id" widget="selection" groups="base.group_multi_company"/>
-                            <field name="active"/>
                         </group>
                     </group>
                 </sheet>


### PR DESCRIPTION
1. Mejoramos para que si el talonario esta archivado no deje consumir número (es para caso de uruguay donde los talonarios de recibos manuales existen y son legales y tienen que tener control de la numeración)
2. Agregamos el open de receipbook para poder ir rápidamente al mismo si es necesario