### PR TITLE
[FIX] l10n_ar_payment_bundle: pass actual params in _prepare_move_lin…

### DIFF
--- a/l10n_ar_payment_bundle/models/account_payment.py
+++ b/l10n_ar_payment_bundle/models/account_payment.py
@@ -188,7 +188,7 @@ class AccountPayment(models.Model):
         )
 
     def _prepare_move_line_default_vals(self, write_off_line_vals=None, force_balance=None):
-        res = super()._prepare_move_line_default_vals(write_off_line_vals=None, force_balance=None)
+        res = super()._prepare_move_line_default_vals(write_off_line_vals=write_off_line_vals, force_balance=force_balance)
         if self.payment_method_code == "payment_bundle":
             bundle_account = self.payment_method_line_id.payment_account_id
             res = [line for line in res if not (line.get("account_id") == bundle_account.id)]


### PR DESCRIPTION
…e_default_vals

write_off_line_vals and force_balance were hardcoded as None instead of passing the actual parameter values to super(), causing KeyError on payment posting.