### PR TITLE
[FIX] account_payment_pro_receiptbook: fix unistall hook

### DIFF
--- a/account_payment_pro_receiptbook/hooks.py
+++ b/account_payment_pro_receiptbook/hooks.py
@@ -7,5 +7,5 @@ def _revert_method(cls, name):
     setattr(cls, name, method.origin)
 
 
-def uninstall_hook(cr, registry):
+def uninstall_hook(env):
     _revert_method(AccountResequenceWizard, "default_get")


### PR DESCRIPTION
In Odoo 19.0, hooks are called with env instead of the old cr, registry pattern.