### PR TITLE
[FIX] l10n_latam_check: prevent recompute when bank_id/issuer_vat set explicitly

### DIFF
--- a/l10n_latam_check_ux/models/l10n_latam_check.py
+++ b/l10n_latam_check_ux/models/l10n_latam_check.py
@@ -65,3 +65,17 @@ class l10nLatamAccountPaymentCheck(models.Model):
             .filtered(lambda x: x.state not in ["draft", "canceled"] and x.l10n_latam_move_check_ids_operation_date)
             .sorted(key=lambda payment: (payment.l10n_latam_move_check_ids_operation_date))[-1:]
         )
+
+    @api.depends("payment_method_line_id.code", "payment_id.partner_id")
+    def _compute_bank_id(self):
+        payment_method_change = self._origin.payment_method_line_id != self.payment_method_line_id
+        partner_id_change = self._origin.payment_id.partner_id != self.payment_id.partner_id
+        if payment_method_change or partner_id_change:
+            super()._compute_bank_id()
+
+    @api.depends("payment_method_line_id.code", "payment_id.partner_id")
+    def _compute_issuer_vat(self):
+        payment_method_change = self._origin.payment_method_line_id != self.payment_method_line_id
+        partner_id_change = self._origin.payment_id.partner_id != self.payment_id.partner_id
+        if payment_method_change or partner_id_change:
+            super()._compute_issuer_vat()


### PR DESCRIPTION
¡

When writing payment_method_line_id together with bank_id or issuer_vat in the same operation, the computed fields were being recalculated and overwriting the explicitly provided values.

This occurred because compute methods are triggered after write/create operations when their dependencies change. If payment_method_line_id was modified along with bank_id or issuer_vat, the compute would run unconditionally and replace the user-provided values with computed ones from the partner.

Solution: Override _compute_bank_id and _compute_issuer_vat to only execute the compute logic when the triggering dependencies (payment method or partner) actually changed, not on every write operation. This allows explicit values to be preserved when set simultaneously with payment_method_line_id changes.