### PR TITLE
[FIX] l10n_latam_check_ux:  Fix internal transfer third party checks

### DIFF
--- a/l10n_latam_check_ux/models/account_payment.py
+++ b/l10n_latam_check_ux/models/account_payment.py
@@ -3,8 +3,7 @@ from odoo.exceptions import ValidationError
 
 
 class AccountPayment(models.Model):
-    _inherit = 'account.payment'
-
+    _inherit = "account.payment"
 
     def action_post(self):
         # nosotros queremos bloquear tmb nros de cheques de terceros que sea unicos
@@ -16,3 +15,35 @@ class AccountPayment(models.Model):
             if rec.l10n_latam_check_warning_msg:
                 raise ValidationError('%s' % rec.l10n_latam_check_warning_msg)
         super().action_post()
+
+    def _create_paired_internal_transfer_payment(self):
+        """
+        Two modifications when only when transferring from a third party checks journal:
+        1. When a paired transfer is created, the default odoo behavior is to use on the paired transfer the first
+        available payment method. If we are transferring to another third party checks journal, then set as payment
+        method on the paired transfer 'in_third_party_checks' or 'out_third_party_checks'
+        2. On the paired transfer set the l10n_latam_check_id field, this field is needed for the
+        l10n_latam_check_operation_ids and also for some warnings and constrains.
+        """
+        # We evalute if the transfer is creating from de wizard transfer check button with check_deposit_transfer context,
+        # in order to not duplicate the transfer when creating the deposit of the check from the wizard.
+        # Who already create both payments at once in the _create_payments method.)
+        if not self.env.context.get("check_deposit_transfer"):
+            third_party_checks = self.filtered(lambda x: x.payment_method_line_id.code in [
+                "in_third_party_checks",
+                "out_third_party_checks"
+            ])
+            for rec in third_party_checks:
+                dest_payment_method_code = "in_third_party_checks" if rec.payment_type == "outbound" else "out_third_party_checks"
+                dest_payment_method = rec.destination_journal_id.inbound_payment_method_line_ids.filtered(
+                    lambda x: x.code == dest_payment_method_code)
+                if dest_payment_method:
+                    super(AccountPayment, rec.with_context(
+                        default_payment_method_line_id=dest_payment_method.id,
+                        default_l10n_latam_move_check_ids=rec.l10n_latam_move_check_ids,
+                    ))._create_paired_internal_transfer_payment()
+                else:
+                    super(AccountPayment, rec.with_context(
+                        default_l10n_latam_move_check_ids=rec.l10n_latam_move_check_ids,
+                    ))._create_paired_internal_transfer_payment()
+            super(AccountPayment, self - third_party_checks)._create_paired_internal_transfer_payment()

--- a/l10n_latam_check_ux/wizards/__init__.py
+++ b/l10n_latam_check_ux/wizards/__init__.py
@@ -3,3 +3,4 @@
 # directory
 ##############################################################################
 from . import account_check_action_wizard
+from . import l10n_latam_payment_mass_transfer

--- a/l10n_latam_check_ux/wizards/l10n_latam_payment_mass_transfer.py
+++ b/l10n_latam_check_ux/wizards/l10n_latam_payment_mass_transfer.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from odoo import models
+
+
+class L10nLatamPaymentMassTransfer(models.TransientModel):
+    _inherit  = 'l10n_latam.payment.mass.transfer'
+
+
+    def _create_payments(self):
+        # Ensure that third-party check deposits made through the Odoo wizard
+        # behave the same way as an internal transfer.
+        outbound_payment = super(L10nLatamPaymentMassTransfer, self.with_context(
+            is_internal_transfer_menu=True,
+            default_destination_journal_id=self.destination_journal_id.id,
+            check_deposit_transfer=True
+        ))._create_payments()
+
+        # Retrieve the corresponding inbound payment by finding the reconciled move lines
+        # and filtering out the outbound payment's move.
+        inbound_payment = outbound_payment.move_id.line_ids.full_reconcile_id.reconciled_line_ids.mapped('move_id').filtered(
+            lambda x: x.id != outbound_payment.move_id.id
+        ).mapped('payment_ids')
+
+        # Set the paired internal transfer payment IDs to establish the link
+        # between the outbound and inbound payments.
+        outbound_payment.paired_internal_transfer_payment_id = inbound_payment.id
+        inbound_payment.paired_internal_transfer_payment_id = outbound_payment.id
+
+        return outbound_payment


### PR DESCRIPTION
This commit implements the necessary corrections to ensure
that the deposit of third-party checks, through the wizard,
behaves the same way as an internal transfer.
This ensures consistency in the process and prevents validation discrepancies.