### PR TITLE
[FIX] account_payment_pro_receiptbook: Include in_process state for move name computation

### DIFF
--- a/account_payment_pro_receiptbook/models/account_move.py
+++ b/account_payment_pro_receiptbook/models/account_move.py
@@ -43,7 +43,7 @@ class AccountMove(models.Model):
     @api.depends()
     def _compute_name(self):
         super()._compute_name()
-        for move in self.filtered(lambda x: x.origin_payment_id.receiptbook_id and x.state == "draft"):
+        for move in self.filtered(lambda x: x.origin_payment_id.receiptbook_id and x.state in ["draft", "in_process"]):
             move.name = move.origin_payment_id.name
 
     @api.depends("origin_payment_id.receiptbook_id")

--- a/account_payment_pro_receiptbook/tests/test_account_paymet_pro_receiptbook_unit_test.py
+++ b/account_payment_pro_receiptbook/tests/test_account_paymet_pro_receiptbook_unit_test.py
@@ -56,3 +56,39 @@ class TestAccountPaymentProReceiptbookUnitTest(common.TransactionCase):
         payment = self.env["account.payment"].with_context(**action_context).create(vals)
         payment.action_post()
         self.assertEqual(payment.name, name, "no se tomo la secuencia correcta del pago")
+
+    # TODO revisar por qué al cambiar por shell los valores se vuelve a cambiar el nombre
+    # def test_payment_sequence_with_reset_to_draft(self):
+    #     """Test payment sequence behavior when resetting to draft and reposting."""
+    #     self.company = self.env.ref('base.company_ri')
+    #     # Step 1: Create a payment with an amount of 100 and post it
+    #     receiptbook_id = self.env["account.payment.receiptbook"].search(
+    #         [("company_id", "=", self.company.id), ("name", "=", "Customer Receipts")]
+    #     )
+    #     payment_vals = {
+    #         "journal_id": self.company_bank_journal.id,
+    #         "amount": 100,
+    #         "date": self.today,
+    #         "receiptbook_id": receiptbook_id.id
+    #     }
+    #     payment = self.env["account.payment"].create(payment_vals)
+    #     payment.action_post()
+
+    #     # Step 2: Reset the payment to draft
+    #     payment.action_draft()
+
+    #     # Step 3: Change amount
+    #     payment.write({'amount': 123})
+
+    #     # Step 4: Post the payment again
+    #     payment.action_post()
+
+    #     # Assert the payment name is updated to the next expected name in the receiptbook sequence
+    #     new_number_next_actual = receiptbook_id.with_context(ir_sequence_date=self.today).sequence_id.number_next_actual
+    #     new_expected_name = "%s %s%s" % (
+    #         receiptbook_id.document_type_id.doc_code_prefix,
+    #         receiptbook_id.prefix,
+    #         str(new_number_next_actual).zfill(receiptbook_id.sequence_id.padding),
+    #     )
+    #     self.assertEqual(payment.name, new_expected_name,
+    #                      "The payment sequence did not update to the next expected name after resetting to draft.")


### PR DESCRIPTION


-  Extend move name computation to consider both 'draft' and 'in_process' states
-  Add skeleton test case (commented) for future implementation of payment sequence reset behavior