### PR TITLE
[IMP] account_payment_pro, bundle: fix payment pro form

### DIFF
--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -163,8 +163,17 @@ class AccountPayment(models.Model):
         # Seteamos posted_before en true para que nos permita pasar a borrador el pago y poder realizar cambio sobre el mismo
         # Nos salteamos la siguente validacion
         # https://github.com/odoo/odoo/blob/b6b90636938ae961c339807ea893cabdede9f549/addons/account/models/account_move.py#L2474
-        if self.company_id.use_payment_pro:
-            self.move_id.posted_before = False
+
+        for rec in self.filtered(lambda p: p.company_id.use_payment_pro):
+            rec.move_id.posted_before = False
+
+            # Al pasar a borrador un pago, eliminamos las conciliaciones parciales que tenga.
+            valid_account_types = rec._get_valid_payment_account_types()
+            payment_lines = rec.move_id.line_ids.filtered(lambda l: l.account_id.account_type in valid_account_types)
+            partials = payment_lines.mapped("matched_debit_ids") | payment_lines.mapped("matched_credit_ids")
+            if partials:
+                partials.unlink()
+
         super().action_draft()
 
     def write(self, vals):

--- a/account_payment_pro/tests/test_account_paymet_pro_unit_test.py
+++ b/account_payment_pro/tests/test_account_paymet_pro_unit_test.py
@@ -88,3 +88,74 @@ class TestAccountPaymentProUnitTest(common.TransactionCase):
         payment._compute_amount_company_currency()
         payment.action_post()
         self.assertEqual(payment.exchange_rate, eur_actual_rate_2, "no se tomo de forma correcta el tipo de cambio")
+
+    def test_action_draft_unreconciles_payment(self):
+        """Test that action_draft removes partial reconciliations when going back to draft"""
+        # Create invoice
+        invoice = self.env["account.move"].create(
+            {
+                "partner_id": self.partner_ri.id,
+                "invoice_date": self.today,
+                "move_type": "out_invoice",
+                "journal_id": self.company_journal.id,
+                "company_id": self.company.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.env.ref("product.product_product_16").id,
+                            "quantity": 1,
+                            "price_unit": 100,
+                        }
+                    ),
+                ],
+            }
+        )
+        invoice.action_post()
+
+        # Create and post payment
+        vals = {
+            "journal_id": self.company_bank_journal.id,
+            "amount": invoice.amount_total,
+            "date": self.today,
+        }
+        action_context = invoice.action_register_payment()["context"]
+        payment = self.env["account.payment"].with_context(**action_context).create(vals)
+        payment.action_post()
+
+        # Get payment lines and verify there are partial reconciliations
+        payment_lines = payment.move_id.line_ids.filtered(
+            lambda l: l.account_id.account_type in payment._get_valid_payment_account_types()
+        )
+        partials_before = payment_lines.mapped("matched_debit_ids") | payment_lines.mapped("matched_credit_ids")
+
+        # Verify that partial reconciliations exist
+        self.assertTrue(partials_before, "There should be partial reconciliations after posting the payment")
+        self.assertTrue(payment.move_id.posted_before, "posted_before should be True after posting")
+
+        # Store the payment_total before going to draft (to verify it's not reset to 0)
+        payment_total_before = payment.payment_total
+
+        # Call action_draft
+        payment.action_draft()
+
+        # Verify that posted_before is False
+        self.assertFalse(payment.move_id.posted_before, "posted_before should be False after action_draft")
+
+        # Verify that payment_total is preserved after action_draft (regression check)
+        self.assertEqual(
+            payment.payment_total,
+            payment_total_before,
+            f"payment_total should remain {payment_total_before} after action_draft, not reset to 0",
+        )
+
+        # Verify that partial reconciliations were removed
+        payment_lines_after = payment.move_id.line_ids.filtered(
+            lambda l: l.account_id.account_type in payment._get_valid_payment_account_types()
+        )
+        partials_after = payment_lines_after.mapped("matched_debit_ids") | payment_lines_after.mapped(
+            "matched_credit_ids"
+        )
+        self.assertFalse(partials_after, "Partial reconciliations should be removed after action_draft")
+
+        # Verify payment is in draft state
+        self.assertEqual(payment.state, "draft", "Payment should be in draft state after action_draft")

--- a/account_payment_pro/views/account_payment_view.xml
+++ b/account_payment_pro/views/account_payment_view.xml
@@ -29,10 +29,23 @@
             <attribute name="readonly">state != 'draft' or context.get('default_company_id')</attribute>
         </xpath>
 
-
         <field name="partner_id" position="before">
             <field name="company_id" options="{'no_create': True}" domain="[('id', 'in', allowed_company_ids)]" groups="base.group_multi_company" readonly="state != 'draft' or context.get('default_company_id')"/>
         </field>
+
+        <xpath expr="//field[@name='partner_id'][2]" position="after">
+            <field name="partner_bank_id" string="Customer Bank Account" context="{'default_partner_id': partner_id, 'display_account_trust': True}" invisible="(not show_partner_bank_account or partner_type != 'customer' or payment_type == 'inbound') or (is_internal_transfer)" required="(require_partner_bank_account) and (not is_internal_transfer)"/>
+            <field name="partner_bank_id" string="Vendor Bank Account" context="{'default_partner_id': partner_id, 'display_account_trust': True}" invisible="(not show_partner_bank_account or partner_type != 'supplier' or payment_type == 'inbound') or (is_internal_transfer)" required="(require_partner_bank_account) and (not is_internal_transfer)"/>
+        </xpath>
+
+        <!-- Hide original partner_bank_id fields from group2 -->
+        <xpath expr="//group[@name='group2']//field[@name='partner_bank_id'][1]" position="attributes">
+            <attribute name="invisible">1</attribute>
+        </xpath>
+        <xpath expr="//group[@name='group2']//field[@name='partner_bank_id'][2]" position="attributes">
+            <attribute name="invisible">1</attribute>
+        </xpath>
+
 
         <!-- movemos amount a la columna 2 para que quede todo lo relativo al metodo de pago junto -->
         <group name="group2">

--- a/l10n_ar_payment_bundle/models/account_payment.py
+++ b/l10n_ar_payment_bundle/models/account_payment.py
@@ -1,3 +1,5 @@
+import re
+
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 from odoo.fields import Command
@@ -161,10 +163,22 @@ class AccountPayment(models.Model):
 
         res = super(AccountPayment, self).action_post()
 
-        start_number = len(self.link_payment_ids.filtered(lambda x: x.name is not False))
-        for i, payment in enumerate(self.link_payment_ids, start=start_number):
-            if not payment.name:
-                payment.name = f"{self.name} ({i + 1})"
+        # Determine the starting suffix number based on the highest numeric
+        # suffix already present in linked payment names (e.g. "PAY00003 (2)").
+        existing_names = self.link_payment_ids.mapped("name")
+        pattern = re.compile(r"\((\d+)\)\s*$")
+        suffix_nums = [int(m.group(1)) for n in existing_names if n for m in [pattern.search(n)] if m]
+        if suffix_nums:
+            starting_suffix = max(suffix_nums)
+        else:
+            # Si no hay sufijos numéricos, arrancamos a partir de la cantidad de nombres no vacíos.
+            starting_suffix = len([n for n in existing_names if n])
+
+        next_num = starting_suffix + 1
+        unnamed_payments = self.link_payment_ids.filtered(lambda p: not p.name)
+        for payment in unnamed_payments:
+            payment.name = f"{self.name} ({next_num})"
+            next_num += 1
 
         draft_linked = self.link_payment_ids.filtered(lambda x: x.state == "draft")
         if draft_linked:


### PR DESCRIPTION
- When using account_payment_pro, if a payment is reconciled and we send it back to draft, we need to unreconcile it first. Otherwise, the payment total resets to 0
- When posting a payment with linked payments, the suffix number in the linked payment
names was calculated based on the count of existing named linked payments.
This could lead to suffix duplication if some linked payments had their name cleared.
- Move the vendor bank account field below partner_id