### PR TITLE
[FIX] account_payment_pro: Fix incorrect selected debt when paying with Pay Now in a different currency

### DIFF
--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -431,7 +431,10 @@ class AccountPayment(models.Model):
     def _compute_selected_debt(self):
         for rec in self:
             # factor = 1
-            rec.selected_debt = sum(rec.to_pay_move_line_ids._origin.mapped('amount_residual')) * (-1.0 if rec.partner_type == 'supplier' else 1.0)
+            amount_residual = sum(rec.to_pay_move_line_ids._origin.mapped('amount_residual'))
+            if self.env.context.get('pay_now') and amount_residual != sum(rec.to_pay_move_line_ids._origin.mapped('amount_residual_currency')):
+                amount_residual = sum(rec.to_pay_move_line_ids._origin.mapped('amount_residual_currency'))
+            rec.selected_debt = amount_residual * (-1.0 if rec.partner_type == 'supplier' else 1.0)
             # TODO error en la creacion de un payment desde el menu?
             # if rec.payment_type == 'outbound' and rec.partner_type == 'customer' or \
             #         rec.payment_type == 'inbound' and rec.partner_type == 'supplier':


### PR DESCRIPTION
When creating an invoice with the `pay_now_journal_id` set to a journal  
that has a different currency than the company currency, the selected debt  
was incorrectly set.  

This fix ensures that the correct currency is considered when setting  
the selected debt, preventing inconsistencies in payment processing.