### PR TITLE
[FIX] account_payment_pro_receiptbook: Fix in post_init_hook when creating new argentine companies

### DIFF
--- a/account_payment_pro_receiptbook/models/account_chart_template.py
+++ b/account_payment_pro_receiptbook/models/account_chart_template.py
@@ -42,4 +42,8 @@ class AccountChartTemplate(models.AbstractModel):
                 'document_type_id': document_type.id,
                 'prefix': '0001-',
             }
-            receipbook.create(vals)
+            # sudo() is used to bypass access restrictions during the initial creation
+            # of receiptbooks when creating an argentine company, 
+            # as the user might not yet have access to the newly created
+            # company due to multi-company rules.
+            receipbook.sudo().create(vals)


### PR DESCRIPTION

The post_init_hook was failing to create receiptbooks for new companies due to multi-company access rules restricting the creation process.

This fix ensures that the process uses `sudo()` to bypass access restrictions temporarily (only in post_init_hook),

allowing receiptbooks to be properly initialized during the company's setup phase.