### PR TITLE
[FIX] account_payment_pro: Fix when calculate unmatched_amount

### DIFF
--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -374,7 +374,9 @@ class AccountPayment(models.Model):
             sign = rec.partner_type == 'supplier' and -1.0 or 1.0
             rec.matched_amount = sign * sum(
                 rec.matched_move_line_ids.with_context(matched_payment_ids=rec.ids).mapped('payment_matched_amount'))
-            rec.unmatched_amount = sign * rec.payment_total - rec.matched_amount
+            if rec.other_currency:
+                rec.payment_total = sign * rec.payment_total
+            rec.unmatched_amount = rec.payment_total - rec.matched_amount
 
     @api.depends('to_pay_move_line_ids')
     def _compute_has_outstanding(self):


### PR DESCRIPTION
This error was introducing in the following commit https://github.com/ingadhoc/account-payment/pull/587

This commit tried to solve the problem when paying with a different currency of the bill. Only in that case the payment_total was consider with an inconsistent sign.

This commit consider both cases.