### PR TITLE
[FIX] l10n_latam_check_ux: Prevent resetting check operation if not the latest

### DIFF
--- a/l10n_latam_check_ux/models/account_payment.py
+++ b/l10n_latam_check_ux/models/account_payment.py
@@ -62,3 +62,13 @@ class AccountPayment(models.Model):
                     )._create_paired_internal_transfer_payment()
                 rec._get_latam_checks()._compute_company_id()
             super(AccountPayment, self - third_party_checks)._create_paired_internal_transfer_payment()
+
+    def action_draft(self):
+        for check in self.mapped("l10n_latam_move_check_ids") + self.mapped("l10n_latam_new_check_ids"):
+            last_operation = check._get_last_operation()
+            if self != last_operation:
+                raise ValidationError(
+                    "You cannot reset this operation to draft because it is not the last operation for the checks."
+                )
+
+        super().action_draft()

--- a/l10n_latam_check_ux/wizards/l10n_latam_payment_mass_transfer.py
+++ b/l10n_latam_check_ux/wizards/l10n_latam_payment_mass_transfer.py
@@ -18,7 +18,9 @@ class L10nLatamPaymentMassTransfer(models.TransientModel):
     check_ids = fields.Many2many(
         check_company=False,
     )
-    split_payment = fields.Boolean()
+    split_payment = fields.Boolean(
+        help="If this option is selected, each check will be registered as an individual payment instead of being grouped into a single payment."
+    )
 
     @api.depends("company_id")
     def _compute_main_company(self):


### PR DESCRIPTION

Add a validation in `action_draft` to prevent a check-related move from being reset to draft if it is not the last operation linked to the check.
This ensures data consistency and prevents altering the state of earlier operations in the check lifecycle.