### PR TITLE
[IMP] account_cashbox: default cashbox for users

### DIFF
--- a/account_cashbox/__manifest__.py
+++ b/account_cashbox/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Cashbox management",
     "summary": "Introduces concept cashbox and accounting journal sessions",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.1.0",
     "category": "Accounting",
     "website": "www.adhoc.com.ar",
     "author": "juanpgarza, ADHOC SA",

--- a/account_cashbox/models/res_users.py
+++ b/account_cashbox/models/res_users.py
@@ -3,7 +3,7 @@
 # directory
 ##############################################################################
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ResUsers(models.Model):
@@ -16,3 +16,15 @@ class ResUsers(models.Model):
         column2="cashbox_id",
     )
     requiere_account_cashbox_session = fields.Boolean()
+
+    default_cashbox_id = fields.Many2one(
+        comodel_name="account.cashbox",
+        domain="[('id', 'in', allowed_cashbox_ids)]",
+        help="""In the case of concurrent sessions in the selected cashbox,
+        the most recently created session for that cashbox will be assigned to the payments.""",
+    )
+
+    @api.onchange("allowed_cashbox_ids")
+    def _onchange_allowed_cashbox_ids(self):
+        if self.default_cashbox_id.id not in self.allowed_cashbox_ids.ids:
+            self.default_cashbox_id = False

--- a/account_cashbox/views/res_users_views.xml
+++ b/account_cashbox/views/res_users_views.xml
@@ -9,6 +9,7 @@
                 <group name="pop_users_conf" string="Cajas">
                     <field name="allowed_cashbox_ids" widget="many2many_tags"/>
                     <field name="requiere_account_cashbox_session"/>
+                    <field name="default_cashbox_id"  options="{'no_create': True}"/>
                 </group>
             </group>
         </field>


### PR DESCRIPTION
This PR adds default cashbox functionality and improves error handling for payment sessions. The changes include:

- Added default_cashbox_id field to res.users model, allowing users to set a default cashbox 
- Improved payment session assignment logic to use default cashbox when multiple sessions are available
- Enhanced error message clarity for payment session requirements
- Added domain constraint and onchange handler for default_cashbox selection
- Added new field in the user view for default cashbox selection
- Updated manifest version to 18.0.1.1.0

Technical changes:
- New field 'default_cashbox_id' in res.users with domain constraint to allowed cashboxes
- Enhanced _compute_cashbox_session_id method in account.payment
- Added onchange handler for allowed_cashbox_ids to ensure default_cashbox validity 
- Updated user interface to include default cashbox selection