### PR TITLE
[FIX] account_payment_pro: Fix layout issue for exchange rate and company currency amount display

### DIFF
--- a/account_payment_pro/__manifest__.py
+++ b/account_payment_pro/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Account Payment Super Power",
-    "version": "18.0.1.7.0",
+    "version": "18.0.1.8.0",
     "category": "Payment",
     "website": "www.adhoc.com.ar",
     "author": "ADHOC SA",

--- a/account_payment_pro/views/account_payment_view.xml
+++ b/account_payment_pro/views/account_payment_view.xml
@@ -58,10 +58,17 @@
             <field name="company_currency_id" invisible="True"/>
             <field name="other_currency" invisible="True"/>
             <field name="force_amount_company_currency" invisible="True"/>
-            <strong class="o_row" invisible="not other_currency" style="margin-left: 0.05px" colspan="1">Rate = <field name="exchange_rate" nolabel="1"/></strong>
-            <div name="amount_company_currency" class="o_row" invisible="not other_currency" colspan="1">
-                <field name="amount_company_currency" readonly="state != 'draft'"/>
-                <label for="amount_company_currency" string=" " invisible="not other_currency"/>
+            <div class="o_row" invisible="not other_currency">
+                <div class="o_cell" colspan="2">
+                    <strong>Rate = <field name="exchange_rate" nolabel="1"/></strong>
+                </div>
+            </div>
+
+            <div class="o_row" invisible="not other_currency">
+                <div class="o_cell" colspan="2">
+                    <field name="amount_company_currency" readonly="state != 'draft'"/>
+                    <label for="amount_company_currency" string=" "/>
+                </div>
             </div>
             <label for="write_off_amount" string="Write Off"  invisible="not write_off_available or is_internal_transfer or not use_payment_pro"/>
             <div name="write_off_amount" class="o_row" invisible="not write_off_available or is_internal_transfer or not use_payment_pro">


### PR DESCRIPTION


Moved the 'exchange_rate' field below the 'amount_company_currency' field to prevent layout overlap when 'other_currency' is true. Each field is now displayed in its own row to ensure better readability and alignment.

This change improves the user interface when dealing with foreign currency transactions by avoiding visual conflicts between related fields.