### PR TITLE
[IMP] account_payment_financial_surcharge: Reintroduce surcharge line…

### DIFF
--- a/account_payment_financial_surcharge/models/account_payment.py
+++ b/account_payment_financial_surcharge/models/account_payment.py
@@ -157,7 +157,7 @@ class AccountPayment(models.Model):
             "tax_ids": [(6, 0, taxes.ids)],
         }
         if amount is not None:
-            vals["amount"] = amount
+            vals["amount_total"] = amount
         if price_unit is not None:
             vals["price_unit"] = price_unit
         return vals


### PR DESCRIPTION
… generation on payment for draft invoices with financing plans

When paying a draft invoice using a payment method with specific financing plans, this change, reintroduces the functionality to automatically generate a surcharge invoice line in the draft invoice before validation. The invoice is then validated without generating a credit note.

This restores previously removed behavior to support surcharges directly within the invoice, improving usability and aligning with business requirements for handling financed payments.

closes ingadhoc/account-payment#689