### PR TITLE
[FIX] account_payment_pro_receiptbook: avoid changing sequence when up date payment

### DIFF
--- a/account_payment_pro_receiptbook/__init__.py
+++ b/account_payment_pro_receiptbook/__init__.py
@@ -1,5 +1,5 @@
 from . import models
-
+from . import tests
 
 def _generate_receiptbooks(env):
     """ Create receiptbooks on existing companies with chart installed"""

--- a/account_payment_pro_receiptbook/models/account_payment.py
+++ b/account_payment_pro_receiptbook/models/account_payment.py
@@ -19,7 +19,8 @@ class AccountPayment(models.Model):
     def action_post(self):
         # si no tengo nombre y tengo talonario de recibo, numeramos con el talonario
         for rec in self.filtered(
-                lambda x: x.receiptbook_id and (not x.name or x.name == '/' or not x.move_id._get_last_sequence())):
+                lambda x: x.receiptbook_id and (not x.name or x.name == '/' or (x.move_id and not x.move_id._get_last_sequence()))
+        ):
             if not rec.receiptbook_id.active:
                 raise ValidationError(_(
                     'Error! The receiptbook "%s" is archived. Please use a differente receipbook.'

--- a/account_payment_pro_receiptbook/tests/__init__.py
+++ b/account_payment_pro_receiptbook/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_account_paymet_pro_receiptbook_unit_test

--- a/account_payment_pro_receiptbook/tests/test_account_paymet_pro_receiptbook_unit_test.py
+++ b/account_payment_pro_receiptbook/tests/test_account_paymet_pro_receiptbook_unit_test.py
@@ -1,0 +1,46 @@
+import odoo.tests.common as common
+from odoo import Command, fields
+
+
+class TestAccountPaymentProReceiptbookUnitTest(common.TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.today = fields.Date.today()
+        self.company = self.env.ref('l10n_ar.company_ri')
+        self.company_bank_journal = self.env["account.journal"].search(
+            [("company_id", "=", self.company.id), ("type", "=", "bank")], limit=1
+        )
+        self.company_sale_journal = self.env["account.journal"].search(
+            [("company_id", "=", self.company.id), ("type", "=", "sale")], limit=1
+        )
+        self.receiptbook = self.env["account.payment.receiptbook"].search(
+            [("company_id", "=", self.company.id), ("name", "=", "Customer Receipts")]
+        )
+
+    def test_payment_amount_update(self):
+        """Test creating a payment, posting it, resetting to draft, updating amount, and validating name."""
+        payment = self.env["account.payment"].create({
+            "amount": 100,
+            "payment_type": "inbound",
+            "partner_id": self.env.ref("l10n_ar.res_partner_adhoc").id,
+            "journal_id": self.company_bank_journal.id,
+            "date": self.today,
+            "company_id": self.company.id,
+            "receiptbook_id": self.receiptbook.id
+        })
+
+        # Post the payment
+        payment.action_post()
+        original_name = payment.name
+
+        # Reset to draft
+        payment.action_draft()
+
+        # Update the amount
+        payment.amount = 200
+
+        # Post again
+        payment.action_post()
+
+        # Validate that the name remains the same
+        self.assertEqual(payment.name, original_name, "The payment name should remain the same after updating the amount.")


### PR DESCRIPTION
This commit:
• Fixes payment sequence condition for receipt book numbering
• Adds test case for payment amount updates while maintaining sequence