### PR TITLE
[FIX] account_payment_pro_receiptbook: Ensure to set l10n_latam_document_type_id when using receiptbook in payment.

### DIFF
--- a/account_payment_pro_receiptbook/models/account_payment.py
+++ b/account_payment_pro_receiptbook/models/account_payment.py
@@ -35,6 +35,12 @@ class AccountPayment(models.Model):
             rec.name = "%s %s" % (rec.receiptbook_id.document_type_id.doc_code_prefix, name)
 
         res = super().action_post()
+        # Reincorporamos el seteo del l10n_latam_document_type_id para el caso de usar talonario de recibo
+        # Ya que debido al fix en
+        # https://github.com/ingadhoc/account-payment/commit/8a6ff0564d3526ec8ead24c90a8e53267d038f6a
+        # se esta evitando el recomputo para impedir que este vuelva a False.
+        for rec in self.filtered(lambda x: x.receiptbook_id):
+            rec.move_id.l10n_latam_document_type_id = rec.receiptbook_id.document_type_id.id
 
         for rec in self.filtered("receiptbook_id.mail_template_id"):
             rec.message_post_with_source(rec.receiptbook_id.mail_template_id, subtype_xmlid="mail.mt_comment")


### PR DESCRIPTION

Previously, we were computing l10n_latam_document_type_id instead of assigning it in the post method (as in previous versions). From v18, it was only being set in the compute method.

Then, due to an issue detected in this commit,
https://github.com/ingadhoc/account-payment/commit/8a6ff0564d3526ec8ead24c90a8e53267d038f6a we attempted to fix a case where the recomputation left it unassigned, both in the post method and the recompute, affecting receipts.(only in v18)