### PR TITLE
[IMP] l10n_ar_payment_bundle: restrict resequence linked payments

### DIFF
--- a/l10n_ar_payment_bundle/__init__.py
+++ b/l10n_ar_payment_bundle/__init__.py
@@ -1,4 +1,5 @@
 from . import models
+from . import wizard
 
 
 def post_init_hook(env):

--- a/l10n_ar_payment_bundle/__manifest__.py
+++ b/l10n_ar_payment_bundle/__manifest__.py
@@ -19,6 +19,8 @@
         "account_payment_pro_receiptbook",
     ],
     "data": [
+        "security/ir.model.access.csv",
+        "views/payment_rename_wizard_view.xml",
         "data/account_payment_method_data.xml",
         "views/account_payment_view.xml",
         "views/report_payment_receipt_templates.xml",

--- a/l10n_ar_payment_bundle/i18n/es.po
+++ b/l10n_ar_payment_bundle/i18n/es.po
@@ -53,6 +53,11 @@ msgid "Bundle Counterpart Currency Amount"
 msgstr "Monto en moneda del pago múltiple de la contrapartida"
 
 #. module: l10n_ar_payment_bundle
+#: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_payment_rename_wizard_form
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: l10n_ar_payment_bundle
 #: model:ir.model,name:l10n_ar_payment_bundle.model_res_company
 msgid "Companies"
 msgstr "Empresas"
@@ -61,6 +66,21 @@ msgstr "Empresas"
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_payment__counterpart_exchange_rate
 msgid "Counterpart Exchange Rate"
 msgstr "Tasa de Imputación"
+
+#. module: l10n_ar_payment_bundle
+#: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_payment_rename_wizard__create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: l10n_ar_payment_bundle
+#: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_payment_rename_wizard__create_date
+msgid "Created on"
+msgstr "Creado el"
+
+#. module: l10n_ar_payment_bundle
+#: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_payment_rename_wizard__current_name
+msgid "Current Name"
+msgstr "Nombre Actual"
 
 #. module: l10n_ar_payment_bundle
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_payment__partner_id
@@ -72,15 +92,24 @@ msgstr "Cliente/Proveedor"
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_journal__display_name
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_payment__display_name
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_payment_method__display_name
+#: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_resequence_wizard__display_name
+#: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_payment_rename_wizard__display_name
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_res_company__display_name
 msgid "Display Name"
 msgstr "Nombre a Mostrar"
+
+#. module: l10n_ar_payment_bundle
+#: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_payment_rename_wizard_form
+msgid "Enter new payment name..."
+msgstr "Ingresar nuevo nombre del pago..."
 
 #. module: l10n_ar_payment_bundle
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_chart_template__id
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_journal__id
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_payment__id
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_payment_method__id
+#: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_resequence_wizard__id
+#: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_payment_rename_wizard__id
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_res_company__id
 msgid "ID"
 msgstr "ID"
@@ -125,6 +154,16 @@ msgid "Journal Entry"
 msgstr "Asiento Contable"
 
 #. module: l10n_ar_payment_bundle
+#: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_payment_rename_wizard__write_uid
+msgid "Last Updated by"
+msgstr "Última vez editado por"
+
+#. module: l10n_ar_payment_bundle
+#: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_payment_rename_wizard__write_date
+msgid "Last Updated on"
+msgstr "Última vez editado el"
+
+#. module: l10n_ar_payment_bundle
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_payment__link_payment_ids
 msgid "Link Payment"
 msgstr "Pago vinculado"
@@ -151,6 +190,11 @@ msgid "Multiple payments"
 msgstr "Pagos múltiples"
 
 #. module: l10n_ar_payment_bundle
+#: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_payment_rename_wizard__new_name
+msgid "New Name"
+msgstr "Nuevo Nombre"
+
+#. module: l10n_ar_payment_bundle
 #. odoo-python
 #: code:addons/l10n_ar_payment_bundle/models/account_payment.py:0
 msgid "Paid Bills"
@@ -163,9 +207,19 @@ msgid "Paid Invoices"
 msgstr "Facturas pagadas"
 
 #. module: l10n_ar_payment_bundle
+#: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_payment_rename_wizard__payment_id
+msgid "Payment"
+msgstr "Pago"
+
+#. module: l10n_ar_payment_bundle
 #: model:ir.model,name:l10n_ar_payment_bundle.model_account_payment_method
 msgid "Payment Methods"
 msgstr "Métodos de pago"
+
+#. module: l10n_ar_payment_bundle
+#: model:ir.model,name:l10n_ar_payment_bundle.model_payment_rename_wizard
+msgid "Payment Rename Wizard"
+msgstr "Asistente para Renombrar Pago"
 
 #. module: l10n_ar_payment_bundle
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_form
@@ -179,6 +233,12 @@ msgid "Payment multiple"
 msgstr "Pago Múltiple"
 
 #. module: l10n_ar_payment_bundle
+#. odoo-python
+#: code:addons/l10n_ar_payment_bundle/wizard/payment_rename.py:0
+msgid "Payment name changed from '%s' to '%s'"
+msgstr "El nombre del pago cambió de '%s' a '%s'"
+
+#. module: l10n_ar_payment_bundle
 #: model:ir.model,name:l10n_ar_payment_bundle.model_account_payment
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_custom_list
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_form
@@ -186,9 +246,32 @@ msgid "Payments"
 msgstr "Pagos"
 
 #. module: l10n_ar_payment_bundle
+#. odoo-python
+#: code:addons/l10n_ar_payment_bundle/wizard/payment_rename.py:0
+msgid "Please enter a new name for the payment."
+msgstr "Por favor ingrese un nuevo nombre para el pago."
+
+#. module: l10n_ar_payment_bundle
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_custom_list
 msgid "Rate"
 msgstr "Tasa de Cambio"
+
+#. module: l10n_ar_payment_bundle
+#: model:ir.model,name:l10n_ar_payment_bundle.model_account_resequence_wizard
+msgid "Remake the sequence of Journal Entries."
+msgstr "Rehacer la secuencia de los Asientos Contables."
+
+#. module: l10n_ar_payment_bundle
+#: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_form
+#: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_payment_rename_wizard_form
+msgid "Rename"
+msgstr "Renombrar"
+
+#. module: l10n_ar_payment_bundle
+#: model:ir.actions.act_window,name:l10n_ar_payment_bundle.action_payment_rename_wizard
+#: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_payment_rename_wizard_form
+msgid "Rename Payment"
+msgstr "Renombrar Pago"
 
 #. module: l10n_ar_payment_bundle
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_form
@@ -240,9 +323,15 @@ msgstr ""
 "y a los Ajustes."
 
 #. module: l10n_ar_payment_bundle
+#. odoo-python
+#: code:addons/l10n_ar_payment_bundle/wizard/payment_rename.py:0
+msgid "This action is only available for bundle payments."
+msgstr "Esta acción solo está disponible para pagos múltiples."
+
+#. module: l10n_ar_payment_bundle
 #: model:ir.model.fields,help:l10n_ar_payment_bundle.field_account_payment__to_pay_move_line_ids
 msgid "This lines are the ones the user has selected to be paid."
-msgstr "Estas líneas son las que el usuario ha seleccionado para pagar"
+msgstr "Estas líneas son las que el usuario ha seleccionado para pagar."
 
 #. module: l10n_ar_payment_bundle
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_payment__to_pay_move_line_ids
@@ -279,3 +368,19 @@ msgid ""
 msgstr ""
 "No puede asignar una Moneda a los diarios que utilizan el método de pago de "
 "Múltiples Pagos."
+
+#. module: l10n_ar_payment_bundle
+#. odoo-python
+#: code:addons/l10n_ar_payment_bundle/wizard/payment_rename.py:0
+msgid "You cannot rename canceled payments."
+msgstr "No puede renombrar pagos cancelados."
+
+#. module: l10n_ar_payment_bundle
+#. odoo-python
+#: code:addons/l10n_ar_payment_bundle/wizard/account_resequence.py:0
+msgid ""
+"You cannot resequence moves linked to a bundle payment. Please resequence "
+"the payment instead."
+msgstr ""
+"No puede resecuenciar movimientos vinculados a un pago múltiple. Por favor "
+"resecuencie el pago en su lugar."

--- a/l10n_ar_payment_bundle/i18n/l10n_ar_payment_bundle.pot
+++ b/l10n_ar_payment_bundle/i18n/l10n_ar_payment_bundle.pot
@@ -46,6 +46,11 @@ msgid "Bundle Counterpart Currency Amount"
 msgstr ""
 
 #. module: l10n_ar_payment_bundle
+#: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_payment_rename_wizard_form
+msgid "Cancel"
+msgstr ""
+
+#. module: l10n_ar_payment_bundle
 #: model:ir.model,name:l10n_ar_payment_bundle.model_res_company
 msgid "Companies"
 msgstr ""
@@ -53,6 +58,21 @@ msgstr ""
 #. module: l10n_ar_payment_bundle
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_payment__counterpart_exchange_rate
 msgid "Counterpart Exchange Rate"
+msgstr ""
+
+#. module: l10n_ar_payment_bundle
+#: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_payment_rename_wizard__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: l10n_ar_payment_bundle
+#: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_payment_rename_wizard__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: l10n_ar_payment_bundle
+#: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_payment_rename_wizard__current_name
+msgid "Current Name"
 msgstr ""
 
 #. module: l10n_ar_payment_bundle
@@ -65,8 +85,15 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_journal__display_name
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_payment__display_name
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_payment_method__display_name
+#: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_resequence_wizard__display_name
+#: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_payment_rename_wizard__display_name
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_res_company__display_name
 msgid "Display Name"
+msgstr ""
+
+#. module: l10n_ar_payment_bundle
+#: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_payment_rename_wizard_form
+msgid "Enter new payment name..."
 msgstr ""
 
 #. module: l10n_ar_payment_bundle
@@ -74,6 +101,8 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_journal__id
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_payment__id
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_payment_method__id
+#: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_resequence_wizard__id
+#: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_payment_rename_wizard__id
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_res_company__id
 msgid "ID"
 msgstr ""
@@ -111,6 +140,16 @@ msgid "Journal Entry"
 msgstr ""
 
 #. module: l10n_ar_payment_bundle
+#: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_payment_rename_wizard__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: l10n_ar_payment_bundle
+#: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_payment_rename_wizard__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: l10n_ar_payment_bundle
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_payment__link_payment_ids
 msgid "Link Payment"
 msgstr ""
@@ -137,6 +176,11 @@ msgid "Multiple payments"
 msgstr ""
 
 #. module: l10n_ar_payment_bundle
+#: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_payment_rename_wizard__new_name
+msgid "New Name"
+msgstr ""
+
+#. module: l10n_ar_payment_bundle
 #. odoo-python
 #: code:addons/l10n_ar_payment_bundle/models/account_payment.py:0
 msgid "Paid Bills"
@@ -149,8 +193,18 @@ msgid "Paid Invoices"
 msgstr ""
 
 #. module: l10n_ar_payment_bundle
+#: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_payment_rename_wizard__payment_id
+msgid "Payment"
+msgstr ""
+
+#. module: l10n_ar_payment_bundle
 #: model:ir.model,name:l10n_ar_payment_bundle.model_account_payment_method
 msgid "Payment Methods"
+msgstr ""
+
+#. module: l10n_ar_payment_bundle
+#: model:ir.model,name:l10n_ar_payment_bundle.model_payment_rename_wizard
+msgid "Payment Rename Wizard"
 msgstr ""
 
 #. module: l10n_ar_payment_bundle
@@ -165,6 +219,12 @@ msgid "Payment multiple"
 msgstr ""
 
 #. module: l10n_ar_payment_bundle
+#. odoo-python
+#: code:addons/l10n_ar_payment_bundle/wizard/payment_rename.py:0
+msgid "Payment name changed from '%s' to '%s'"
+msgstr ""
+
+#. module: l10n_ar_payment_bundle
 #: model:ir.model,name:l10n_ar_payment_bundle.model_account_payment
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_custom_list
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_form
@@ -172,8 +232,31 @@ msgid "Payments"
 msgstr ""
 
 #. module: l10n_ar_payment_bundle
+#. odoo-python
+#: code:addons/l10n_ar_payment_bundle/wizard/payment_rename.py:0
+msgid "Please enter a new name for the payment."
+msgstr ""
+
+#. module: l10n_ar_payment_bundle
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_custom_list
 msgid "Rate"
+msgstr ""
+
+#. module: l10n_ar_payment_bundle
+#: model:ir.model,name:l10n_ar_payment_bundle.model_account_resequence_wizard
+msgid "Remake the sequence of Journal Entries."
+msgstr ""
+
+#. module: l10n_ar_payment_bundle
+#: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_form
+#: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_payment_rename_wizard_form
+msgid "Rename"
+msgstr ""
+
+#. module: l10n_ar_payment_bundle
+#: model:ir.actions.act_window,name:l10n_ar_payment_bundle.action_payment_rename_wizard
+#: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_payment_rename_wizard_form
+msgid "Rename Payment"
 msgstr ""
 
 #. module: l10n_ar_payment_bundle
@@ -254,4 +337,12 @@ msgstr ""
 msgid ""
 "You cannot assign a currency to journals that use the payment bundle payment"
 " method."
+msgstr ""
+
+#. module: l10n_ar_payment_bundle
+#. odoo-python
+#: code:addons/l10n_ar_payment_bundle/wizard/account_resequence.py:0
+msgid ""
+"You cannot resequence moves linked to a bundle payment. Please resequence "
+"the payment instead."
 msgstr ""

--- a/l10n_ar_payment_bundle/security/ir.model.access.csv
+++ b/l10n_ar_payment_bundle/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_payment_rename_wizard_user,payment.rename.wizard.user,model_payment_rename_wizard,account.group_account_user,1,1,1,1
+access_payment_rename_wizard_manager,payment.rename.wizard.manager,model_payment_rename_wizard,account.group_account_manager,1,1,1,1

--- a/l10n_ar_payment_bundle/views/account_payment_view.xml
+++ b/l10n_ar_payment_bundle/views/account_payment_view.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+
+
     <record id="view_account_payment_from_bundle_tree" model="ir.ui.view">
         <field name="name">account.payment.tree</field>
         <field name="model">account.payment</field>
@@ -108,6 +110,14 @@
         <field name="priority" eval="30"/>
         <field name="inherit_id" ref="account.view_account_payment_form" />
         <field name="arch" type="xml">
+            <button name="action_draft" position="after">
+                <button name="%(l10n_ar_payment_bundle.action_payment_rename_wizard)d"
+                        type="action"
+                        string="Rename"
+                        class="btn-secondary"
+                        invisible="not is_main_payment or state not in ['in_process', 'paid']"
+                        groups="base.group_no_one"/>
+            </button>
             <button name="button_open_journal_entry" position="attributes">
                 <attribute name="invisible" separator=" and " add="not show_move_button"></attribute>
             </button>

--- a/l10n_ar_payment_bundle/views/payment_rename_wizard_view.xml
+++ b/l10n_ar_payment_bundle/views/payment_rename_wizard_view.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Wizard form view -->
+    <record id="view_payment_rename_wizard_form" model="ir.ui.view">
+        <field name="name">payment.rename.wizard.form</field>
+        <field name="model">payment.rename.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Rename Payment">
+                <group>
+                    <field name="payment_id" readonly="1"/>
+                    <field name="current_name"/>
+                    <field name="new_name" placeholder="Enter new payment name..."/>
+                </group>
+                <footer>
+                    <button name="action_rename_payment" type="object" string="Rename" class="btn-primary" data-hotkey="q"/>
+                    <button special="cancel" string="Cancel" class="btn-secondary" data-hotkey="x"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <!-- Window action to open the wizard -->
+    <record id="action_payment_rename_wizard" model="ir.actions.act_window">
+        <field name="name">Rename Payment</field>
+        <field name="res_model">payment.rename.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+</odoo>

--- a/l10n_ar_payment_bundle/wizard/__init__.py
+++ b/l10n_ar_payment_bundle/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import account_resequence

--- a/l10n_ar_payment_bundle/wizard/__init__.py
+++ b/l10n_ar_payment_bundle/wizard/__init__.py
@@ -1,1 +1,2 @@
 from . import account_resequence
+from . import payment_rename

--- a/l10n_ar_payment_bundle/wizard/account_resequence.py
+++ b/l10n_ar_payment_bundle/wizard/account_resequence.py
@@ -1,0 +1,15 @@
+from odoo import _, api, models
+from odoo.exceptions import UserError
+
+
+class AccountResequenceWizard(models.TransientModel):
+    _inherit = "account.resequence.wizard"
+
+    @api.model
+    def default_get(self, fields):
+        move_ids = self.env["account.move"].browse(self.env.context.get("active_ids", []))
+        if any(move_ids.payment_ids.main_payment_id):
+            raise UserError(
+                _("You cannot resequence moves linked to a bundle payment. Please resequence the payment instead.")
+            )
+        return super().default_get(fields)

--- a/l10n_ar_payment_bundle/wizard/payment_rename.py
+++ b/l10n_ar_payment_bundle/wizard/payment_rename.py
@@ -1,0 +1,71 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class PaymentRenameWizard(models.TransientModel):
+    _name = "payment.rename.wizard"
+    _description = "Payment Rename Wizard"
+
+    payment_id = fields.Many2one(
+        "account.payment",
+        string="Payment",
+        required=True,
+    )
+    new_name = fields.Char(
+        required=True,
+    )
+    current_name = fields.Char(
+        string="Current Name",
+        related="payment_id.name",
+        readonly=True,
+    )
+
+    @api.model
+    def open_rename_wizard(self, payment_ids):
+        """Server action method to open rename wizard"""
+        payment = self.env["account.payment"].browse(payment_ids)
+
+        return {
+            "type": "ir.actions.act_window",
+            "res_model": "payment.rename.wizard",
+            "view_mode": "form",
+            "target": "new",
+            "context": {"default_payment_id": payment.id},
+        }
+
+    @api.model
+    def default_get(self, fields_list):
+        result = super().default_get(fields_list)
+        payment_id = None
+
+        payment_id = self.env.context.get("active_id")
+
+        if payment_id:
+            payment = self.env["account.payment"].browse(payment_id)
+            result["payment_id"] = payment_id
+            result["new_name"] = payment.name
+        return result
+
+    def action_rename_payment(self):
+        """Rename the payment"""
+        if not self.new_name:
+            raise UserError(_("Please enter a new name for the payment."))
+
+        # Update the payment name for main and linked payments
+        old_name = self.payment_id.name
+        self.payment_id.write({"name": self.new_name})
+        for i, payment in enumerate(self.payment_id.link_payment_ids):
+            new_linked_name = f"{self.new_name} ({i + 1})"
+            payment.name = new_linked_name
+            payment.move_id.name = new_linked_name  # Update the move name to keep it in sync with the payment name
+
+        # Log the change in chatter
+        self.payment_id.message_post(
+            body=_("Payment name changed from '%s' to '%s'") % (old_name, self.new_name),
+            message_type="notification",
+        )
+
+        return {
+            "type": "ir.actions.client",
+            "tag": "reload",
+        }


### PR DESCRIPTION
This commit adds a check to the account resequence wizard to prevent resequencing of payments linked to a payment bundle. This is necessary to avoid breaking the link between the payments and the payment bundle, which could lead to inconsistencies in the payment records and potential issues with reconciliation and reporting