### PR TITLE
[IMP] account_payment_group: Propagate invoice reference to payment when using pay now journal

### DIFF
--- a/account_payment_group/models/account_move.py
+++ b/account_payment_group/models/account_move.py
@@ -143,6 +143,7 @@ class AccountMove(models.Model):
                     'journal_id': pay_journal.id,
                     'payment_method_id': payment_method.id,
                     'date': rec.invoice_date,
+                    'ref': rec.payment_reference,
                 })
                 # if validate_payment:
                 payment_group.post()


### PR DESCRIPTION
When a reference is set on the invoice and a "pay now" journal is used, 
this reference is now also assigned to the generated payment. 
This helps maintain consistency and traceability between the invoice and the related payment record.