### PR TITLE
[IMP] account_payment_pro:  apply dynamic domain to journal_id in account_payment_invoice_wizard modelbased on partner type and company

### DIFF
--- a/account_payment_pro/__manifest__.py
+++ b/account_payment_pro/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Account Payment Super Power",
-    "version": "17.0.4.0.0",
+    "version": "17.0.5.0.0",
     "category": "Payment",
     "website": "www.adhoc.com.ar",
     "author": "ADHOC SA",

--- a/account_payment_pro/wizards/account_payment_invoice_wizard.py
+++ b/account_payment_pro/wizards/account_payment_invoice_wizard.py
@@ -26,6 +26,10 @@ class AccountPaymentInvoiceWizard(models.TransientModel):
         required=True,
         ondelete='cascade',
     )
+    available_journal_ids = fields.Many2many(
+        comodel_name='account.journal',
+        compute='_compute_available_journal_ids'
+    )
     invoice_date = fields.Date(
         string='Refund Date',
         default=fields.Date.context_today,
@@ -231,3 +235,15 @@ class AccountPaymentInvoiceWizard(models.TransientModel):
                 self.document_number)
             if self.document_number != document_number:
                 self.document_number = document_number
+
+    @api.depends('payment_id.partner_type')
+    def _compute_available_journal_ids(self):
+        journal_type = 'sale'
+        if self.payment_id.partner_type == 'supplier':
+            journal_type = 'purchase'
+        journal_domain = [
+            ('type', '=', journal_type),
+            ('company_id', '=', self.payment_id.company_id.id),
+        ]
+        self.available_journal_ids = self.env['account.journal'].search(journal_domain).ids
+

--- a/account_payment_pro/wizards/account_payment_invoice_wizard_view.xml
+++ b/account_payment_pro/wizards/account_payment_invoice_wizard_view.xml
@@ -25,10 +25,11 @@
                             <field name="description"/>
                          </group>
                          <group>
-                            <field name="journal_id"/>
+                            <field name="journal_id" domain="[('id', 'in', available_journal_ids)]"/>
                             <field name="journal_document_type_id" string="Document Type" invisible="not use_documents" required="use_documents"/>
                             <field name="document_number" invisible="not use_documents or not l10n_latam_manual_document_number" required="l10n_latam_manual_document_number and use_documents"/>
                             <field name="company_id" invisible="1"/>
+                            <field name="available_journal_ids" invisible="1"/>
                             <field name="invoice_date"/>
                             <field name="date" groups="base.group_no_one"/>
                          </group>


### PR DESCRIPTION

Previously, the journal_id field did not enforce any domain restrictions after initial selection, which could allow users to manually select journals not appropriate for the payment type.

This commit adds a dynamic domain by adding available_journal_ids field in order to restrict available journals according to the partner type (customer or supplier) and the company of the payment. The first matching journal is also preselected automatically to ease data entry.