### PR TITLE
[FIX] card_installment: add card_installment_view file

### DIFF
--- a/card_installment/__manifest__.py
+++ b/card_installment/__manifest__.py
@@ -6,7 +6,7 @@
     'author': 'ADHOC SA',
     'website': "https://www.adhoc.com.ar",
     'category': 'Technical',
-    'version': "16.0.1.0.0",
+    'version': "16.0.1.1.0",
     'depends': ['product', 'account'],
     'license': 'LGPL-3',
     'images': [
@@ -18,10 +18,10 @@
         'data/account_card.xml',
         'data/decimal_installment_coeficent.xml',
         'views/account_card.xml',
+        'views/card_installment_view.xml',
     ],
     'demo': [
         'demo/product_product.xml',
         'demo/account_card.xml',
     ],
 }
-

--- a/card_installment/views/card_installment_view.xml
+++ b/card_installment/views/card_installment_view.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <menuitem action="action_account_card" id="menu_account_card" parent="account.root_payment_menu" sequence="20" />
+    <menuitem action="action_card_installment" id="menu_account_finacial_plans" parent="account.root_payment_menu" sequence="21" />
+</odoo>


### PR DESCRIPTION
This commit fixes issue https://github.com/ingadhoc/account-payment/issues/670

The file card_installment_view.xml was created in the migration of the module to v17 (https://github.com/ingadhoc/account-payment/pull/425/commits/fa39fcbee5851ced1c81e19918e891f7450ead8a) but is not present in this version. This makes the module to depend on account_financial_surcharge to allow the users to see card menu item.