### PR TITLE
[IMP] l10n_latam_check_ux: Split payment into check transfer

### DIFF
--- a/l10n_latam_check_ux/__manifest__.py
+++ b/l10n_latam_check_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Latam Check UX",
-    "version": "18.0.1.8.0",
+    "version": "18.0.2.0.0",
     "category": "Accounting",
     "sequence": 14,
     "summary": "",
@@ -38,6 +38,7 @@
         "views/l10n_latam_check_view.xml",
         "views/account_journal_view.xml",
         "views/report_payment_receipt_templates.xml",
+        "wizards/l10n_latam_payment_mass_transfer.xml",
         "reports/report_account_transfer.xml",
         "security/ir.model.access.csv",
     ],

--- a/l10n_latam_check_ux/wizards/l10n_latam_payment_mass_transfer.py
+++ b/l10n_latam_check_ux/wizards/l10n_latam_payment_mass_transfer.py
@@ -1,4 +1,4 @@
-from odoo import _, api, fields, models
+from odoo import Command, _, api, fields, models
 from odoo.exceptions import ValidationError
 
 
@@ -16,6 +16,7 @@ class L10nLatamPaymentMassTransfer(models.TransientModel):
     check_ids = fields.Many2many(
         check_company=False,
     )
+    split_payment = fields.Boolean()
 
     @api.depends("company_id")
     def _compute_main_company(self):
@@ -27,6 +28,9 @@ class L10nLatamPaymentMassTransfer(models.TransientModel):
             raise ValidationError(
                 _("In order to transfer checks between branches you need to use internal transfer menu.")
             )
+        if self.split_payment:
+            return self._create_split_payments()
+
         # Ensure that third-party check deposits made through the Odoo wizard
         # behave the same way as an internal transfer.
         outbound_payment = super(
@@ -53,6 +57,86 @@ class L10nLatamPaymentMassTransfer(models.TransientModel):
         inbound_payment.destination_journal_id = self.journal_id
 
         return outbound_payment
+
+    def _create_split_payments(self):
+        """This is nedeed because we would like to create a payment of type internal transfer for each check with the
+        counterpart journal and then, when posting a second payment will be created automatically"""
+        self.ensure_one()
+        checks = self.check_ids.filtered(
+            lambda x: x.payment_method_line_id.code == "new_third_party_checks"
+            and x.currency_id == self.check_ids[0].currency_id
+        )
+        currency_id = self.check_ids[0].currency_id
+
+        pay_method_line = self.journal_id._get_available_payment_method_lines("outbound").filtered(
+            lambda x: x.code in ("out_third_party_checks", "return_third_party_checks")
+        )[:1]
+        outbound_payments = self.env["account.payment"]
+        for check in checks:
+            outbound_payment = (
+                self.env["account.payment"]
+                .with_context(check_deposit_transfer=True)
+                .create(
+                    {
+                        "date": self.payment_date,
+                        "amount": check.amount,
+                        "partner_id": self.env.company.partner_id.id,
+                        "payment_type": "outbound",
+                        "memo": self.communication,
+                        "journal_id": self.journal_id.id,
+                        "currency_id": currency_id.id,
+                        "is_internal_transfer": True,
+                        "payment_method_line_id": pay_method_line.id if pay_method_line else False,
+                        "destination_journal_id": self.destination_journal_id.id,
+                        "l10n_latam_move_check_ids": [Command.link(check.id)],
+                    }
+                )
+            )
+            outbound_payment.action_post()
+            inbound_payment = (
+                self.env["account.payment"]
+                .with_context(check_deposit_transfer=True)
+                .create(
+                    {
+                        "date": self.payment_date,
+                        "amount": check.amount,
+                        "partner_id": self.env.company.partner_id.id,
+                        "payment_type": "inbound",
+                        "memo": self.communication,
+                        "journal_id": self.destination_journal_id.id,
+                        "currency_id": currency_id.id,
+                        "is_internal_transfer": True,
+                        "destination_journal_id": self.journal_id.id,
+                        "paired_internal_transfer_payment_id": outbound_payment.id,
+                        "l10n_latam_move_check_ids": [Command.link(check.id)],
+                    }
+                )
+            )
+
+            dest_payment_method = self.destination_journal_id.inbound_payment_method_line_ids.filtered(
+                lambda x: x.code == "in_third_party_checks"
+            )
+            outbound_payment.paired_internal_transfer_payment_id = inbound_payment.id
+            if dest_payment_method:
+                inbound_payment.payment_method_line_id = dest_payment_method
+                inbound_payment.action_post()
+            else:
+                # In case the journal is not part of the third party check, when posting the move we remove the checks
+                # when the payment method line is not for checks, but in this case, we don't want to remove it so that
+                # the operation_ids is filled with the two payments
+                inbound_payment.with_context(l10n_ar_skip_remove_check=True).action_post()
+
+            body_inbound = _("This payment has been created from: ") + outbound_payment._get_html_link()
+            inbound_payment.message_post(body=body_inbound)
+            body_outbound = _("A second payment has been created: ") + inbound_payment._get_html_link()
+            outbound_payment.message_post(body=body_outbound)
+
+            (outbound_payment.move_id.line_ids + inbound_payment.move_id.line_ids).filtered(
+                lambda l: l.account_id == outbound_payment.destination_account_id and not l.reconciled
+            ).reconcile()
+
+            outbound_payments |= outbound_payment
+        return outbound_payments
 
     @api.constrains("check_ids")
     def _check_company_matches_active_company(self):

--- a/l10n_latam_check_ux/wizards/l10n_latam_payment_mass_transfer.xml
+++ b/l10n_latam_check_ux/wizards/l10n_latam_payment_mass_transfer.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_l10n_latam_payment_mass_transfer_form" model="ir.ui.view">
+        <field name="name">l10n_latam.payment.mass.transfer.form</field>
+        <field name="model">l10n_latam.payment.mass.transfer</field>
+        <field name="inherit_id" ref="l10n_latam_check.view_l10n_latam_payment_mass_transfer_form"></field>
+        <field name="arch" type="xml">
+            <field name="destination_journal_id" position="after">
+                <field name="split_payment"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Traceability in the General Ledger
It's essential to be able to identify which specific checks were deposited in each operation within the check account's general ledger. With the current grouping method, this information is lost.

Operational Control and Reconciliation
In situations involving errors, rejections, or claims, it's necessary to have clear traceability for each check from the moment it's received until it's deposited. Splitting the payments allows for this tracking directly from the accounting records, eliminating the need to rely on external information or indirect tracing methods.

Facilitates Internal and External Audits
Having a separate entry for each check simplifies the accounting review process. It allows for a direct cross-reference between the movements recorded in the check account and the physical or digitized documents.

Consistency with the Entry Record
When a check is received (collected), it is recorded individually in the check account. By maintaining this same level of detail at the time of deposit, we ensure consistency across all movements.