### PR TITLE
[FIX] account_payment_pro_receiptbook: remove predefined name for sequence computation

### DIFF
--- a/account_payment_pro_receiptbook/models/__init__.py
+++ b/account_payment_pro_receiptbook/models/__init__.py
@@ -6,3 +6,4 @@ from . import account_chart_template
 from . import res_company
 from . import res_config_setting
 from . import account_journal
+from . import account_payment_register

--- a/account_payment_pro_receiptbook/models/account_payment_register.py
+++ b/account_payment_pro_receiptbook/models/account_payment_register.py
@@ -1,0 +1,11 @@
+from odoo import models
+
+
+class AccountPaymentRegister(models.TransientModel):
+    _inherit = "account.payment.register"
+
+    def _init_payments(self, to_process, edit_mode=False):
+        for rec in to_process:
+            if self.env["res.company"].browse(rec["create_vals"]["company_id"]).use_payment_pro:
+                rec["create_vals"]["name"] = "/"
+        return super()._init_payments(to_process, edit_mode=edit_mode)


### PR DESCRIPTION
This change updates the sequence computation on payments of multiple invoices selected to use the record's ID instead of the code, ensuring the method next_by_id is always triggered during action_post.