### PR TITLE
[FIX] account_cashbox: exclude canceled payments from session totals

### DIFF
--- a/account_cashbox/models/account_cashbox_session_line.py
+++ b/account_cashbox/models/account_cashbox_session_line.py
@@ -35,7 +35,10 @@ class PopSessionJournalControl(models.Model):
     @api.depends("cashbox_session_id.payment_ids", "cashbox_session_id.payment_ids.state", "balance_start")
     def _compute_amounts(self):
         payments_lines = self.env["account.payment"].search(
-            [("cashbox_session_id", "in", self.mapped("cashbox_session_id").ids), ("state", "!=", "draft")]
+            [
+                ("cashbox_session_id", "in", self.mapped("cashbox_session_id").ids),
+                ("state", "not in", ["draft", "canceled"]),
+            ]
         )
         for record in self:
             lines = payments_lines.filtered(


### PR DESCRIPTION
When computing the total amounts in cashbox sessions, canceled payments should be excluded to ensure accurate financial reporting. This commit modifies the domain used to fetch payment lines to filter out those with a 'canceled' state, in addition to the existing exclusion of 'draft' payments.