### PR TITLE
[FIX] l10n_ar_payment_bundle: Make counterpart currency readonly in l…

### DIFF
--- a/l10n_ar_payment_bundle/views/account_payment_view.xml
+++ b/l10n_ar_payment_bundle/views/account_payment_view.xml
@@ -112,6 +112,9 @@
             <button name="action_post_and_new" position="attributes">
                 <attribute name="invisible">1</attribute>
             </button>
+            <field name="counterpart_currency_id" position="attributes">
+                <attribute name="readonly" separator=" or " add="main_payment_id"/>
+            </field>
             <button name="button_open_journal_entry" position="attributes">
                 <attribute name="invisible" separator=" and " add="not show_move_button"></attribute>
             </button>


### PR DESCRIPTION
…inked payments

When the payment is part of a payment bundle, the counterpart currency should not be editable as it is determined by the main payment. This commit adds a readonly attribute to the counterpart_currency field when the payment is linked to a main payment.