### PR TITLE
[FIX] account_payment_pro: add journal_id dependency to _compute_available_partner_bank_ids

### DIFF
--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -633,3 +633,7 @@ class AccountPayment(models.Model):
                 {"matched_payment_ids": self._get_mached_payment()}
             )
         return super().web_read(specification)
+
+    @api.depends("journal_id")
+    def _compute_available_partner_bank_ids(self):
+        super()._compute_available_partner_bank_ids()


### PR DESCRIPTION

Without this dependency, the partner_bank_id field may be computed incorrectly, picking the value from a previous record instead of updating according to the current journal_id.

This happens because _compute_partner_bank_id depends on both available_partner_bank_ids and journal_id, but _compute_available_partner_bank_ids was not triggered when journal_id changed, causing inconsistencies.