### PR TITLE
[FIX] account_payment_pro_receiptbook: Fix the setting of l10n_latam_document_type_id when having receitbook.

### DIFF
--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -458,14 +458,14 @@ class AccountPayment(models.Model):
 
         # Se recomputan las lienas solo si la deuda que esta seleccionada solo si
         # cambio el partner, compania o partner_type
-
-        with_payment_pro = self.filtered(lambda x: x.company_id.use_payment_pro and not x.is_internal_transfer)
-        if not self._context.get('pay_now'):
-            (self - with_payment_pro).to_pay_move_line_ids = [Command.clear()]
-        for rec in with_payment_pro:
-            if rec.partner_id != rec._origin.partner_id or rec.partner_type != rec._origin.partner_type or \
-                    rec.company_id != rec._origin.company_id:
-                rec._add_all()
+        if self.state == 'draft':
+            with_payment_pro = self.filtered(lambda x: x.company_id.use_payment_pro and not x.is_internal_transfer)
+            if not self._context.get('pay_now'):
+                (self - with_payment_pro).to_pay_move_line_ids = [Command.clear()]
+            for rec in with_payment_pro:
+                if rec.partner_id != rec._origin.partner_id or rec.partner_type != rec._origin.partner_type or \
+                        rec.company_id != rec._origin.company_id:
+                    rec._add_all()
 
     def _get_to_pay_move_lines_domain(self):
         self.ensure_one()

--- a/account_payment_pro_receiptbook/models/account_move.py
+++ b/account_payment_pro_receiptbook/models/account_move.py
@@ -38,3 +38,8 @@ class AccountMove(models.Model):
         receiptbook_recs = self.filtered(lambda x: x.receiptbook_id and x.journal_id.type in ('bank', 'cash'))
         receiptbook_recs.made_sequence_hole = False
         super(AccountMove, self - receiptbook_recs)._compute_made_sequence_hole()
+
+    @api.depends('payment_id.receiptbook_id')
+    def _compute_l10n_latam_document_type(self):
+        receiptbook_payments = self.filtered(lambda x: x.payment_id.receiptbook_id)
+        super(AccountMove, self - receiptbook_payments)._compute_l10n_latam_document_type()


### PR DESCRIPTION

The fix ensures that when using a receipt, the `l10n_latam_document_type_id` field is set by inheriting its compute method instead of setting it only at the moment of posting.

Previously, if the field was set only in the action post when using receitbook, any recomputation could reset it to False. By overriding the compute method, the correct document type is assigned when using a receipt, preventing unintended resets.