### PR TITLE
[REV] account_payment_pro_receiptbook: add unique index for receiptbook

### DIFF
--- a/account_payment_pro_receiptbook/__manifest__.py
+++ b/account_payment_pro_receiptbook/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Account Payment receiptbook",
-    "version": "18.0.1.5.0",
+    "version": "18.0.1.4.0",
     "category": "Payment",
     "website": "www.adhoc.com.ar",
     "author": "ADHOC SA",

--- a/account_payment_pro_receiptbook/models/account_move.py
+++ b/account_payment_pro_receiptbook/models/account_move.py
@@ -1,5 +1,4 @@
 from odoo import api, fields, models
-from odoo.tools import index_exists
 
 
 class AccountMove(models.Model):
@@ -83,20 +82,3 @@ class AccountMove(models.Model):
                 move.made_sequence_gap = move.sequence_number > 1 and (move.sequence_number - 1) not in previous_numbers
 
         super(AccountMove, self - with_receiptbook)._compute_made_sequence_gap()
-
-    _sql_constraints = [
-        (
-            "unique_name_receiptbook",
-            "",
-            "Another entry with the same name already exists.",
-        )
-    ]
-
-    def _auto_init(self):
-        super()._auto_init()
-        if not index_exists(self.env.cr, "account_move_unique_name_receiptbook"):
-            self.env.cr.execute("""
-                CREATE UNIQUE INDEX account_move_unique_name_receiptbook
-                                 ON account_move(name, receiptbook_id)
-                              WHERE (state = 'posted' AND name != '/')
-            """)


### PR DESCRIPTION
This commit reverts commit https://github.com/ingadhoc/account-payment/pull/681/commits/bfa2f9a50e0100c4b799e9a3aef4615efe4a148c because some databases already have duplicated move names with receiptbook