### PR TITLE
[FIX] account_payment_loan: hide "Register Loan" button when no residual amount is pending

### DIFF
--- a/account_payment_loan/__manifest__.py
+++ b/account_payment_loan/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Account Payment Personal Loan",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.1.0",
     "category": "Accounting",
     "sequence": 14,
     "summary": "",

--- a/account_payment_loan/views/account_move_views.xml
+++ b/account_payment_loan/views/account_move_views.xml
@@ -9,7 +9,7 @@
             <button name="button_draft" position="after">
                 <button
                     name="action_register_loan"
-                    invisible="state not in ['draft', 'posted'] or move_type not in ('out_invoice', 'out_refund')"
+                    invisible="state not in ['draft', 'posted'] or move_type not in ('out_invoice', 'out_refund') or amount_residual &lt;= 0"
                     string="Register Loan"
                     type="object"
                 />


### PR DESCRIPTION

- Added condition in the view so that the "Register Loan" button is not displayed when amount_residual <= 0.
- The existing restrictions for states other than draft/posted and for move types different from out_invoice/out_refund are preserved.
- Improves usability by preventing the button from being shown on moves without any pending residual amount.