### PR TITLE
[IMP] l10n_ar_payment_bundle: enforce payment/move journal consistency

### DIFF
--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -680,3 +680,9 @@ class AccountPayment(models.Model):
     @api.depends("journal_id")
     def _compute_available_partner_bank_ids(self):
         super()._compute_available_partner_bank_ids()
+
+    @api.constrains("journal_id", "move_id")
+    def _check_payment_move_journal_consistency(self):
+        for rec in self.filtered(lambda x: x.move_id and x.move_id.state not in ["draft", "cancel"]):
+            if rec.journal_id != rec.move_id.journal_id:
+                raise ValidationError(_("The payment journal must match the journal of its journal entry."))


### PR DESCRIPTION
Add a defensive constraint on account.payment to prevent journal mismatches between a payment and its journal entry.

- Add _check_payment_move_journal_consistency in l10n_ar_payment_bundle
- Validate that journal_id == move_id.journal_id when move_id exists
- Raise a clear ValidationError when an inconsistent write is attempted

This prevents edge cases where a payment journal is modified (e.g. by custom writes/imports) without keeping the linked move journal in sync.