### PR TITLE
[IMP] l10n_ar_payment_bundle: remove chart template restriction

### DIFF
--- a/l10n_ar_payment_bundle/__init__.py
+++ b/l10n_ar_payment_bundle/__init__.py
@@ -3,10 +3,8 @@ from . import models
 
 def post_init_hook(env):
     """Existing companies that have the Argentinean Chart of Accounts set"""
-    template_codes = ["ar_ri", "ar_ex", "ar_base"]
-    ar_companies = env["res.company"].search([("chart_template", "in", template_codes), ("parent_id", "=", False)])
+    ar_companies = env["res.company"].search([("parent_id", "=", False)]).filtered(lambda x: x.country_code == "AR")
     for company in ar_companies:
-        template_code = company.chart_template
         ChartTemplate = env["account.chart.template"].with_company(company)
-        if journals_to_create := ChartTemplate._get_payment_bundle_account_journal(template_code):
+        if journals_to_create := ChartTemplate._get_payment_bundle_account_journal(company.chart_template):
             ChartTemplate._load_data({"account.journal": journals_to_create})

--- a/l10n_ar_payment_bundle/models/account_chart_template.py
+++ b/l10n_ar_payment_bundle/models/account_chart_template.py
@@ -6,8 +6,8 @@ class AccountChartTemplate(models.AbstractModel):
     _inherit = "account.chart.template"
 
     @template(model="account.journal")
-    def _get_payment_bundle_account_journal(self, template_code):
-        if self.env.company.country_code == "AR" and template_code in ["ar_ri", "ar_ex", "ar_base"]:
+    def _get_payment_bundle_account_journal(self, chart_template):
+        if self.env.company.country_code == "AR":
             return {
                 "payment_bundle_journal": {
                     "name": _("Multiple payments"),
@@ -32,3 +32,5 @@ class AccountChartTemplate(models.AbstractModel):
                     ],
                 },
             }
+        else:
+            return False


### PR DESCRIPTION
This commit removes the restriction on the chart template when creating payment bundles for Argentinean companies. Now, any company with the country code "AR" will create a payment bundle journal, regardless of their chart template. This avoids issues when companies used custom chart templates based on the Argentinean one in previous versions, because in v18+ the custom templates don't apply.