### PR TITLE
[FIX] account_payment_pro_receiptbook: Payment sequence and name computation fixes

### DIFF
--- a/account_payment_pro_receiptbook/models/account_move.py
+++ b/account_payment_pro_receiptbook/models/account_move.py
@@ -43,7 +43,10 @@ class AccountMove(models.Model):
     @api.depends()
     def _compute_name(self):
         super()._compute_name()
-        for move in self.filtered(lambda x: x.origin_payment_id.receiptbook_id and x.state in ["draft", "in_process"]):
+        for move in self.filtered(
+            lambda x: x.origin_payment_id.receiptbook_id
+            and (x.state == "draft" or x.origin_payment_id.state == "draft")
+        ):
             move.name = move.origin_payment_id.name
 
     @api.depends("origin_payment_id.receiptbook_id")

--- a/account_payment_pro_receiptbook/models/account_payment.py
+++ b/account_payment_pro_receiptbook/models/account_payment.py
@@ -31,8 +31,10 @@ class AccountPayment(models.Model):
                 raise ValidationError(
                     _("Error!. Please define sequence on the receiptbook related documents to this payment.")
                 )
-            name = rec.receiptbook_id.with_context(ir_sequence_date=rec.date).sequence_id.next_by_id()
-            rec.name = "%s %s" % (rec.receiptbook_id.document_type_id.doc_code_prefix, name)
+
+            if not rec.name or rec.name == "/":
+                name = rec.receiptbook_id.with_context(ir_sequence_date=rec.date).sequence_id.next_by_id()
+                rec.name = "%s %s" % (rec.receiptbook_id.document_type_id.doc_code_prefix, name)
 
         res = super().action_post()
         # Reincorporamos el seteo del l10n_latam_document_type_id para el caso de usar talonario de recibo


### PR DESCRIPTION
This commit:
•  Adjusts move name computation to consider payment state 
•  Fixes payment sequence condition for receipt book numbering 
•  Adds test case for payment amount updates while maintaining sequence