### PR TITLE
[FIX] account_financial_surcharge: use rec reference instead of self

### DIFF
--- a/account_payment_financial_surcharge/models/account_payment.py
+++ b/account_payment_financial_surcharge/models/account_payment.py
@@ -103,7 +103,7 @@ class AccountPayment(models.Model):
                             "journal_id": journal.id,
                             "product_id": product.id,
                             "tax_ids": [(6, 0, taxes.ids)],
-                            "amount_total": self.financing_surcharge,
+                            "amount_total": rec.financing_surcharge,
                         }
                     )
                 )


### PR DESCRIPTION
Change self.financing_surcharge to rec.financing_surcharge to properly reference the current record in iteration context