### PR TITLE
[FIX] account_payment_pro: Fix in calculation of amount_company_currency

### DIFF
--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -257,7 +257,7 @@ class AccountPayment(models.Model):
                 force_amount_company_currency = False
             rec.force_amount_company_currency = force_amount_company_currency
 
-    @api.depends("amount", "other_currency", "force_amount_company_currency", "amount_company_currency_signed")
+    @api.depends("amount", "other_currency", "force_amount_company_currency")
     def _compute_amount_company_currency(self):
         """
         * Si las monedas son iguales devuelve 1
@@ -270,7 +270,7 @@ class AccountPayment(models.Model):
             elif rec.force_amount_company_currency:
                 amount_company_currency = rec.force_amount_company_currency
             else:
-                amount_company_currency = rec.amount_company_currency_signed or rec.currency_id._convert(
+                amount_company_currency = rec.currency_id._convert(
                     rec.amount, rec.company_id.currency_id, rec.company_id, rec.date
                 )
             rec.amount_company_currency = amount_company_currency


### PR DESCRIPTION
Following Odoo core changes introduced in commit [ca388226a2bf5726f5d4c3641665595a184f709c](https://github.com/odoo/odoo/commit/ca388226a2bf5726f5d4c3641665595a184f709c), the field `amount_company_currency_signed` is now guaranteed to carry the correct sign. This affect in our computation of `amount_company_currency` by adding a sing incorrect to our field.

The method `_compute_amount_company_currency` was updated accordingly:
- Removed `amount_company_currency_signed` from the dependencies.
- Removed the conditional fallback to `amount_company_currency_signed`.

The amount is now always converted using `_convert` when needed, or taken from `force_amount_company_currency` if explicitly set.