### PR TITLE
[FIX] account_withholding: cambio de impuesto de retención en pagos.

### DIFF
--- a/account_withholding/__manifest__.py
+++ b/account_withholding/__manifest__.py
@@ -34,5 +34,5 @@
     'installable': True,
     'name': 'Withholdings on Payments',
     'test': [],
-    'version': "16.0.3.1.0",
+    'version': "16.0.3.2.0",
 }

--- a/account_withholding/views/account_payment_view.xml
+++ b/account_withholding/views/account_payment_view.xml
@@ -8,7 +8,8 @@
             <field name="destination_journal_id" position="after">
                 <div colspan="2" attrs="{'invisible': [('payment_method_code', '!=', 'withholding')]}">
                     <group name="withholding_data">
-                        <field name="tax_withholding_id"  options="{'no_create': True, 'no_open': True}" domain="[('type_tax_use', '=', partner_type), ('company_id', '=', company_id)]" attrs="{'required': [('payment_method_code', '=', 'withholding')]}"/>
+                        <field name="line_ids" invisible="1"/>
+                        <field name="tax_withholding_id"  options="{'no_create': True, 'no_open': True}" domain="[('type_tax_use', '=', partner_type), ('company_id', '=', company_id)]" attrs="{'required': [('payment_method_code', '=', 'withholding')], 'readonly': [('line_ids', '!=', [])]}"/>
                         <field name="withholding_number"/>
                         <field name="withholding_base_amount" attrs="{'required': [('payment_method_code', '=', 'withholding')]}"/>
                     </group>


### PR DESCRIPTION
Ticket: 93448
El objetivo de este commit es que cuando se quiera cambiar el impuesto de retención en un pago el campo el impuesto de retención 'tax_withholding_id' se convierta en readonly para forzar a eliminar la línea de pago y volverla a crear, de lo contrario si permitimos cambiar el impuesto entonces no se actualiza el apunte contable de la retención con la cuenta del nuevo impuesto.