### PR TITLE
[IMP] l10n_ar_payment_bundle: broaden AR company detection to country…

### DIFF
--- a/l10n_ar_payment_bundle/__init__.py
+++ b/l10n_ar_payment_bundle/__init__.py
@@ -3,8 +3,7 @@ from . import models
 
 def post_init_hook(env):
     """Existing companies that have the Argentinean Chart of Accounts set"""
-    template_codes = ["ar_ri", "ar_ex", "ar_base"]
-    ar_companies = env["res.company"].search([("chart_template", "in", template_codes), ("parent_id", "=", False)])
+    ar_companies = env["res.company"].search([("partner_id.country_id.code", "=", "AR"), ("parent_id", "=", False)])
     for company in ar_companies:
         template_code = company.chart_template
         ChartTemplate = env["account.chart.template"].with_company(company)

--- a/l10n_ar_payment_bundle/models/account_chart_template.py
+++ b/l10n_ar_payment_bundle/models/account_chart_template.py
@@ -7,7 +7,7 @@ class AccountChartTemplate(models.AbstractModel):
 
     @template(model="account.journal")
     def _get_payment_bundle_account_journal(self, template_code):
-        if self.env.company.country_code == "AR" and template_code in ["ar_ri", "ar_ex", "ar_base"]:
+        if self.env.company.country_code == "AR":
             return {
                 "payment_bundle_journal": {
                     "name": _("Multiple payments"),


### PR DESCRIPTION
… code

Use partner country code (AR) instead of specific chart of accounts template codes (ar_ri, ar_ex, ar_base) to detect Argentine companies, both in the post_init_hook and in the payment bundle journal template.

This ensures the payment bundle journal is created for all Argentine companies regardless of which chart of accounts they use.