### PR TITLE
[FIX] account_payment_pro: Allow changing journal on confirmed payments by setting quick_edit_mode

### DIFF
--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -142,7 +142,11 @@ class AccountPayment(models.Model):
                 # https://github.com/odoo/odoo/blob/b6b90636938ae961c339807ea893cabdede9f549/addons/account/models/account_move.py#L2476
                 # y permitirnos realizar la modificacion del journal.
                 if 'journal_id' in vals and rec.journal_id.id != vals['journal_id']:
-                    rec.move_id.sequence_number = 0
+                    # Lo agregamos a este cambio por el siguiente campo agregado en
+                    #  https://github.com/odoo/odoo/commit/da49c9268b3876a0482a5593379c02418e806b61
+                    # De esta forma evitamos el error de asignar un sequence_number de forma random que ademas se estaba recomputando nuevamente, 
+                    # volviendo a su valor original.
+                    rec.move_id.quick_edit_mode = True
 
                 # Lo siguiente lo agregamos para primero obligarnos a cambiar el journal_id y no la company_id. Una vez cambiado el journal_id
                 # la company_id se cambia correctamente.


### PR DESCRIPTION

Set `quick_edit_mode = True`  introducing in (https://github.com/odoo/odoo/commit/da49c9268b3876a0482a5593379c02418e806b61) when journal_id is changed on a confirmed payment and then reseted to draft.

This avoids previously hack to set sequence_number randomly reassigned, since it was being recomputed anyway and reverted to its original value leading to the odoo restriction.

This fix allows changing the journal on confirmed payments without side effects.