### PR TITLE
[FIX] account_payment_pro: remove compute in inverse of amount_company_currency

### DIFF
--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -277,7 +277,6 @@ class AccountPayment(models.Model):
     @api.onchange("amount_company_currency")
     def _inverse_amount_company_currency(self):
         for rec in self:
-            rec._compute_other_currency()
             if rec.other_currency and rec.amount_company_currency != rec.currency_id._convert(
                 rec.amount, rec.company_id.currency_id, rec.company_id, rec.date
             ):


### PR DESCRIPTION
This is a partial revert of commit https://github.com/ingadhoc/account-payment/commit/b342df9467f9e16f399bf96415f36bf0808e23eb that computes other currency in inverse due to 'Compute method failed to assign account' error.
