### PR TITLE
[FIX] account_payment_pro: avoid negative default amount in payment

### DIFF
--- a/account_payment_pro/models/account_move_line.py
+++ b/account_payment_pro/models/account_move_line.py
@@ -71,7 +71,7 @@ class AccountMoveLine(models.Model):
                 "default_payment_type": payment_type,
                 "default_partner_type": partner_type,
                 "default_partner_id": to_pay_partner_id,
-                "default_amount": to_pay_amount,
+                "default_amount": abs(to_pay_amount),
                 "default_to_pay_move_line_ids": to_pay_move_lines.ids,
                 # We set this because if became from other view and in the context has 'create=False'
                 # you can't crate payment lines (for ej: subscription)


### PR DESCRIPTION
When creating a payment from an invoice with a negative residual amount, the default amount was being set to a negative value. This commit ensures that the default amount is never negative, setting it to positive if the calculated amount is negative.