### PR TITLE
[FIX] account_payment_pro: avoid computed field dependency error in pay_now

### DIFF
--- a/account_payment_pro/models/account_move.py
+++ b/account_payment_pro/models/account_move.py
@@ -60,19 +60,18 @@ class AccountMove(models.Model):
                 )
             )
 
+            # compute payment_difference here to avoid lazy evaluation issues
+            difference = payment.payment_difference
+
             # el difference es positivo para facturas (de cliente o proveedor) pero negativo para NC.
             # para factura de proveedor o NC de cliente es outbound
             # para factura de cliente o NC de proveedor es inbound
             # igualmente lo hacemos con el difference y no con el type por las dudas de que facturas en negativo
-            if (
-                partner_type == "supplier"
-                and payment.payment_difference >= 0.0
-                or partner_type == "customer"
-                and payment.payment_difference < 0.0
-            ):
+            if partner_type == "supplier" and difference >= 0.0 or partner_type == "customer" and difference < 0.0:
                 payment.payment_type = "outbound"
                 payment.payment_method_id = pay_journal._get_manual_payment_method_id(payment_type).id
-            payment.amount = abs(payment.payment_difference)
+
+            payment.amount = abs(difference)
             payment.action_post()
             rec.write({"matched_payment_ids": [(4, payment.id)]})
 


### PR DESCRIPTION
Store payment_difference in a local variable before using it to avoid
"Compute method failed to assign payment_total" error when accessing
the computed field multiple times in pay_now method