### PR TITLE
[IMP] account_cashbox: improve internal transfer payments 

### DIFF
--- a/account_cashbox/models/account_cashbox_session.py
+++ b/account_cashbox/models/account_cashbox_session.py
@@ -25,6 +25,12 @@ class AccountCashboxSession(models.Model):
     user_ids = fields.Many2many(
         "res.users", required=True, readonly=False, tracking=True, compute="_compute_user_ids", store=True
     )
+    allowed_res_users_ids = fields.Many2many(
+        "res.users",
+        related="cashbox_id.allowed_res_users_ids",
+        readonly=True,
+        store=False,
+    )
     opening_date = fields.Datetime(readonly=True, copy=False)
     closing_date = fields.Datetime(readonly=True, copy=False)
     state = fields.Selection(
@@ -89,6 +95,14 @@ class AccountCashboxSession(models.Model):
                 )
                 for journal in rec.cashbox_id.journal_ids
             ]
+
+            @api.constrains("user_ids", "cashbox_id")
+            def _check_user_ids_allowed(self):
+                for rec in self:
+                    if rec.cashbox_id.restrict_users and rec.user_ids:
+                        allowed = set(rec.cashbox_id.allowed_res_users_ids.ids)
+                        if not set(rec.user_ids.ids).issubset(allowed):
+                            raise ValidationError(_("All session users must be allowed on the cashbox."))
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/account_cashbox/models/account_payment.py
+++ b/account_cashbox/models/account_payment.py
@@ -25,8 +25,27 @@ class AccountPayment(models.Model):
         "account.cashbox.session",
         string="Destination POP Session",
         help="In case of internal transfer payments, this field indicates the destination POP session.",
-        domain="[('state', '=', 'opened'), '|', ('user_ids', '=', uid), ('user_ids', '=', False)]",
+        domain="[('state', '=', 'opened'), ('cashbox_id.journal_ids', '=', destination_journal_id), '|', ('user_ids', '=', uid), ('user_ids', '=', False)]",
     )
+
+    @api.onchange("destination_journal_id")
+    def _onchange_destination_journal_id(self):
+        """Clear destination_cashbox_session_id when destination journal changes
+        and no open sessions exist for the new journal"""
+        if self.destination_journal_id:
+            # Check if the current session is still valid for the new journal
+            if self.destination_cashbox_session_id:
+                valid_session = self.env["account.cashbox.session"].search_count(
+                    [
+                        ("id", "=", self.destination_cashbox_session_id.id),
+                        ("state", "=", "opened"),
+                        ("cashbox_id.journal_ids", "=", self.destination_journal_id.id),
+                    ]
+                )
+                if not valid_session:
+                    self.destination_cashbox_session_id = False
+        else:
+            self.destination_cashbox_session_id = False
 
     @api.depends_context("uid")
     # dummy depends para que se compute(no estamos seguros porque solo con el depends_context no computa)

--- a/account_cashbox/models/account_payment.py
+++ b/account_cashbox/models/account_payment.py
@@ -21,6 +21,13 @@ class AccountPayment(models.Model):
         compute_sudo=False,
     )
 
+    destination_cashbox_session_id = fields.Many2one(
+        "account.cashbox.session",
+        string="Destination POP Session",
+        help="In case of internal transfer payments, this field indicates the destination POP session.",
+        domain="[('state', '=', 'opened'), '|', ('user_ids', '=', uid), ('user_ids', '=', False)]",
+    )
+
     @api.depends_context("uid")
     # dummy depends para que se compute(no estamos seguros porque solo con el depends_context no computa)
     @api.depends("partner_id")
@@ -51,7 +58,16 @@ class AccountPayment(models.Model):
                 raise ValidationError(_("The currency of the journal must be the of the payment."))
 
     def _create_paired_internal_transfer_payment(self):
-        super(AccountPayment, self.with_context(paired_transfer=True))._create_paired_internal_transfer_payment()
+        for payment in self:
+            super(
+                AccountPayment,
+                payment.with_context(
+                    paired_transfer=True,
+                    default_cashbox_session_id=payment.destination_cashbox_session_id,
+                ),
+            )._create_paired_internal_transfer_payment()
+            if payment.paired_internal_transfer_payment_id:
+                payment.paired_internal_transfer_payment_id.destination_cashbox_session_id = False
 
     def action_post(self):
         for rec in self:

--- a/account_cashbox/tests/__init__.py
+++ b/account_cashbox/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_internal_transfer_cashbox_session

--- a/account_cashbox/tests/test_internal_transfer_cashbox_session.py
+++ b/account_cashbox/tests/test_internal_transfer_cashbox_session.py
@@ -1,0 +1,240 @@
+from odoo import Command, fields
+from odoo.tests import common, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestInternalTransferCashboxSession(common.TransactionCase):
+    """Tests para validar transferencias internas con sesiones de caja"""
+
+    def setUp(self):
+        super().setUp()
+        self.company = self.env.company
+
+        # Buscar journals existentes con outstanding account configurado
+        journals = self.env["account.journal"].search(
+            [
+                ("company_id", "=", self.company.id),
+                ("type", "in", ["bank", "cash"]),
+                ("default_account_id", "!=", False),
+            ],
+            limit=2,
+        )
+
+        if len(journals) < 2:
+            # Si no hay journals con outstanding account, buscar cualquiera y configurarlo
+            journals = self.env["account.journal"].search(
+                [("company_id", "=", self.company.id), ("type", "in", ["bank", "cash"])], limit=2
+            )
+
+            if len(journals) < 2:
+                self.skipTest("Se requieren al menos 2 journals de tipo bank/cash para ejecutar este test")
+
+            # Configurar outstanding account si no existe
+            for journal in journals:
+                if not journal.default_account_id:
+                    # Buscar o crear una cuenta de outstanding
+                    outstanding_account = self.env["account.account"].search(
+                        [
+                            ("company_id", "=", self.company.id),
+                            ("account_type", "=", "asset_current"),
+                            ("reconcile", "=", True),
+                        ],
+                        limit=1,
+                    )
+                    if outstanding_account:
+                        journal.default_account_id = outstanding_account
+
+        self.source_journal = journals[0]
+        self.destination_journal = journals[1]
+
+        # Configurar payment method lines con payment_account_id
+        for journal in [self.source_journal, self.destination_journal]:
+            for line in journal.inbound_payment_method_line_ids | journal.outbound_payment_method_line_ids:
+                if not line.payment_account_id and journal.default_account_id:
+                    line.payment_account_id = journal.default_account_id
+
+        # Crear cashboxes (cajas) para las sesiones con allow_concurrent_sessions
+        self.source_cashbox = self.env["account.cashbox"].create(
+            {
+                "name": "Source Cashbox",
+                "company_id": self.company.id,
+                "journal_ids": [Command.link(self.source_journal.id)],
+                "allow_concurrent_sessions": True,
+            }
+        )
+
+        self.destination_cashbox = self.env["account.cashbox"].create(
+            {
+                "name": "Destination Cashbox",
+                "company_id": self.company.id,
+                "journal_ids": [Command.link(self.destination_journal.id)],
+                "allow_concurrent_sessions": True,
+            }
+        )
+
+        # Crear y abrir sesiones de caja
+        self.source_session = self.env["account.cashbox.session"].create(
+            {
+                "cashbox_id": self.source_cashbox.id,
+                "name": "Source Session 001",
+            }
+        )
+        self.source_session.action_account_cashbox_session_open()
+
+        self.destination_session = self.env["account.cashbox.session"].create(
+            {
+                "cashbox_id": self.destination_cashbox.id,
+                "name": "Destination Session 001",
+            }
+        )
+        self.destination_session.action_account_cashbox_session_open()
+
+    def test_internal_transfer_sets_destination_cashbox_session(self):
+        """Verifica que al crear una transferencia interna con destination_cashbox_session_id,
+        el pago pareado obtiene la sesión de caja destino correcta"""
+
+        # Crear un pago de transferencia interna con sesión de caja origen y destino
+        payment = self.env["account.payment"].create(
+            {
+                "journal_id": self.source_journal.id,
+                "destination_journal_id": self.destination_journal.id,
+                "amount": 1000.0,
+                "date": fields.Date.today(),
+                "cashbox_session_id": self.source_session.id,
+                "destination_cashbox_session_id": self.destination_session.id,
+                "is_internal_transfer": True,
+            }
+        )
+
+        # Postear el pago (esto debería crear el pago pareado)
+        payment.action_post()
+
+        # Verificar que existe el pago pareado
+        self.assertTrue(
+            payment.paired_internal_transfer_payment_id, "El pago pareado de transferencia interna no fue creado"
+        )
+
+        # Verificar que el pago pareado tiene la sesión de caja destino
+        paired_payment = payment.paired_internal_transfer_payment_id
+        self.assertEqual(
+            paired_payment.cashbox_session_id,
+            self.destination_session,
+            "El pago pareado no tiene la sesión de caja destino correcta",
+        )
+
+        # Verificar que el campo destination_cashbox_session_id del pago pareado es False
+        self.assertFalse(
+            paired_payment.destination_cashbox_session_id,
+            "El destination_cashbox_session_id del pago pareado debería ser False",
+        )
+
+    def test_internal_transfer_without_destination_session(self):
+        """Verifica que cuando no se especifica destination_cashbox_session_id,
+        el pago pareado se crea sin sesión de caja"""
+
+        # Crear un pago de transferencia interna sin destination_cashbox_session_id
+        payment = self.env["account.payment"].create(
+            {
+                "journal_id": self.source_journal.id,
+                "destination_journal_id": self.destination_journal.id,
+                "amount": 500.0,
+                "date": fields.Date.today(),
+                "cashbox_session_id": self.source_session.id,
+                "is_internal_transfer": True,
+            }
+        )
+
+        # Postear el pago
+        payment.action_post()
+
+        # Verificar que existe el pago pareado
+        self.assertTrue(
+            payment.paired_internal_transfer_payment_id, "El pago pareado de transferencia interna no fue creado"
+        )
+
+        # Verificar que el pago pareado no tiene sesión de caja
+        paired_payment = payment.paired_internal_transfer_payment_id
+        self.assertFalse(
+            paired_payment.cashbox_session_id,
+            "El pago pareado no debería tener sesión de caja cuando no se especifica destination_cashbox_session_id",
+        )
+
+    def test_multiple_internal_transfers_with_sessions(self):
+        """Verifica que múltiples transferencias internas con sesiones de caja
+        funcionan correctamente"""
+
+        payments = self.env["account.payment"]
+
+        # Crear múltiples pagos
+        for i in range(3):
+            payment = self.env["account.payment"].create(
+                {
+                    "journal_id": self.source_journal.id,
+                    "destination_journal_id": self.destination_journal.id,
+                    "amount": 100.0 * (i + 1),
+                    "date": fields.Date.today(),
+                    "cashbox_session_id": self.source_session.id,
+                    "destination_cashbox_session_id": self.destination_session.id,
+                    "is_internal_transfer": True,
+                }
+            )
+            payments |= payment
+
+        # Postear todos los pagos
+        payments.action_post()
+
+        # Verificar que todos los pagos pareados tienen la sesión correcta
+        for payment in payments:
+            self.assertTrue(
+                payment.paired_internal_transfer_payment_id, f"El pago pareado para el pago {payment.id} no fue creado"
+            )
+            self.assertEqual(
+                payment.paired_internal_transfer_payment_id.cashbox_session_id,
+                self.destination_session,
+                f"El pago pareado del pago {payment.id} no tiene la sesión de caja destino correcta",
+            )
+            self.assertFalse(
+                payment.paired_internal_transfer_payment_id.destination_cashbox_session_id,
+                f"El destination_cashbox_session_id del pago pareado {payment.id} debería ser False",
+            )
+
+    def test_destination_session_domain_filter(self):
+        """Verifica que solo sesiones abiertas pueden ser seleccionadas como destino"""
+
+        # Crear una tercera sesión pero cerrada
+        closed_cashbox = self.env["account.cashbox"].create(
+            {
+                "name": "Closed Cashbox",
+                "company_id": self.company.id,
+                "journal_ids": [Command.link(self.destination_journal.id)],
+                "allow_concurrent_sessions": True,
+            }
+        )
+
+        closed_session = self.env["account.cashbox.session"].create(
+            {
+                "cashbox_id": closed_cashbox.id,
+                "name": "Closed Session 001",
+            }
+        )
+        closed_session.action_account_cashbox_session_open()
+        closed_session.action_closing_control()
+        closed_session.action_account_cashbox_session_close()
+
+        # Crear pago en la primera compañía
+        # Solo debería poder usar sesiones abiertas en destination_cashbox_session_id
+        payment = self.env["account.payment"].create(
+            {
+                "journal_id": self.source_journal.id,
+                "destination_journal_id": self.destination_journal.id,
+                "amount": 1000.0,
+                "date": fields.Date.today(),
+                "cashbox_session_id": self.source_session.id,
+                "destination_cashbox_session_id": self.destination_session.id,
+                "is_internal_transfer": True,
+            }
+        )
+
+        # Verificar que la sesión destino es la abierta
+        self.assertEqual(payment.destination_cashbox_session_id, self.destination_session)
+        self.assertNotEqual(payment.destination_cashbox_session_id, closed_session)

--- a/account_cashbox/views/account_cashbox_session.xml
+++ b/account_cashbox/views/account_cashbox_session.xml
@@ -58,7 +58,7 @@
                     <group>
                         <group>
                             <field name="cashbox_id" force_save="True" options="{'no_create':True}" invisible="context.get('hide_cashbox_id')"/>
-                            <field name="user_ids" widget="many2many_tags" invisible="not restrict_users" required="restrict_users" options="{'no_create':True}"/>
+                            <field name="user_ids" domain="[('id','in',allowed_res_users_ids)]" widget="many2many_tags" invisible="not restrict_users" required="restrict_users" options="{'no_create':True}" />
                         </group>
                         <group>
                             <field name="opening_date" readonly="not allow_dates_edition"/>

--- a/account_cashbox/views/account_payment.xml
+++ b/account_cashbox/views/account_payment.xml
@@ -19,7 +19,7 @@
             <field name="destination_journal_id" position="after">
                 <field
                     name="destination_cashbox_session_id"
-                    domain="[('state', '=', 'opened'), ('company_id', '=', company_id), '|', ('user_ids', '=', uid), ('user_ids', '=', False)]"
+                    domain="[('state', '=', 'opened'), ('company_id', '=', company_id), ('cashbox_id.journal_ids', '=', destination_journal_id), '|', ('user_ids', '=', uid), ('user_ids', '=', False)]"
                     required="requiere_account_cashbox_session and state == 'draft' and payment_type == 'transfer'"
                     readonly = "state != 'draft'"
                     invisible = "not is_internal_transfer or not destination_journal_id or (paired_internal_transfer_payment_id and not destination_cashbox_session_id)"

--- a/account_cashbox/views/account_payment.xml
+++ b/account_cashbox/views/account_payment.xml
@@ -16,6 +16,15 @@
                     readonly = "state != 'draft'"
                     options="{'no_create': True}"/>
             </field>
+            <field name="destination_journal_id" position="after">
+                <field
+                    name="destination_cashbox_session_id"
+                    domain="[('state', '=', 'opened'), ('company_id', '=', company_id), '|', ('user_ids', '=', uid), ('user_ids', '=', False)]"
+                    required="requiere_account_cashbox_session and state == 'draft' and payment_type == 'transfer'"
+                    readonly = "state != 'draft'"
+                    invisible = "not is_internal_transfer or not destination_journal_id or (paired_internal_transfer_payment_id and not destination_cashbox_session_id)"
+                    options="{'no_create': True}"/>
+            </field>
         </field>
     </record>
 


### PR DESCRIPTION
1. In `account.payment`, when creating the paired internal transfer payment, set the `cashbox_session_id` to the `destination_cashbox_session_id` of the original payment.