### PR TITLE
[FIX] l10n_latam_check_ux: include return_third_party_checks in payment method filter

### DIFF
--- a/l10n_latam_check_ux/models/account_payment.py
+++ b/l10n_latam_check_ux/models/account_payment.py
@@ -38,7 +38,8 @@ class AccountPayment(models.Model):
         # Who already create both payments at once in the _create_payments method.)
         if not self.env.context.get("check_deposit_transfer"):
             third_party_checks = self.filtered(
-                lambda x: x.payment_method_line_id.code in ["in_third_party_checks", "out_third_party_checks"]
+                lambda x: x.payment_method_line_id.code
+                in ["in_third_party_checks", "out_third_party_checks", "return_third_party_checks"]
             )
             for rec in third_party_checks:
                 dest_payment_method_code = (


### PR DESCRIPTION

Include return_third_party_checks in the payment method filter so that when a check is moved to a "third-party check return/rejection" operation, the correct payment method is assigned and the operation remains properly linked. This change ensures consistent behavior with Odoo’s built-in wizard.