### PR TITLE
[FIX] account_cashbox_latam_check: fix compute cashbox session

### DIFF
--- a/account_cashbox_l10n_latam_check/wizards/l10n_latam_payment_mass_transfer.py
+++ b/account_cashbox_l10n_latam_check/wizards/l10n_latam_payment_mass_transfer.py
@@ -8,9 +8,8 @@ class L10nLatamPaymentMassTransfer(models.TransientModel):
     cashbox_session_id = fields.Many2one(
         "account.cashbox.session",
         string="POP Session",
-        compute="_compute_cashbox_session_id",
         readonly=False,
-        store=True,
+        compute="_compute_cashbox_session_id",
     )
     requiere_account_cashbox_session = fields.Boolean(
         compute="_compute_requiere_account_cashbox_session",
@@ -24,6 +23,7 @@ class L10nLatamPaymentMassTransfer(models.TransientModel):
     def _compute_requiere_account_cashbox_session(self):
         self.requiere_account_cashbox_session = self.env.user.requiere_account_cashbox_session
 
+    @api.depends("destination_journal_id")
     def _compute_cashbox_session_id(self):
         for rec in self:
             session_ids = self.env["account.cashbox.session"].search(


### PR DESCRIPTION
- Remove the stored from session_id field to avoid issues when recomputing the cashbox session.
- Adds a dependency to the compute method to ensure it is recomputed when the destination journal is changed.