### PR TITLE
[FIX] l10n_ar_payment_bundle: Disallow bundle journals in internal transfers

### DIFF
--- a/l10n_ar_payment_bundle/models/account_payment.py
+++ b/l10n_ar_payment_bundle/models/account_payment.py
@@ -101,21 +101,13 @@ class AccountPayment(models.Model):
             journals = rec.available_journal_ids
 
             # If it's a linked payment remove only the bundle journal (any currency allowed)
-            if rec.main_payment_id:
-                journals = journals.filtered(lambda j: j._origin.id != bundle_journal_id)
-            # Internal transfers cannot use journals configured with payment bundle methods.
-            elif rec.is_internal_transfer:
-                journals = journals.filtered(lambda j: j._origin.id != bundle_journal_id)
-            # If company doesn't use Payment Pro just remove bundle journal
-            elif not rec.use_payment_pro:
+            if rec.main_payment_id or rec.is_main_payment or not rec.use_payment_pro:
                 journals = journals.filtered(lambda j: j._origin.id != bundle_journal_id)
 
             rec.available_journal_ids = journals
 
     def _compute_destination_journal_domain(self):
-        parent = super(AccountPayment, self)
-        if hasattr(parent, "_compute_destination_journal_domain"):
-            parent._compute_destination_journal_domain()
+        super()._compute_destination_journal_domain()
 
         for rec in self.filtered(lambda p: p.is_internal_transfer and p.destination_company_id):
             bundle_journal_id = rec.company_id._get_bundle_journal(rec.payment_type)

--- a/l10n_ar_payment_bundle/models/account_payment.py
+++ b/l10n_ar_payment_bundle/models/account_payment.py
@@ -2,7 +2,7 @@ import re
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
-from odoo.fields import Command
+from odoo.fields import Command, Domain
 
 
 class AccountPayment(models.Model):
@@ -90,7 +90,7 @@ class AccountPayment(models.Model):
         for rec in main_payment_ids:
             rec.link_payments_total = sum(rec.link_payment_ids.mapped("payment_total"))
 
-    @api.depends("use_payment_pro", "main_payment_id")
+    @api.depends("use_payment_pro", "main_payment_id", "is_internal_transfer")
     def _compute_available_journal_ids(self):
         super()._compute_available_journal_ids()
         for rec in self:
@@ -103,11 +103,28 @@ class AccountPayment(models.Model):
             # If it's a linked payment remove only the bundle journal (any currency allowed)
             if rec.main_payment_id:
                 journals = journals.filtered(lambda j: j._origin.id != bundle_journal_id)
+            # Internal transfers cannot use journals configured with payment bundle methods.
+            elif rec.is_internal_transfer:
+                journals = journals.filtered(lambda j: j._origin.id != bundle_journal_id)
             # If company doesn't use Payment Pro just remove bundle journal
             elif not rec.use_payment_pro:
                 journals = journals.filtered(lambda j: j._origin.id != bundle_journal_id)
 
             rec.available_journal_ids = journals
+
+    def _compute_destination_journal_domain(self):
+        parent = super(AccountPayment, self)
+        if hasattr(parent, "_compute_destination_journal_domain"):
+            parent._compute_destination_journal_domain()
+
+        for rec in self.filtered(lambda p: p.is_internal_transfer and p.destination_company_id):
+            bundle_journal_id = rec.company_id._get_bundle_journal(rec.payment_type)
+            if not bundle_journal_id:
+                continue
+
+            rec.destination_journal_domain = Domain(rec.destination_journal_domain or []) & Domain(
+                [("id", "!=", bundle_journal_id)]
+            )
 
     @api.depends("main_payment_id.to_pay_move_line_ids")
     def _compute_to_pay_move_lines(self):

--- a/l10n_ar_payment_bundle/wizard/__init__.py
+++ b/l10n_ar_payment_bundle/wizard/__init__.py
@@ -1,2 +1,3 @@
 from . import account_resequence
 from . import payment_rename
+from . import l10n_latam_payment_mass_transfer

--- a/l10n_ar_payment_bundle/wizard/l10n_latam_payment_mass_transfer.py
+++ b/l10n_ar_payment_bundle/wizard/l10n_latam_payment_mass_transfer.py
@@ -1,0 +1,35 @@
+from odoo import api, fields, models
+
+
+class L10nLatamPaymentMassTransfer(models.TransientModel):
+    _inherit = "l10n_latam.payment.mass.transfer"
+
+    destination_journal_domain = fields.Json(
+        compute="_compute_destination_journal_domain",
+        readonly=True,
+    )
+
+    destination_journal_id = fields.Many2one(
+        domain="destination_journal_domain",
+    )
+
+    @api.depends("journal_id", "company_id")
+    def _compute_destination_journal_domain(self):
+        """Exclude bundle journals from destination journal selection."""
+        for rec in self:
+            base_domain = [
+                ("type", "in", ("bank", "cash")),
+                ("id", "!=", rec.journal_id.id),
+                ("company_id", "=", rec.company_id.id),
+            ]
+
+            # Exclude both inbound and outbound bundle journals
+            bundle_journal_inbound = rec.company_id._get_bundle_journal("inbound")
+            bundle_journal_outbound = rec.company_id._get_bundle_journal("outbound")
+
+            if bundle_journal_inbound:
+                base_domain.append(("id", "!=", bundle_journal_inbound))
+            if bundle_journal_outbound:
+                base_domain.append(("id", "!=", bundle_journal_outbound))
+
+            rec.destination_journal_domain = base_domain

--- a/l10n_latam_check_ux/models/account_payment.py
+++ b/l10n_latam_check_ux/models/account_payment.py
@@ -125,6 +125,14 @@ class AccountPayment(models.Model):
 
         super().action_draft()
 
+    def _is_latam_check_transfer(self):
+        self.ensure_one()
+        return super()._is_latam_check_transfer() or (
+            self.is_internal_transfer
+            and bool(self.l10n_latam_move_check_ids)
+            and self.destination_account_id == self.company_id.transfer_account_id
+        )
+
     @api.onchange("destination_journal_id")
     def _onchange_destination_journal_clear_move_checks(self):
         """When destination journal changes on an inbound internal transfer, remove checks
@@ -142,3 +150,35 @@ class AccountPayment(models.Model):
             )
             if invalid:
                 rec.l10n_latam_move_check_ids -= invalid
+
+    @api.constrains(
+        "is_internal_transfer",
+        "payment_type",
+        "payment_method_line_id",
+        "destination_journal_id",
+        "l10n_latam_move_check_ids",
+    )
+    def _check_inbound_transfer_checks_current_journal(self):
+        """Keep server-side behavior aligned with the wizard domain in Odoo.
+
+        For inbound internal transfers receiving third-party checks, all selected checks
+        must come from the same current journal: the source journal (`destination_journal_id`).
+        """
+        for rec in self.filtered(
+            lambda x: (
+                x.state == "draft"
+                and x.is_internal_transfer
+                and x.payment_type == "inbound"
+                and x.payment_method_line_id.code == "in_third_party_checks"
+                and x.destination_journal_id
+                and x.l10n_latam_move_check_ids
+            )
+        ):
+            invalid_checks = rec.l10n_latam_move_check_ids.filtered(
+                lambda c: c.current_journal_id != rec.destination_journal_id
+            )
+            if invalid_checks:
+                raise ValidationError(
+                    "All selected checks must belong to the source journal (%s)."
+                    % rec.destination_journal_id.display_name
+                )

--- a/l10n_latam_check_ux/models/account_payment.py
+++ b/l10n_latam_check_ux/models/account_payment.py
@@ -57,8 +57,10 @@ class AccountPayment(models.Model):
         # Who already create both payments at once in the _create_payments method.)
         if not self.env.context.get("check_deposit_transfer"):
             third_party_checks = self.filtered(
-                lambda x: x.payment_method_line_id.code
-                in ["in_third_party_checks", "out_third_party_checks", "return_third_party_checks"]
+                lambda x: (
+                    x.payment_method_line_id.code
+                    in ["in_third_party_checks", "out_third_party_checks", "return_third_party_checks"]
+                )
             )
             for rec in third_party_checks:
                 dest_payment_method_code = (
@@ -112,3 +114,21 @@ class AccountPayment(models.Model):
                     )
 
         super().action_draft()
+
+    @api.onchange("destination_journal_id")
+    def _onchange_destination_journal_clear_move_checks(self):
+        """When destination journal changes on an inbound internal transfer, remove checks
+        that are no longer in the (new) destination journal."""
+        for rec in self.filtered(
+            lambda x: (
+                x.is_internal_transfer
+                and x.payment_type == "inbound"
+                and x.payment_method_code == "in_third_party_checks"
+                and x.l10n_latam_move_check_ids
+            )
+        ):
+            invalid = rec.l10n_latam_move_check_ids.filtered(
+                lambda c: c.current_journal_id != rec.destination_journal_id
+            )
+            if invalid:
+                rec.l10n_latam_move_check_ids -= invalid

--- a/l10n_latam_check_ux/models/account_payment.py
+++ b/l10n_latam_check_ux/models/account_payment.py
@@ -85,12 +85,22 @@ class AccountPayment(models.Model):
                         ),
                     )._create_paired_internal_transfer_payment()
 
-                rec.write(
-                    {
-                        "l10n_latam_move_check_ids_operation_date": rec.l10n_latam_move_check_ids_operation_date
-                        - timedelta(seconds=1)
-                    }
-                )
+                # The outbound must have a greater operation_date than the inbound so it is
+                # identified as the latest operation. Subtract 1s from the inbound payment.
+                if rec.payment_type == "inbound":
+                    rec.write(
+                        {
+                            "l10n_latam_move_check_ids_operation_date": rec.l10n_latam_move_check_ids_operation_date
+                            + timedelta(minutes=1)
+                        }
+                    )
+                else:
+                    rec.write(
+                        {
+                            "l10n_latam_move_check_ids_operation_date": rec.l10n_latam_move_check_ids_operation_date
+                            - timedelta(minutes=1)
+                        }
+                    )
                 rec._get_latam_checks()._compute_current_journal()
                 rec._get_latam_checks()._compute_company_id()
 

--- a/l10n_latam_check_ux/models/account_payment.py
+++ b/l10n_latam_check_ux/models/account_payment.py
@@ -182,3 +182,64 @@ class AccountPayment(models.Model):
                     "All selected checks must belong to the source journal (%s)."
                     % rec.destination_journal_id.display_name
                 )
+
+    def _prepare_paired_payment_values(self):
+        """Override to validate check payment method combinations on internal transfers.
+
+        Rules:
+        - Third-party check outbounds must pair with third-party check inbounds
+        - Non-check payment methods cannot pair with check methods (except the above)
+        - Check outbound methods cannot be paired destinations
+        """
+        vals = super()._prepare_paired_payment_values()
+        if not self.is_internal_transfer:
+            return vals
+
+        paired_method_code = (
+            self.env["account.payment.method.line"].browse(vals.get("payment_method_line_id")).code
+            if vals.get("payment_method_line_id")
+            else None
+        )
+        source_method_code = self.payment_method_line_id.code
+
+        # Valid check method codes
+        check_inbound_codes = {"in_third_party_checks", "new_third_party_checks"}
+        check_outbound_codes = {"out_third_party_checks", "return_third_party_checks", "own_checks"}
+        all_check_codes = check_inbound_codes | check_outbound_codes
+
+        # Rule 1: Outbound third-party checks must pair with inbound third-party checks
+        if source_method_code == "out_third_party_checks":
+            if paired_method_code not in ["in_third_party_checks", "manual", "new_third_party_checks"]:
+                raise ValidationError(
+                    "When transferring third-party checks out (source: '%s'), "
+                    "the destination journal must have the 'Third Party Checks' inbound method. "
+                    "Please select a different destination journal." % self.payment_method_line_id.name
+                )
+
+        # Rule 2: Non-third-party-check outbounds cannot pair with any check method
+        elif source_method_code != "out_third_party_checks" and paired_method_code in all_check_codes:
+            raise ValidationError(
+                "The payment method '%s' cannot be paired with a check payment method. "
+                "To transfer checks, use a third-party checks journal as the source. "
+                "Please select a different destination journal."
+                % (
+                    self.env["account.payment.method.line"].browse(vals.get("payment_method_line_id")).name
+                    if vals.get("payment_method_line_id")
+                    else "None"
+                )
+            )
+
+        # Rule 3: Check outbound methods cannot be on the paired (destination) side
+        # (This catches edge cases where config might slip through)
+        if paired_method_code in check_outbound_codes:
+            raise ValidationError(
+                "Outbound check methods (%s) are not allowed on the destination journal. "
+                "Please configure the destination journal with appropriate inbound payment methods."
+                % (
+                    self.env["account.payment.method.line"].browse(vals.get("payment_method_line_id")).name
+                    if vals.get("payment_method_line_id")
+                    else "None"
+                )
+            )
+
+        return vals

--- a/l10n_latam_check_ux/models/l10n_latam_check.py
+++ b/l10n_latam_check_ux/models/l10n_latam_check.py
@@ -50,7 +50,7 @@ class l10nLatamAccountPaymentCheck(models.Model):
         return (
             (self.payment_id + self.operation_ids)
             .filtered(lambda x: x.state not in ["draft", "canceled"] and x.l10n_latam_move_check_ids_operation_date)
-            .sorted(key=lambda payment: (payment.l10n_latam_move_check_ids_operation_date))[-1:]
+            .sorted(key=lambda payment: payment.l10n_latam_move_check_ids_operation_date)[-1:]
         )
 
     @api.depends("payment_method_line_id.code", "payment_id.partner_id")

--- a/l10n_latam_check_ux/tests/__init__.py
+++ b/l10n_latam_check_ux/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_check_transfers

--- a/l10n_latam_check_ux/tests/test_check_transfers.py
+++ b/l10n_latam_check_ux/tests/test_check_transfers.py
@@ -1,0 +1,255 @@
+from odoo import Command, fields
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.exceptions import ValidationError
+from odoo.tests.common import tagged
+
+
+@tagged("post_install_l10n", "post_install", "-at_install")
+class TestL10nLatamCheckUxTransfers(AccountTestInvoicingCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.today = fields.Date.today()
+        cls.ar = ar = cls.env.ref("base.ar")
+
+        cls.company = cls.company_data["company"]
+        cls.company_bank_journal = cls.company_data["default_journal_bank"] or cls.env["account.journal"].search(
+            [("company_id", "=", cls.company.id), ("type", "=", "bank")], limit=1
+        )
+        cls.company_journal = cls.env["account.journal"].search(
+            [("company_id", "=", cls.company.id), ("type", "=", "sale")], limit=1
+        )
+        third_party_checks_journals = cls.env["account.journal"].search(
+            [
+                ("company_id", "=", cls.company.id),
+                ("inbound_payment_method_line_ids.code", "=", "in_third_party_checks"),
+                ("inbound_payment_method_line_ids.code", "=", "new_third_party_checks"),
+                (
+                    "outbound_payment_method_line_ids.code",
+                    "in",
+                    ("out_third_party_checks", "return_third_party_checks"),
+                ),
+            ]
+        )
+        if len(third_party_checks_journals) < 2:
+            inbound_account_id = cls.inbound_payment_method_line.payment_account_id.id
+            outbound_account_id = cls.outbound_payment_method_line.payment_account_id.id
+
+            def create_check_journal(name, code):
+                return cls.env["account.journal"].create(
+                    {
+                        "name": name,
+                        "code": code,
+                        "type": "cash",
+                        "company_id": cls.company.id,
+                        "inbound_payment_method_line_ids": [
+                            Command.create(
+                                {
+                                    "payment_method_id": cls.env.ref(
+                                        "l10n_latam_check.account_payment_method_new_third_party_checks"
+                                    ).id,
+                                    "name": "Receive Third Party Checks",
+                                    "payment_account_id": inbound_account_id,
+                                }
+                            ),
+                            Command.create(
+                                {
+                                    "payment_method_id": cls.env.ref(
+                                        "l10n_latam_check.account_payment_method_in_third_party_checks"
+                                    ).id,
+                                    "name": "Receive Existing Third Party Checks",
+                                    "payment_account_id": inbound_account_id,
+                                }
+                            ),
+                        ],
+                        "outbound_payment_method_line_ids": [
+                            Command.create(
+                                {
+                                    "payment_method_id": cls.env.ref(
+                                        "l10n_latam_check.account_payment_method_out_third_party_checks"
+                                    ).id,
+                                    "name": "Deliver Third Party Checks",
+                                    "payment_account_id": outbound_account_id,
+                                }
+                            )
+                        ],
+                    }
+                )
+
+            if len(third_party_checks_journals) == 0:
+                third_party_checks_journals |= create_check_journal("Third Party Checks", "TPC")
+                third_party_checks_journals |= create_check_journal("Rejected Third Party Checks", "RTC")
+            else:
+                third_party_checks_journals |= create_check_journal("Rejected Third Party Checks", "RTC")
+
+        cls.third_party_check_journal = third_party_checks_journals[:1]
+        cls.rejected_check_journal = third_party_checks_journals[1:2]
+
+        cls.assertTrue(cls.company_bank_journal.ids, "A bank journal is required to run this test")
+        cls.assertTrue(
+            cls.third_party_check_journal.ids, "Third party check journal was not created so we can run the tests"
+        )
+        cls.assertTrue(cls.rejected_check_journal.ids, "Rejected check journal was not created so we can run the tests")
+
+        outbound_method_commands = []
+        if not cls.company_bank_journal.outbound_payment_method_line_ids.filtered(
+            lambda method: method.code == "own_checks"
+        ):
+            outbound_method_commands.append(
+                Command.create(
+                    {
+                        "payment_method_id": cls.env.ref("l10n_latam_check.account_payment_method_own_checks").id,
+                        "name": "Own Checks",
+                        "payment_account_id": cls.outbound_payment_method_line.payment_account_id.id,
+                    }
+                )
+            )
+        if not cls.company_bank_journal.outbound_payment_method_line_ids.filtered(
+            lambda method: method.code == "out_third_party_checks"
+        ):
+            outbound_method_commands.append(
+                Command.create(
+                    {
+                        "payment_method_id": cls.env.ref(
+                            "l10n_latam_check.account_payment_method_out_third_party_checks"
+                        ).id,
+                        "name": "Rejected Check",
+                        "payment_account_id": cls.outbound_payment_method_line.payment_account_id.id,
+                    }
+                )
+            )
+        if outbound_method_commands:
+            cls.company_bank_journal.write({"outbound_payment_method_line_ids": outbound_method_commands})
+
+        if "use_payment_pro" in cls.company._fields:
+            cls.company.use_payment_pro = True
+        cls.eur_currency = cls.env["res.currency"].with_context(active_test=False).search([("name", "=", "EUR")])
+        cls.eur_currency.active = True
+        cls.partner_ri = cls.env["res.partner"].create(dict(name="RI Partner", vat="34278580484", country_id=ar.id))
+
+    def _create_third_party_check(self, journal, check_number):
+        payment = self.env["account.payment"].create(
+            {
+                "partner_id": self.partner_a.id,
+                "payment_type": "inbound",
+                "journal_id": journal.id,
+                "l10n_latam_new_check_ids": [
+                    Command.create(
+                        {
+                            "name": check_number,
+                            "payment_date": fields.Date.add(fields.Date.today(), months=1),
+                            "amount": 100.0,
+                        }
+                    )
+                ],
+                "payment_method_line_id": journal._get_available_payment_method_lines("inbound")
+                .filtered(lambda x: x.code == "new_third_party_checks")[:1]
+                .id,
+            }
+        )
+        payment.action_post()
+        return payment.l10n_latam_new_check_ids
+
+    def test_deposit_third_party_check_to_bank(self):
+        check = self._create_third_party_check(self.third_party_check_journal, "UX-DEP-0001")
+        bank_journal = self.company_bank_journal
+
+        self.env["l10n_latam.payment.mass.transfer"].with_context(
+            active_model="l10n_latam.check",
+            active_ids=check.ids,
+        ).create(
+            {
+                "destination_journal_id": bank_journal.id,
+            }
+        )._create_payments()
+
+        self.assertEqual(check.current_journal_id, bank_journal)
+
+    def test_bank_rejection_receives_in_rejected_journal(self):
+        check = self._create_third_party_check(self.third_party_check_journal, "UX-REJ-0001")
+        bank_journal = self.company_bank_journal
+
+        self.env["l10n_latam.payment.mass.transfer"].with_context(
+            active_model="l10n_latam.check",
+            active_ids=check.ids,
+        ).create(
+            {
+                "destination_journal_id": bank_journal.id,
+            }
+        )._create_payments()
+
+        self.env["l10n_latam.payment.mass.transfer"].with_context(
+            active_model="l10n_latam.check",
+            active_ids=check.ids,
+        ).create(
+            {
+                "destination_journal_id": self.rejected_check_journal.id,
+            }
+        )._create_payments()
+
+        last_operation = check._get_last_operation()
+        self.assertEqual(check.current_journal_id, self.rejected_check_journal)
+        self.assertEqual(last_operation.payment_type, "inbound")
+        self.assertEqual(last_operation.payment_method_line_id.code, "in_third_party_checks")
+
+    def test_internal_transfer_own_checks_bank_to_cash(self):
+        bank_journal = self.company_bank_journal
+        cash_journal = self.env["account.journal"].search(
+            [
+                ("company_id", "=", bank_journal.company_id.id),
+                ("type", "=", "cash"),
+            ],
+            limit=1,
+        )
+        self.assertTrue(cash_journal, "A cash journal is required to run this test")
+
+        own_checks_method = bank_journal._get_available_payment_method_lines("outbound").filtered(
+            lambda x: x.code == "own_checks"
+        )[:1]
+        self.assertTrue(own_checks_method, "Bank journal must have own_checks payment method")
+
+        payment = self.env["account.payment"].create(
+            {
+                "partner_id": self.partner_ri.id,
+                "payment_type": "outbound",
+                "journal_id": bank_journal.id,
+                "destination_journal_id": cash_journal.id,
+                "is_internal_transfer": True,
+                "payment_method_line_id": own_checks_method.id,
+                "l10n_latam_new_check_ids": [
+                    Command.create(
+                        {
+                            "payment_date": fields.Date.add(fields.Date.today(), months=1),
+                            "amount": 250.0,
+                        }
+                    )
+                ],
+            }
+        )
+        payment.action_post()
+
+        self.assertEqual(payment.payment_method_line_id.code, "own_checks")
+        self.assertTrue(payment.paired_internal_transfer_payment_id)
+        self.assertEqual(payment.paired_internal_transfer_payment_id.journal_id, cash_journal)
+
+    def test_inbound_internal_transfer_rejects_checks_from_other_current_journal(self):
+        check_on_hand = self._create_third_party_check(self.third_party_check_journal, "UX-MIX-0001")
+        check_rejected = self._create_third_party_check(self.rejected_check_journal, "UX-MIX-0002")
+
+        payment_method_in = self.rejected_check_journal._get_available_payment_method_lines("inbound").filtered(
+            lambda x: x.code == "in_third_party_checks"
+        )[:1]
+
+        with self.assertRaisesRegex(ValidationError, "All selected checks must belong to the source journal"):
+            self.env["account.payment"].create(
+                {
+                    "partner_id": self.partner_ri.id,
+                    "payment_type": "inbound",
+                    "is_internal_transfer": True,
+                    "journal_id": self.rejected_check_journal.id,
+                    "destination_journal_id": self.third_party_check_journal.id,
+                    "payment_method_line_id": payment_method_in.id,
+                    "l10n_latam_move_check_ids": [Command.set((check_on_hand | check_rejected).ids)],
+                    "amount": 200.0,
+                }
+            )

--- a/l10n_latam_check_ux/views/account_payment_view.xml
+++ b/l10n_latam_check_ux/views/account_payment_view.xml
@@ -17,6 +17,7 @@
                 'search_default_last_90_days': payment_method_code in ['in_third_party_checks', 'out_third_party_checks', 'return_third_party_checks'],
             }
             </attribute>
+            <attribute name="domain">[('payment_method_code', '=', 'new_third_party_checks'), ('current_journal_id', '=', journal_id), ('company_id', '=', company_id)] if payment_type == 'outbound' else [('payment_method_code', '=', 'new_third_party_checks'), ('current_journal_id', '=', destination_journal_id), ('company_id', '=', company_id)] if (is_internal_transfer and payment_type == 'inbound' and destination_journal_id) else [('id', '=', False)] if (is_internal_transfer and payment_type == 'inbound') else [('payment_method_code', '=', 'new_third_party_checks'), ('current_journal_id', '=', False), ('company_id', '=', company_id)]</attribute>
         </xpath>
         <xpath expr="//field[@name='l10n_latam_move_check_ids']/list[@name='existing_checks']" position="attributes">
             <attribute name="create">false</attribute>


### PR DESCRIPTION
- Exclude journals with payment method code `payment_bundle` from source journal candidates when `is_internal_transfer` is enabled.
- Exclude bundle journals from `destination_journal_id` domain for internal transfers.