### PR TITLE
[ADD] account_cashbox_bundle: Exclude payment bundles from cashbox sessions

### DIFF
--- a/account_cashbox/models/account_payment.py
+++ b/account_cashbox/models/account_payment.py
@@ -55,7 +55,7 @@ class AccountPayment(models.Model):
 
     def action_post(self):
         for rec in self:
-            if not rec.cashbox_session_id and self.env.user.requiere_account_cashbox_session:
+            if not rec.cashbox_session_id and rec.requiere_account_cashbox_session:
                 rec._compute_cashbox_session_id()
             elif rec.cashbox_session_id and rec.cashbox_session_id.state != "opened":
                 raise UserError(
@@ -68,7 +68,7 @@ class AccountPayment(models.Model):
 
             if (
                 not self.env.context.get("paired_transfer")
-                and self.env.user.requiere_account_cashbox_session
+                and rec.requiere_account_cashbox_session
                 and not rec.cashbox_session_id
             ):
                 raise UserError(

--- a/account_cashbox_bundle/README.md
+++ b/account_cashbox_bundle/README.md
@@ -1,0 +1,85 @@
+# Account Cashbox Bundle
+
+Technical bridge module that ensures proper integration between Account Cashbox and Payment Bundle functionality.
+
+## Features
+
+This module provides seamless integration between cashbox operations and payment bundles:
+
+- **Excludes bundle journals from cashbox configuration**: Payment bundle journals are automatically filtered out from cashbox journal selection, as they operate differently from regular cashbox transactions.
+
+- **Smart cashbox session handling**: Main bundle payments automatically bypass cashbox session requirements, while child payments within the bundle maintain proper cashbox controls.
+
+- **Domain restrictions**: Prevents configuration errors by ensuring bundle payment methods cannot be associated with cashbox sessions.
+
+## Installation
+
+This module is set to `auto_install`, meaning it will be automatically installed when both dependencies are present:
+
+- `account_cashbox`
+- `l10n_ar_payment_bundle`
+
+No manual installation is required.
+
+## Configuration
+
+No configuration needed. The module works automatically once installed.
+
+## Usage
+
+### Cashbox Configuration
+
+When setting up a cashbox:
+
+1. Navigate to **Accounting → Configuration → Cashboxes**
+2. Create or edit a cashbox
+3. When selecting journals, payment bundle journals will be automatically excluded from available options
+
+This ensures only regular cash and bank journals can be associated with cashbox sessions.
+
+### Payment Operations
+
+**Bundle Payments (Main):**
+- When creating a payment using a payment bundle journal, the cashbox session requirement is automatically bypassed
+- This is correct behavior as bundle payments are container/parent payments
+
+**Child Payments:**
+- Individual payments within a bundle will follow standard cashbox rules
+- Cashbox session requirements are determined by user configuration and journal settings
+
+## Technical Details
+
+### Models Extended
+
+**account.cashbox**
+- Adds domain restriction to `journal_ids` field to exclude journals with payment_bundle methods
+
+**account.payment**
+- Overrides `_compute_requiere_account_cashbox_session()` to disable cashbox requirement for main payments
+
+### Dependencies
+
+- `account_cashbox`
+- `l10n_ar_payment_bundle`
+
+## Bug Tracker
+
+Bugs are tracked on [GitHub Issues](https://github.com/adhoc-ar/account-payment/issues).
+
+If you encounter any issues, please check if it has already been reported. If not, please [create a new issue](https://github.com/adhoc-ar/account-payment/issues/new) with detailed steps to reproduce.
+
+## Credits
+
+### Authors
+
+- ADHOC SA
+
+### Contributors
+
+- ADHOC SA
+
+### Maintainer
+
+This module is maintained by **ADHOC SA**.
+
+For more information, please visit <https://www.adhoc.com.ar>

--- a/account_cashbox_bundle/__init__.py
+++ b/account_cashbox_bundle/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import demo

--- a/account_cashbox_bundle/__manifest__.py
+++ b/account_cashbox_bundle/__manifest__.py
@@ -1,0 +1,17 @@
+{
+    "name": "Account Cashbox Bundle",
+    "version": "18.0.1.0.0",
+    "category": "Accounting",
+    "summary": "Technical bridge module for account_cashbox and l10n_ar_payment_bundle",
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "depends": [
+        "account_cashbox",
+        "l10n_ar_payment_bundle",
+    ],
+    "data": ["views/account_payment.xml"],
+    "demo": ["demo/account_cashbox_bundle_demo.xml"],
+    "installable": True,
+    "auto_install": True,
+}

--- a/account_cashbox_bundle/demo/__init__.py
+++ b/account_cashbox_bundle/demo/__init__.py
@@ -1,0 +1,1 @@
+from . import account_cashbox_bundle_demo

--- a/account_cashbox_bundle/demo/account_cashbox_bundle_demo.py
+++ b/account_cashbox_bundle/demo/account_cashbox_bundle_demo.py
@@ -1,0 +1,101 @@
+import logging
+
+from odoo import Command, api, models
+
+_logger = logging.getLogger(__name__)
+
+
+class AccountChartTemplate(models.AbstractModel):
+    _inherit = "account.chart.template"
+
+    @api.model
+    def _install_account_cashbox_bundle_demo(self, companies):
+        """
+        Crea demo data minimalista para probar account_cashbox_bundle.
+        Cubre los casos de uso:
+        1. Diarios bundle no deben estar en cashbox configuration
+        2. Main payments no requieren cashbox session
+        3. Child payments sí requieren session cuando el usuario lo requiere
+
+        Nota: El diario bundle (payment_bundle_journal) ya es creado por l10n_ar_payment_bundle,
+        por lo que no es necesario crearlo aquí.
+
+        Se crea solo para la compañía Responsable Inscripto (base.company_ri).
+        """
+        for company in companies:
+            _logger.info("Creating cashbox bundle demo data for company: %s", company.name)
+            self = self.with_company(company)
+
+            demo_data = {
+                "res.partner": self._cashbox_bundle_demo_partners(company),
+                "res.users": self._cashbox_bundle_demo_users(company),
+                "ir.sequence": self._cashbox_bundle_demo_sequences(company),
+                "account.cashbox": self._cashbox_bundle_demo_cashboxes(company),
+            }
+
+            self.sudo()._load_data(demo_data)
+
+    @api.model
+    def _cashbox_bundle_demo_partners(self, company):
+        """Create minimal partner for payments"""
+        return {
+            "demo_partner_cashbox": {
+                "name": "Demo Cashbox Partner",
+                "company_id": company.id,
+            },
+        }
+
+    @api.model
+    def _cashbox_bundle_demo_users(self, company):
+        """Create user that requires cashbox session"""
+        return {
+            "demo_user_requires_cashbox": {
+                "name": "Demo Cashbox User",
+                "login": "demo_cashbox_user",
+                "email": "demo_cashbox@test.com",
+                "company_id": company.id,
+                "company_ids": [Command.set([company.id])],
+                "requiere_account_cashbox_session": True,
+            },
+        }
+
+    @api.model
+    def _cashbox_bundle_demo_sequences(self, company):
+        """Create sequence for cashbox sessions"""
+        return {
+            "account_cashbox_sequence": {
+                "name": "Cashbox Sessions",
+                "code": "account.cashbox.session",
+                "prefix": "CASH/%(year)s/",
+                "padding": 3,
+                "company_id": company.id,
+            },
+        }
+
+    @api.model
+    def _cashbox_bundle_demo_cashboxes(self, company):
+        """Create cashbox with existing journals (excluding bundle journal)"""
+        # Find existing cash and bank journals for the company
+        existing_cash_journals = self.env["account.journal"].search(
+            [("type", "=", "cash"), ("company_id", "=", company.id)], limit=1
+        )
+
+        existing_bank_journals = self.env["account.journal"].search(
+            [("type", "=", "bank"), ("company_id", "=", company.id)], limit=1
+        )
+
+        # Build journal_ids list with existing journals
+        journal_ids = []
+        if existing_cash_journals:
+            journal_ids.append((4, existing_cash_journals.id))
+        if existing_bank_journals:
+            journal_ids.append((4, existing_bank_journals.id))
+
+        return {
+            "demo_cashbox_main": {
+                "name": "Demo Cashbox",
+                "company_id": company.id,
+                "journal_ids": journal_ids,
+                "sequence_id": "account_cashbox_sequence",
+            },
+        }

--- a/account_cashbox_bundle/demo/account_cashbox_bundle_demo.xml
+++ b/account_cashbox_bundle/demo/account_cashbox_bundle_demo.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <function model="account.chart.template" name="_install_account_cashbox_bundle_demo">
+        <value model="res.company" eval="[obj().env.ref('base.company_ri')]"/>
+    </function>
+</odoo>

--- a/account_cashbox_bundle/models/__init__.py
+++ b/account_cashbox_bundle/models/__init__.py
@@ -1,0 +1,2 @@
+from . import account_cashbox
+from . import account_payment

--- a/account_cashbox_bundle/models/account_cashbox.py
+++ b/account_cashbox_bundle/models/account_cashbox.py
@@ -1,0 +1,15 @@
+from odoo import fields, models
+
+
+class AccountCashbox(models.Model):
+    _inherit = "account.cashbox"
+
+    journal_ids = fields.Many2many(
+        domain=[
+            ("type", "in", ["bank", "cash"]),
+            "!",
+            "|",
+            ("inbound_payment_method_line_ids.payment_method_id.code", "=", "payment_bundle"),
+            ("outbound_payment_method_line_ids.payment_method_id.code", "=", "payment_bundle"),
+        ],
+    )

--- a/account_cashbox_bundle/models/account_payment.py
+++ b/account_cashbox_bundle/models/account_payment.py
@@ -1,0 +1,13 @@
+from odoo import api, models
+
+
+class AccountPayment(models.Model):
+    _inherit = "account.payment"
+
+    @api.depends_context("uid")
+    @api.depends("partner_id", "journal_id", "is_main_payment")
+    def _compute_requiere_account_cashbox_session(self):
+        super()._compute_requiere_account_cashbox_session()
+        for rec in self:
+            if rec.is_main_payment:
+                rec.requiere_account_cashbox_session = False

--- a/account_cashbox_bundle/tests/__init__.py
+++ b/account_cashbox_bundle/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_account_cashbox_bundle

--- a/account_cashbox_bundle/tests/test_account_cashbox_bundle.py
+++ b/account_cashbox_bundle/tests/test_account_cashbox_bundle.py
@@ -1,0 +1,238 @@
+from odoo.tests import common, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestAccountCashboxBundle(common.TransactionCase):
+    """Tests for account_cashbox_bundle module integration"""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Use Responsable Inscripto company (same as demo data)
+        cls.company = cls.env.ref("base.company_ri")
+
+        # Load demo data dynamically
+        chart = cls.env["account.chart.template"].with_company(cls.company)
+        chart._install_account_cashbox_bundle_demo([cls.company])
+
+        # Reference demo data using chart.ref() with company context
+        cls.demo_partner = chart.ref("demo_partner_cashbox")
+        cls.demo_user_cashbox = chart.ref("demo_user_requires_cashbox")
+
+        # Find existing cash and bank journals instead of creating demo ones
+        cls.demo_journal_cash = cls.env["account.journal"].search(
+            [("type", "=", "cash"), ("company_id", "=", cls.company.id)], limit=1
+        )
+        cls.demo_journal_bank = cls.env["account.journal"].search(
+            [("type", "=", "bank"), ("company_id", "=", cls.company.id)], limit=1
+        )
+
+        # Ensure we found the required journals for testing
+        if not cls.demo_journal_cash:
+            raise ValueError(
+                "No cash journal found for company %s. Cannot run cashbox bundle tests." % cls.company.name
+            )
+        if not cls.demo_journal_bank:
+            raise ValueError(
+                "No bank journal found for company %s. Cannot run cashbox bundle tests." % cls.company.name
+            )
+
+        # Use the bundle journal created by l10n_ar_payment_bundle
+        cls.demo_journal_bundle = chart.ref("payment_bundle_journal")
+        cls.demo_cashbox = chart.ref("demo_cashbox_main")
+
+    def test_bundle_journal_not_in_cashbox_domain(self):
+        """
+        Test Case 1: Bundle journals should not be selectable in cashbox configuration
+        Validates that journals with payment_bundle method are excluded from journal_ids domain
+        """
+        # Get the domain from the field definition
+        journal_field = self.env["account.cashbox"]._fields["journal_ids"]
+        domain = journal_field.domain
+
+        # Apply domain to search journals
+        if callable(domain):
+            domain = domain(self.env["account.cashbox"])
+
+        available_journals = self.env["account.journal"].search(domain)
+
+        # Verify bundle journal is NOT in available journals
+        self.assertNotIn(
+            self.demo_journal_bundle,
+            available_journals,
+            "Bundle journal should not be available in cashbox configuration",
+        )
+
+        # Verify regular cash/bank journals ARE available
+        self.assertIn(
+            self.demo_journal_cash,
+            available_journals,
+            "Regular cash journal should be available in cashbox configuration",
+        )
+        self.assertIn(
+            self.demo_journal_bank,
+            available_journals,
+            "Regular bank journal should be available in cashbox configuration",
+        )
+
+    def test_main_payment_no_cashbox_session_required(self):
+        """
+        Test Case 2 & 3: Main payment (bundle) should not require cashbox session
+        Child payments should require cashbox session if user requires it
+        """
+        # Create main payment (bundle payment)
+        main_payment = (
+            self.env["account.payment"]
+            .with_user(self.demo_user_cashbox)
+            .create(
+                {
+                    "payment_type": "outbound",
+                    "partner_id": self.demo_partner.id,
+                    "amount": 0,
+                    "journal_id": self.demo_journal_bundle.id,
+                    "payment_method_line_id": self.env["account.payment.method.line"]
+                    .search(
+                        [
+                            ("journal_id", "=", self.demo_journal_bundle.id),
+                            ("payment_method_id.code", "=", "payment_bundle"),
+                        ],
+                        limit=1,
+                    )
+                    .id,
+                }
+            )
+        )
+
+        # Verify it's marked as main payment
+        self.assertTrue(main_payment.is_main_payment, "Payment with bundle method should be marked as main payment")
+
+        # Verify main payment does NOT require cashbox session
+        self.assertFalse(
+            main_payment.requiere_account_cashbox_session, "Main payment (bundle) should not require cashbox session"
+        )
+
+        # Create a child payment linked to main payment
+        child_payment = (
+            self.env["account.payment"]
+            .with_user(self.demo_user_cashbox)
+            .create(
+                {
+                    "payment_type": "outbound",
+                    "partner_id": self.demo_partner.id,
+                    "amount": 100.0,
+                    "journal_id": self.demo_journal_cash.id,
+                    "main_payment_id": main_payment.id,
+                }
+            )
+        )
+
+        # Verify child payment is NOT a main payment
+        self.assertFalse(child_payment.is_main_payment, "Child payment should not be marked as main payment")
+
+        # Verify child payment DOES require cashbox session (user has requiere_account_cashbox_session = True)
+        self.assertTrue(
+            child_payment.requiere_account_cashbox_session,
+            "Child payment should require cashbox session when user requires it",
+        )
+
+    def test_bundle_only_withholdings_no_session_required(self):
+        """
+        Test Case 3: Bundle payment with only withholdings (is_main_payment) doesn't require session
+        This is the same as test_main_payment_no_cashbox_session_required because withholdings
+        are only added to main payments, not to child payments
+        """
+        # Create main payment (which could have only withholdings)
+        main_payment_withholdings = (
+            self.env["account.payment"]
+            .with_user(self.demo_user_cashbox)
+            .create(
+                {
+                    "payment_type": "outbound",
+                    "partner_id": self.demo_partner.id,
+                    "amount": 0,  # Main payment amount is always 0
+                    "journal_id": self.demo_journal_bundle.id,
+                    "payment_method_line_id": self.env["account.payment.method.line"]
+                    .search(
+                        [
+                            ("journal_id", "=", self.demo_journal_bundle.id),
+                            ("payment_method_id.code", "=", "payment_bundle"),
+                        ],
+                        limit=1,
+                    )
+                    .id,
+                }
+            )
+        )
+
+        # Verify it doesn't require cashbox session (even if it only has withholdings)
+        self.assertFalse(
+            main_payment_withholdings.requiere_account_cashbox_session,
+            "Bundle payment with only withholdings should not require cashbox session",
+        )
+
+    def test_user_without_session_requirement(self):
+        """
+        Additional test: Verify that without requiere_account_cashbox_session,
+        both main and child payments don't require session
+        """
+        # Create a regular user without session requirement
+        regular_user = self.env["res.users"].create(
+            {
+                "name": "Regular User",
+                "login": "regular_user",
+                "email": "regular@test.com",
+                "requiere_account_cashbox_session": False,
+                "company_id": self.company.id,
+                "company_ids": [(4, self.company.id)],
+            }
+        )
+
+        # Create payments with this user
+        main_payment = (
+            self.env["account.payment"]
+            .with_user(regular_user)
+            .create(
+                {
+                    "payment_type": "outbound",
+                    "partner_id": self.demo_partner.id,
+                    "amount": 0,
+                    "journal_id": self.demo_journal_bundle.id,
+                    "company_id": self.company.id,
+                    "payment_method_line_id": self.env["account.payment.method.line"]
+                    .search(
+                        [
+                            ("journal_id", "=", self.demo_journal_bundle.id),
+                            ("payment_method_id.code", "=", "payment_bundle"),
+                        ],
+                        limit=1,
+                    )
+                    .id,
+                }
+            )
+        )
+
+        child_payment = (
+            self.env["account.payment"]
+            .with_user(regular_user)
+            .create(
+                {
+                    "payment_type": "outbound",
+                    "partner_id": self.demo_partner.id,
+                    "amount": 100.0,
+                    "journal_id": self.demo_journal_cash.id,
+                    "main_payment_id": main_payment.id,
+                    "company_id": self.company.id,
+                }
+            )
+        )
+
+        # Neither should require session
+        self.assertFalse(
+            main_payment.requiere_account_cashbox_session,
+            "Main payment should not require session when user doesn't require it",
+        )
+        self.assertFalse(
+            child_payment.requiere_account_cashbox_session,
+            "Child payment should not require session when user doesn't require it",
+        )

--- a/account_cashbox_bundle/views/account_payment.xml
+++ b/account_cashbox_bundle/views/account_payment.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_account_payment_form" model="ir.ui.view">
+        <field name="name">account.payment.form</field>
+        <field name="model">account.payment</field>
+        <field name="inherit_id" ref="account.view_account_payment_form"/>
+        <field name="arch" type="xml">
+                <field name="cashbox_session_id" position="attributes">
+                    <attribute name="invisible">is_main_payment</attribute>
+                </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Add new technical bridge module to handle cashbox session requirements for payment bundles.

Features:
* Prevent bundle journals from being selected in cashbox configuration
* Main payments (payment bundles) don't require cashbox session
* Child payments still require cashbox session as configured
* Hide cashbox_session_id field for main payments in UI

Technical improvements in account_cashbox:
* Use computed field requiere_account_cashbox_session in action_post instead of direct user field access for better extensibility

Use cases covered:
- Bundle journals excluded from cashbox configuration domain
- Main payment created: no session required
- Child payments created: session required if user requires it
- Bundle with only withholdings: no session required (main payment)