### PR TITLE
[FIX] account_payment_pro_receiptbook: Prevent missing auto-increment of receiptbook sequence when creating payments via transaction

### DIFF
--- a/account_payment_pro_receiptbook/models/account_payment.py
+++ b/account_payment_pro_receiptbook/models/account_payment.py
@@ -65,3 +65,9 @@ class AccountPayment(models.Model):
                     limit=1,
                 )
                 rec.receiptbook_id = receiptbook
+
+    @api.depends()
+    def _compute_name(self):
+        super(
+            AccountPayment, self.filtered(lambda x: not x.move_id or x.move_id.state != "draft" or not x.receiptbook_id)
+        )._compute_name()


### PR DESCRIPTION

When creating a payment from a payment transaction, the receiptbook sequence was not auto-incremented.

This issue occurred because _post_process calls _create_payment, which sets 'write_off_line_vals': [] and then calls AccountPayment.create. Since 'write_off_line_vals' is an empty list, write_off_line_vals_list[i] is not None evaluates as True, triggering _generate_journal_entry.

_generate_journal_entry creates the move and executes:

pay.write({'move_id': move.id, 'state': 'in_process'})

As a result, the payment state changes from draft to in_process, which computes the payment name. Because the payment already has a name, the condition:

for rec in self.filtered(
    lambda x: x.receiptbook_id
    and (not x.name or x.name == "/" or (x.move_id and not x.move_id._get_last_sequence()))
):

is skipped, so the receiptbook sequence is never incremented.