### PR TITLE
[FIX] account_payment_pro: protect of wrong context active_ids

### DIFF
--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -595,7 +595,8 @@ class AccountPayment(models.Model):
                 "asset_receivable" if self.partner_type == "customer" else "liability_payable",
             ),
         ]
-        if self.env.context.get("active_ids"):
+        # TODO revisar bien estos, no debería ser necesario, ver el blame porque se agrego lo del active_ids
+        if self.env.context.get("active_ids") and self.env.context.get("active_model") == "account.move.line":
             domain.append(("move_id.line_ids", "in", self.env.context.get("active_ids")))
         return domain
 


### PR DESCRIPTION
Antes del fix, si en active_ids viene otra cosa que no sea account.move.line va a fallar