### PR TITLE
[FIX] account_payment_pro_receiptbook: bypass check sequence by date

### DIFF
--- a/account_payment_pro_receiptbook/models/account_move.py
+++ b/account_payment_pro_receiptbook/models/account_move.py
@@ -72,8 +72,16 @@ class AccountMove(models.Model):
                     [
                         ("receiptbook_id", "=", receiptbook.id),
                         ("sequence_prefix", "=", prefix),
-                        ("sequence_number", ">=", min(moves.mapped("sequence_number")) - 1),
-                        ("sequence_number", "<=", max(moves.mapped("sequence_number")) - 1),
+                        (
+                            "sequence_number",
+                            ">=",
+                            min(moves.mapped("sequence_number")) - 1,
+                        ),
+                        (
+                            "sequence_number",
+                            "<=",
+                            max(moves.mapped("sequence_number")) - 1,
+                        ),
                     ]
                 )
                 .mapped("sequence_number")
@@ -82,3 +90,10 @@ class AccountMove(models.Model):
                 move.made_sequence_gap = move.sequence_number > 1 and (move.sequence_number - 1) not in previous_numbers
 
         super(AccountMove, self - with_receiptbook)._compute_made_sequence_gap()
+
+    def _must_check_constrains_date_sequence(self):
+        # OVERRIDES sequence.mixin to skip date sequence check for receiptbook moves
+        self.ensure_one()
+        if self.receiptbook_id:
+            return False
+        return super()._must_check_constrains_date_sequence()


### PR DESCRIPTION
When creating account moves from payments linked to receipt books, the date sequence constraint must be bypassed. This solves the issue of creating more than 9  payments with the same name and (1,2, 3, ..., 10) sequence numbers.