### PR TITLE
[MOV] account_payment_pro: move template fix from saas_client_account

### DIFF
--- a/account_payment_pro/__init__.py
+++ b/account_payment_pro/__init__.py
@@ -1,2 +1,54 @@
 from . import models
 from . import wizards
+
+
+def _update_payment_receipt_template(env):
+    template = env.ref("account.mail_template_data_payment_receipt", raise_if_not_found=False)
+    if template:
+        template.write(
+            {
+                "body_html": """<div style="margin: 0px; padding: 0px;">
+                                <p style="margin: 0px; padding: 0px; font-size: 13px;">
+                                    Dear <t t-out="object.partner_id.name or ''">Azure Interior</t><br/><br/>
+                                    Thank you for your payment.
+                                    Here is your payment receipt <span style="font-weight:bold;" t-out="(object.name or '').replace('/','-') or ''">BNK1-2021-05-0002</span> amounting
+                                    to <span style="font-weight:bold;" t-out="format_amount(object.payment_total, object.currency_id) or ''">$ 10.00</span> from <t t-out="object.company_id.name or ''">YourCompany</t>.
+                                    <br/><br/>
+                                    Do not hesitate to contact us if you have any questions.
+                                    <br/><br/>
+                                    Best regards,
+                                    <t t-if="not is_html_empty(user.signature)">
+                                        <br/><br/>
+                                        <t t-out="user.signature or ''">--<br/>Mitchell Admin</t>
+                                    </t>
+                                </p>
+                            </div>
+                            """,
+            }
+        )
+        text_es = """<div style="margin: 0px; padding: 0px;">
+                                <p style="margin: 0px; padding: 0px; font-size: 13px;">
+                                    Apreciable <t t-out="object.partner_id.name or ''">Azure Interior</t><br/><br/>
+                                    Gracias por su pago.
+                                    Aquí está el recibo de su pago <span style="font-weight:bold;" t-out="(object.name or '').replace('/','-') or ''">BNK1-2021-05-0002</span> por un total
+                                    de <span style="font-weight:bold;" t-out="format_amount(object.payment_total, object.currency_id) or ''">$ 10.00</span> de <t t-out="object.company_id.name or ''">SuEmpresa</t>.
+                                    <br/><br/>
+                                    No dude en contactarnos si tiene alguna pregunta.
+                                    <br/><br/>
+                                    Saludos,
+                                    <t t-if="not is_html_empty(user.signature)">
+                                        <br/><br/>
+                                        <t t-out="user.signature or ''">--<br/>Mitchell Admin</t>
+                                    </t>
+                                </p>
+                            </div>
+                            """
+
+        if env["res.lang"].search([("code", "=", "es_419")]):
+            template.with_context(lang="es_419").write({"body_html": text_es})
+        if env["res.lang"].search([("code", "=", "es_AR")]):
+            template.with_context(lang="es_AR").write({"body_html": text_es})
+
+
+def _post_init_hooks(env):
+    _update_payment_receipt_template(env)

--- a/account_payment_pro/__manifest__.py
+++ b/account_payment_pro/__manifest__.py
@@ -29,4 +29,5 @@
         "views/res_company_setting.xml",
     ],
     "demo": [],
+    "post_init_hook": "_post_init_hooks",
 }

--- a/account_payment_pro/models/__init__.py
+++ b/account_payment_pro/models/__init__.py
@@ -5,3 +5,4 @@ from . import account_journal
 from . import res_company
 from . import res_config_setting
 from . import account_write_off_type
+from . import base_language_install

--- a/account_payment_pro/models/base_language_install.py
+++ b/account_payment_pro/models/base_language_install.py
@@ -1,0 +1,34 @@
+from odoo import models
+
+
+class BaseLanguageInstall(models.TransientModel):
+    _inherit = "base.language.install"
+
+    def lang_install(self):
+        res = super().lang_install()
+
+        es_langs = self.lang_ids.filtered(lambda x: x.code in ["es_419", "es_AR"])
+        if es_langs:
+            template = self.env.ref("account.mail_template_data_payment_receipt", raise_if_not_found=False)
+            if template:
+                text_es = """<div style="margin: 0px; padding: 0px;">
+                                <p style="margin: 0px; padding: 0px; font-size: 13px;">
+                                    Apreciable <t t-out="object.partner_id.name or ''">Azure Interior</t><br/><br/>
+                                    Gracias por su pago.
+                                    Aquí está el recibo de su pago <span style="font-weight:bold;" t-out="(object.name or '').replace('/','-') or ''">BNK1-2021-05-0002</span> por un total
+                                    de <span style="font-weight:bold;" t-out="format_amount(object.payment_total, object.currency_id) or ''">$ 10.00</span> de <t t-out="object.company_id.name or ''">SuEmpresa</t>.
+                                    <br/><br/>
+                                    No dude en contactarnos si tiene alguna pregunta.
+                                    <br/><br/>
+                                    Saludos,
+                                    <t t-if="not is_html_empty(user.signature)">
+                                        <br/><br/>
+                                        <t t-out="user.signature or ''">--<br/>Mitchell Admin</t>
+                                    </t>
+                                </p>
+                            </div>
+                            """
+                for lang in es_langs:
+                    template.with_context(lang=lang.code).write({"body_html": text_es})
+
+        return res


### PR DESCRIPTION
This commit https://github.com/ingadhoc/odoo-saas-adhoc/commit/b1c5ebe5291c83a728b8770fe7410238d53a1949 changed the payment receipt template to use 'payment_total' instead of 'amount' to include withholdings The change was made in saas_client_account but it should be in account_payment_pro because that field is defined in payment_pro.