### PR TITLE
[FIX] account_cashbox: validate session only for draft payments

### DIFF
--- a/account_cashbox/models/account_payment.py
+++ b/account_cashbox/models/account_payment.py
@@ -54,7 +54,7 @@ class AccountPayment(models.Model):
         super(AccountPayment, self.with_context(paired_transfer=True))._create_paired_internal_transfer_payment()
 
     def action_post(self):
-        for rec in self:
+        for rec in self.filtered(lambda x: x.state == "draft"):
             if not rec.cashbox_session_id and rec.requiere_account_cashbox_session:
                 rec._compute_cashbox_session_id()
             elif rec.cashbox_session_id and rec.cashbox_session_id.state != "opened":


### PR DESCRIPTION
Restrict cashbox session validation in action_post to payments in the 'draft' state. This prevents a UserError when _compute_state triggers action_post to move an in_process payment to paid after its original session has already been closed.