### PR TITLE
[REV] Revert to commit bf1d3f0690be88ca13ebddd098f49971d4601a59

### DIFF
--- a/account_payment_pro_receiptbook/__manifest__.py
+++ b/account_payment_pro_receiptbook/__manifest__.py
@@ -23,7 +23,7 @@
         'data/l10n_latam.document.type.csv',
     ],
     'installable': True,
-    'auto_install': ["account_payment_pro","l10n_ar_account_tax_settlement"],
+    'auto_install': ["account_payment_pro"],
     'application': False,
     'post_init_hook': '_generate_receiptbooks',
     "demo": [


### PR DESCRIPTION
The module dependencies should be available in a CE environment. 
Revert the __manifest__.py file to commit bf1d3f0690be88ca13ebddd098f49971d4601a59 to avoid cross-references between modules available for the CE version and only available in the EE version.