### PR TITLE
[FIX] account_cashbox: compute amount in company currency if needed

### DIFF
--- a/account_cashbox/models/account_cashbox_session_line.py
+++ b/account_cashbox/models/account_cashbox_session_line.py
@@ -38,11 +38,15 @@ class PopSessionJournalControl(models.Model):
             [("cashbox_session_id", "in", self.mapped("cashbox_session_id").ids), ("state", "!=", "draft")]
         )
         for record in self:
-            amount = sum(
-                payments_lines.filtered(
-                    lambda p: p.cashbox_session_id == record.cashbox_session_id and p.journal_id == record.journal_id
-                ).mapped("amount_signed")
+            lines = payments_lines.filtered(
+                lambda p: p.cashbox_session_id == record.cashbox_session_id and p.journal_id == record.journal_id
             )
+
+            if record.journal_id.currency_id:
+                amount = sum(lines.mapped("amount_signed"))
+            else:
+                amount = sum(lines.mapped("amount_company_currency_signed"))
+
             record.amount = amount
             record.balance_end = amount + record.balance_start
             self -= record


### PR DESCRIPTION
When the journal of a cashbox session line has a different currency than the company, the amount should be computed in company currency.