### PR TITLE
[FIX] account_payment_group: fix exchange difference when currency set on payable account

### DIFF
--- a/account_payment_group/models/account_payment_group.py
+++ b/account_payment_group/models/account_payment_group.py
@@ -440,7 +440,13 @@ class AccountPaymentGroup(models.Model):
 
         # En ciertos casos por redondeo genera el asiento aunque tenga activo el reconcile on company currency.
         # Este contexto evita esos casos
-        if self.company_id.reconcile_on_company_currency:
+        if (
+                self.company_id.reconcile_on_company_currency
+                and not (
+                    self.partner_id.property_account_payable_id.currency_id
+                    or self.partner_id.property_account_receivable_id.currency_id
+                )
+            ):
             self = self.with_context(no_exchange_difference=True)
 
         created_automatically = self._context.get('created_automatically')


### PR DESCRIPTION
This pull request makes a targeted fix to the payment posting logic in `account_payment_group.py`. The change ensures that the context flag to avoid exchange difference entries is only set when the partner's payable account does not have a specific currency configured, preventing incorrect behavior in multi-currency scenarios.

Payment posting logic fix:

* Updated the condition in the `post` method to only set the `no_exchange_difference` context when the company has `reconcile_on_company_currency` enabled and the partner’s payable account lacks a currency, improving accuracy for multi-currency partners.