### PR TITLE
[FIX] account_payment_pro: Prevent duplicate tax withholdings when splitting payments

### DIFF
--- a/account_payment_pro/models/account_move_line.py
+++ b/account_payment_pro/models/account_move_line.py
@@ -64,6 +64,7 @@ class AccountMoveLine(models.Model):
                 payment_type = "outbound"
             else:
                 payment_type = "inbound" if partner_type == "customer" else "outbound"
+            create_and_new = True if self._context.get("create_and_new") else False
             context = {
                 "active_model": "account.move.line",
                 "active_ids": self.ids,
@@ -74,6 +75,7 @@ class AccountMoveLine(models.Model):
                 # We set this because if became from other view and in the context has 'create=False'
                 # you can't crate payment lines (for ej: subscription)
                 "create": True,
+                "create_and_new": create_and_new,
                 "default_company_id": company_id,
             }
             if self._context.get("default_l10n_ar_fiscal_position_id") is not None:

--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -492,6 +492,7 @@ class AccountPayment(models.Model):
         self.action_post()
         return self.to_pay_move_line_ids.with_context(
             force_payment_pro=True,
+            create_and_new=True,
             default_move_journal_types=("bank", "cash"),
             default_to_pay_amount=self.payment_difference,
             default_l10n_ar_fiscal_position_id=False,


### PR DESCRIPTION

Ensure that tax withholdings are not recalculated when a payment is split, particularly when changing the journal in the second payment. To achieve this, added a context flag to detect when the payment is being created using the "Create and New" button. This prevents the system from incorrectly applying withholdings again in the new payment.