### PR TITLE
[IMP] account_payment_financial_surcharge: Reintroduce surcharge line generation on payment for draft invoices with financing plans

### DIFF
--- a/account_payment_financial_surcharge/__init__.py
+++ b/account_payment_financial_surcharge/__init__.py
@@ -1,2 +1,4 @@
 from . import models
 from . import wizards
+from .hooks import uninstall_hook
+from .monkey_patches import monkey_patches

--- a/account_payment_financial_surcharge/__manifest__.py
+++ b/account_payment_financial_surcharge/__manifest__.py
@@ -19,4 +19,6 @@
     "images": [],
     "installable": True,
     "auto_install": False,
+    "post_load": "monkey_patches",
+    "uninstall_hook": "uninstall_hook",
 }

--- a/account_payment_financial_surcharge/hooks.py
+++ b/account_payment_financial_surcharge/hooks.py
@@ -1,0 +1,13 @@
+from odoo.addons.account.models.account_move_line import AccountMoveLine
+
+
+def _revert_method(cls, name):
+    """Revert the original method called ``name`` in the given class.
+    See :meth:`~._patch_method`.
+    """
+    method = getattr(cls, name)
+    setattr(cls, name, method.origin)
+
+
+def uninstall_hook(env):
+    _revert_method(AccountMoveLine, "_check_amls_exigibility_for_reconciliation")

--- a/account_payment_financial_surcharge/models/__init__.py
+++ b/account_payment_financial_surcharge/models/__init__.py
@@ -1,2 +1,3 @@
 from . import account_payment
+from . import account_move_line
 from . import account_payment_method_line

--- a/account_payment_financial_surcharge/models/account_move_line.py
+++ b/account_payment_financial_surcharge/models/account_move_line.py
@@ -1,0 +1,11 @@
+from odoo import models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    def _check_reconciliation(self):
+        for line in self:
+            if not line.full_reconcile_id and (line.matched_debit_ids or line.matched_credit_ids):
+                self = self - line
+        super(AccountMoveLine, self)._check_reconciliation()

--- a/account_payment_financial_surcharge/monkey_patches.py
+++ b/account_payment_financial_surcharge/monkey_patches.py
@@ -1,0 +1,54 @@
+from odoo import _, api
+from odoo.addons.account.models.account_move_line import AccountMoveLine
+from odoo.exceptions import UserError
+
+
+def monkey_patches():
+    def _check_amls_exigibility_for_reconciliation(self, shadowed_aml_values=None):
+        """Ensure the current journal items are eligible to be reconciled together.
+        :param shadowed_aml_values: A mapping aml -> dictionary to replace some original aml values to something else.
+                                    This is usefull if you want to preview the reconciliation before doing some changes
+                                    on amls like changing a date or an account.
+        """
+        if not self:
+            return
+
+        if any(aml.reconciled for aml in self):
+            raise UserError(_("You are trying to reconcile some entries that are already reconciled."))
+        if any(aml.parent_state == "cancel" for aml in self):
+            raise UserError(_("You can only reconcile posted entries."))
+        accounts = self.mapped(lambda x: x._get_reconciliation_aml_field_value("account_id", shadowed_aml_values))
+        if len(accounts) > 1:
+            raise UserError(
+                _(
+                    "Entries are not from the same account: %s",
+                    ", ".join(accounts.mapped("display_name")),
+                )
+            )
+        if len(self.company_id.root_id) > 1:
+            raise UserError(
+                _(
+                    "Entries don't belong to the same company: %s",
+                    ", ".join(self.company_id.mapped("display_name")),
+                )
+            )
+        if not accounts.reconcile and accounts.account_type not in ("asset_cash", "liability_credit_card"):
+            raise UserError(
+                _(
+                    "Account %s does not allow reconciliation. First change the configuration of this account "
+                    "to allow it.",
+                    accounts.display_name,
+                )
+            )
+
+    def _patch_method(cls, name, method):
+        origin = getattr(cls, name)
+        method.origin = origin
+        # propagate decorators from origin to method, and apply api decorator
+        wrapped = api.propagate(origin, method)
+        wrapped.origin = origin
+        setattr(cls, name, wrapped)
+
+    _patch_method(
+        AccountMoveLine, "_check_amls_exigibility_for_reconciliation", _check_amls_exigibility_for_reconciliation
+    )


### PR DESCRIPTION

When paying a draft invoice using a payment method with specific financing plans, this change, reintroduces the functionality to automatically generate a surcharge invoice line in the draft invoice before validation. The invoice is then validated without generating a credit note.

This restores previously removed behavior to support surcharges directly within the invoice, improving usability and aligning with business requirements for handling financed payments.