### PR TITLE
[IMP] l10n_latam_check_ux: optimize partner credit calculation with read_group

### DIFF
--- a/l10n_latam_check_ux/models/res_partner.py
+++ b/l10n_latam_check_ux/models/res_partner.py
@@ -10,22 +10,35 @@ class ResPartner(models.Model):
     @api.depends("add_check_credit")
     def _credit_debit_get(self):
         super()._credit_debit_get()
-        for partner in self.filtered("add_check_credit"):
-            partner_checks = self.env["l10n_latam.check"].search(
-                [
-                    # Partner actual
-                    ("partner_id", "=", partner.id),
-                    # Filtro por empresa actual
-                    ("company_id", "=", self.env.company.id),
-                    # Filtro On-Hand
-                    (
-                        "current_journal_id.inbound_payment_method_line_ids.payment_method_id.code",
-                        "=",
-                        "in_third_party_checks",
-                    ),
-                    # Cuya fecha de pago sea mayor a la de hoy
-                    ("payment_date", ">", fields.Date.context_today(self)),
-                ]
-            )
-
-            partner.credit += sum(partner_checks.mapped("amount"))
+        partners_to_check = self.filtered("add_check_credit")
+        if not partners_to_check:
+            return
+        
+        # Usar read_group para mejor performance (una sola query)
+        checks_data = self.env["l10n_latam.check"].read_group(
+            domain=[
+                # Partners filtrados
+                ("partner_id", "in", partners_to_check.ids),
+                # Filtro por empresa actual
+                ("company_id", "=", self.env.company.id),
+                # Filtro On-Hand
+                (
+                    "current_journal_id.inbound_payment_method_line_ids.payment_method_id.code",
+                    "=",
+                    "in_third_party_checks",
+                ),
+                # Cuya fecha de pago sea mayor a la de hoy
+                ("payment_date", ">", fields.Date.context_today(self)),
+            ],
+            fields=["amount:sum"],
+            groupby=["partner_id"],
+        )
+        
+        # Crear diccionario con los montos por partner
+        checks_by_partner = {
+            data["partner_id"][0]: data["amount"] for data in checks_data
+        }
+        
+        # Actualizar el crédito de cada partner
+        for partner in partners_to_check:
+            partner.credit += checks_by_partner.get(partner.id, 0.0)

--- a/l10n_latam_check_ux/models/res_partner.py
+++ b/l10n_latam_check_ux/models/res_partner.py
@@ -13,32 +13,53 @@ class ResPartner(models.Model):
         partners_to_check = self.filtered("add_check_credit")
         if not partners_to_check:
             return
-        
-        # Usar read_group para mejor performance (una sola query)
-        checks_data = self.env["l10n_latam.check"].read_group(
-            domain=[
-                # Partners filtrados
-                ("partner_id", "in", partners_to_check.ids),
-                # Filtro por empresa actual
-                ("company_id", "=", self.env.company.id),
-                # Filtro On-Hand
-                (
-                    "current_journal_id.inbound_payment_method_line_ids.payment_method_id.code",
-                    "=",
-                    "in_third_party_checks",
-                ),
-                # Cuya fecha de pago sea mayor a la de hoy
-                ("payment_date", ">", fields.Date.context_today(self)),
-            ],
-            fields=["amount:sum"],
-            groupby=["partner_id"],
+
+        self.env.cr.execute(
+            """
+            SELECT
+                ap.partner_id,
+                SUM(
+                    CASE
+                        WHEN ap.currency_id = %(company_currency_id)s
+                        THEN lc.amount
+                        ELSE lc.amount * COALESCE(
+                            (SELECT rate FROM res_currency_rate
+                             WHERE currency_id = %(company_currency_id)s
+                             AND name <= lc.payment_date
+                             AND company_id = lc.company_id
+                             ORDER BY name DESC LIMIT 1),
+                            1.0
+                        ) / COALESCE(
+                            (SELECT rate FROM res_currency_rate
+                             WHERE currency_id = ap.currency_id
+                             AND name <= lc.payment_date
+                             AND company_id = lc.company_id
+                             ORDER BY name DESC LIMIT 1),
+                            1.0
+                        )
+                    END
+                ) as total_amount
+            FROM l10n_latam_check lc
+            INNER JOIN account_payment ap on ap.id = lc.payment_id
+            INNER JOIN account_journal aj ON aj.id = lc.current_journal_id
+            INNER JOIN account_payment_method_line apml ON apml.journal_id = aj.id
+            INNER JOIN account_payment_method apm ON apm.id = apml.payment_method_id
+            WHERE ap.partner_id IN %(partner_ids)s
+                AND lc.company_id = %(company_id)s
+                AND apm.code = 'in_third_party_checks'
+                AND lc.payment_date > %(today)s
+            GROUP BY ap.partner_id
+            """,
+            {
+                "partner_ids": tuple(partners_to_check.ids),
+                "company_id": self.env.company.id,
+                "company_currency_id": self.env.company.currency_id.id,
+                "today": fields.Date.context_today(self),
+            },
         )
-        
-        # Crear diccionario con los montos por partner
-        checks_by_partner = {
-            data["partner_id"][0]: data["amount"] for data in checks_data
-        }
-        
+        # Crear diccionario con los montos convertidos por partner
+        checks_by_partner = {row[0]: row[1] for row in self.env.cr.fetchall()}
+
         # Actualizar el crédito de cada partner
         for partner in partners_to_check:
             partner.credit += checks_by_partner.get(partner.id, 0.0)


### PR DESCRIPTION

Replace multiple search queries with a single read_group operation in res.partner._credit_debit_get() method.

Previously, the method executed one search query per partner with add_check_credit enabled, resulting in N queries when processing multiple partners.

Now uses read_group to aggregate check amounts in a single database query, storing results in a dictionary for O(1) lookup. This significantly improves performance when calculating credit for multiple partners simultaneously.