### PR TITLE
[FIX] l10n_ar_payment_bundle: bypass check sequence by date

### DIFF
--- a/l10n_ar_payment_bundle/models/__init__.py
+++ b/l10n_ar_payment_bundle/models/__init__.py
@@ -1,5 +1,8 @@
-from . import res_company
-from . import account_chart_template
-from . import account_payment
-from . import account_payment_method
-from . import account_journal
+from . import (
+    account_chart_template,
+    account_journal,
+    account_move,
+    account_payment,
+    account_payment_method,
+    res_company,
+)

--- a/l10n_ar_payment_bundle/models/account_move.py
+++ b/l10n_ar_payment_bundle/models/account_move.py
@@ -1,0 +1,12 @@
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def _must_check_constrains_date_sequence(self):
+        # OVERRIDES sequence.mixin
+        self.ensure_one()
+        if self.receiptbook_id:
+            return False
+        return super()._must_check_constrains_date_sequence()


### PR DESCRIPTION
When creating account moves from payments linked to receipt books, the date sequence constraint must be bypassed.
This solves the issue of creating more than 9 linked payments in a bundle payment.