### PR TITLE
[IMP] _payment_pro: auto-adjust amount on to_pay lines change

### DIFF
--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -883,6 +883,32 @@ class AccountPayment(models.Model):
             ):
                 rec.unreconciled_amount = rec.to_pay_amount - rec.selected_debt
 
+    @api.onchange("to_pay_move_line_ids")
+    def _onchange_to_pay_lines_adjust_amount(self):
+        """Ajustar amount para que payment_total cubra to_pay_amount a la tasa de hoy.
+        Cuando action_register_payment envía default_amount basado en amount_residual,
+        ese monto usa la tasa original de la factura, no la de hoy. Esto genera un
+        payment_difference que debe corregirse ajustando amount.
+        Aplica a todos los tipos de pago (clientes y proveedores).
+        """
+        for rec in self:
+            if not rec.use_payment_pro or rec.state != "draft":
+                continue
+            if not rec.to_pay_move_line_ids:
+                continue
+            if not rec.payment_difference or not rec.currency_id:
+                continue
+            # Convertir payment_difference (en B2) a moneda A (currency_id del pago)
+            if rec.counterpart_currency_id != rec.destination_currency_id:
+                # B1 ≠ B2 (reconcile): B2=C siempre → C→A = diff * accounting_rate
+                diff_in_a = rec.payment_difference * (rec.accounting_rate or 1.0)
+            else:
+                # B1 = B2: counterpart_rate = B1/A → A = diff / counterpart_rate
+                counterpart = rec.counterpart_rate or 1.0
+                diff_in_a = rec.payment_difference / counterpart if counterpart else rec.payment_difference
+            amount = rec.amount + diff_in_a
+            rec.amount = amount if amount > 0 else 0
+
     @api.onchange("company_id")
     def _onchange_company_id(self):
         if self._origin.company_id and self.company_id != self._origin.company_id and self.state == "draft":

--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -165,6 +165,13 @@ class AccountPayment(models.Model):
         compute="_compute_multi_currency_debt",
     )
 
+    amount_precision = fields.Float(
+        digits=(16, 12),
+        store=True,
+        readonly=False,
+        copy=False,
+    )
+
     @api.depends("to_pay_move_line_ids", "company_id.reconcile_on_company_currency")
     def _compute_multi_currency_debt(self):
         for rec in self:
@@ -359,6 +366,12 @@ class AccountPayment(models.Model):
                 rec.env["account.write_off.type"].search([("company_ids", "=", rec.company_id.id)], limit=1)
             )
 
+    @api.onchange("amount")
+    def _onchange_amount(self):
+        for rec in self:
+            if rec._origin.currency_id == rec.currency_id:
+                rec.amount_precision = 0
+
     @api.onchange("currency_id")
     def _onchange_currency_recompute_amount(self):
         """Al cambiar la moneda del diario, reconvertir amount a la nueva moneda A."""
@@ -368,20 +381,33 @@ class AccountPayment(models.Model):
             # por eso refleja la moneda real anterior (funciona en registros nuevos y
             # en cambios consecutivos A→B→C sin guardar, donde _origin no sirve).
             old_currency = rec.previous_currency_id
+            old_amount = rec.amount_precision if rec.amount_precision != 0 else rec.amount
+            # Si no hay previous_currency_id (primer onchange o registro guardado),
+            # intentar obtenerlo de _origin si existe
+            if not old_currency and rec._origin and rec._origin.id:
+                old_currency = rec._origin.currency_id
+
             # Actualizar para el próximo onchange antes de cualquier continue
             rec.previous_currency_id = new_currency
+
+            # Validaciones: solo convertir en draft y si hay monto
             if rec.state != "draft" or not rec.amount:
                 continue
             if not old_currency or old_currency == new_currency:
                 continue
-            rec.amount = abs(
+
+            # Convertir el monto de la moneda antigua a la nueva
+            amount = abs(
                 old_currency._convert(
-                    rec.amount,
+                    old_amount,
                     new_currency,
                     rec.company_id,
                     rec.date or fields.Date.context_today(rec),
+                    False,
                 )
             )
+            rec.amount = amount
+            rec.amount_precision = amount
 
     @api.constrains("to_pay_move_line_ids")
     def _check_to_pay_lines_account(self):
@@ -400,7 +426,7 @@ class AccountPayment(models.Model):
             currencies = rec.to_pay_move_line_ids.mapped("currency_id")
             if len(currencies) > 1:
                 raise ValidationError(
-                    _("All selected debt lines must have the same currency. " "Found: %s")
+                    _("All selected debt lines must have the same currency. Found: %s")
                     % ", ".join(currencies.mapped("name"))
                 )
 
@@ -478,8 +504,16 @@ class AccountPayment(models.Model):
         for rec in self:
             if rec.counterpart_currency_id and rec.counterpart_currency_id != rec.currency_id:
                 if rec.counterpart_rate:
+                    amount = (
+                        rec.amount
+                        if rec.counterpart_currency_id.is_zero(
+                            rec.counterpart_rate * (rec.amount - rec.amount_precision)
+                        )
+                        or rec.amount_precision == 0
+                        else rec.amount_precision
+                    )
                     # amount está en A, convertir a B1 usando counterpart_rate
-                    rec.counterpart_currency_amount = rec.amount * rec.counterpart_rate
+                    rec.counterpart_currency_amount = amount * rec.counterpart_rate
                 else:
                     rec.counterpart_currency_amount = 0.0
             else:
@@ -492,6 +526,11 @@ class AccountPayment(models.Model):
             if rec.counterpart_currency_id and not rec.counterpart_currency_id.is_zero(
                 rec.amount * rec.counterpart_rate - rec.counterpart_currency_amount
             ):
+                # NO aplicar redondeo para mantener precisión exacta del monto en ARS
+                # El amount en USD tendrá los decimales necesarios para que
+                # amount × counterpart_rate = counterpart_currency_amount (exacto)
+                # Ejemplo: 11,642.48 ARS ÷ 1,300 = 8.955753846... USD (sin redondear)
+                # Verificación: 8.955753846 × 1,300 = 11,642.48 ARS ✓ (sin diferencia)
                 rec.amount = rec.counterpart_currency_amount / rec.counterpart_rate if rec.counterpart_rate else 0
 
     @api.depends(
@@ -852,6 +891,33 @@ class AccountPayment(models.Model):
         for rec in self:
             rec.payment_difference = rec.to_pay_amount - rec.payment_total
 
+    def _get_payment_difference_in_currency_a(self):
+        """Convierte payment_difference (B2) a moneda A (currency_id del pago)."""
+        self.ensure_one()
+        if self.counterpart_currency_id != self.destination_currency_id:
+            # B1 ≠ B2 (reconcile): B2=C siempre → C→A = diff * accounting_rate
+            return self.payment_difference * (self.accounting_rate or 1.0)
+        else:
+            # B1 = B2: counterpart_rate = B1/A → A = diff / counterpart_rate
+            counterpart = self.counterpart_rate or 1.0
+            return self.payment_difference / counterpart if counterpart else self.payment_difference
+
+    def action_adjust_amount_for_difference(self):
+        """Ajusta amount para que payment_difference quede en cero."""
+        for rec in self:
+            if not rec.payment_difference:
+                continue
+            diff_in_a = rec._get_payment_difference_in_currency_a()
+            amount = rec.amount + diff_in_a
+            rec.amount = amount if amount > 0 else 0
+
+    def action_adjust_writeoff_for_difference(self):
+        """Ajusta write_off_amount para que payment_difference quede en cero."""
+        for rec in self:
+            if not rec.payment_difference:
+                continue
+            rec.write_off_amount += rec.payment_difference
+
     # En el pasado se contaba con to_pay_move_line_ids.amount_residual dentro de los depends,  y no deberiamos por cuestiones de performance, ya que ademas no era necesario
     @api.depends("to_pay_move_line_ids", "destination_currency_id", "payment_type")
     def _compute_selected_debt(self):
@@ -898,14 +964,7 @@ class AccountPayment(models.Model):
                 continue
             if not rec.payment_difference or not rec.currency_id:
                 continue
-            # Convertir payment_difference (en B2) a moneda A (currency_id del pago)
-            if rec.counterpart_currency_id != rec.destination_currency_id:
-                # B1 ≠ B2 (reconcile): B2=C siempre → C→A = diff * accounting_rate
-                diff_in_a = rec.payment_difference * (rec.accounting_rate or 1.0)
-            else:
-                # B1 = B2: counterpart_rate = B1/A → A = diff / counterpart_rate
-                counterpart = rec.counterpart_rate or 1.0
-                diff_in_a = rec.payment_difference / counterpart if counterpart else rec.payment_difference
+            diff_in_a = rec._get_payment_difference_in_currency_a()
             amount = rec.amount + diff_in_a
             rec.amount = amount if amount > 0 else 0
 
@@ -918,12 +977,7 @@ class AccountPayment(models.Model):
             return
         for check in self.l10n_latam_new_check_ids:
             if not check.amount:
-                # Convertir payment_difference (en B2) a moneda A
-                if self.counterpart_currency_id != self.destination_currency_id:
-                    diff_in_a = self.payment_difference * (self.accounting_rate or 1.0)
-                else:
-                    counterpart = self.counterpart_rate or 1.0
-                    diff_in_a = self.payment_difference / counterpart if counterpart else self.payment_difference
+                diff_in_a = self._get_payment_difference_in_currency_a()
                 if diff_in_a > 0:
                     check.amount = self.currency_id.round(diff_in_a)
 

--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -909,6 +909,24 @@ class AccountPayment(models.Model):
             amount = rec.amount + diff_in_a
             rec.amount = amount if amount > 0 else 0
 
+    @api.onchange("l10n_latam_new_check_ids")
+    def _onchange_new_check_default_amount(self):
+        """Al agregar un cheque nuevo, calcular su monto como la diferencia pendiente de pago."""
+        if not self.use_payment_pro or self.state != "draft":
+            return
+        if not self.to_pay_move_line_ids or not self.payment_difference:
+            return
+        for check in self.l10n_latam_new_check_ids:
+            if not check.amount:
+                # Convertir payment_difference (en B2) a moneda A
+                if self.counterpart_currency_id != self.destination_currency_id:
+                    diff_in_a = self.payment_difference * (self.accounting_rate or 1.0)
+                else:
+                    counterpart = self.counterpart_rate or 1.0
+                    diff_in_a = self.payment_difference / counterpart if counterpart else self.payment_difference
+                if diff_in_a > 0:
+                    check.amount = self.currency_id.round(diff_in_a)
+
     @api.onchange("company_id")
     def _onchange_company_id(self):
         if self._origin.company_id and self.company_id != self._origin.company_id and self.state == "draft":

--- a/account_payment_pro/views/account_payment_view.xml
+++ b/account_payment_pro/views/account_payment_view.xml
@@ -113,6 +113,8 @@
             <field name="accounting_rate_inverted" invisible="True"/>
             <!-- Campo técnico: round-trip de la moneda anterior para _onchange_currency_recompute_amount -->
             <field name="previous_currency_id" invisible="True"/>
+            <!-- Campo técnico: almacena amount con precisión completa (12 decimales) para conversiones exactas -->
+            <field name="amount_precision" invisible="True"/>
             <!-- Importe en moneda de contrapartida: visible si A != B -->
             <!-- TODO ver si encontramos una mejor opcion y/o podemos ponerle la negrita tmb al destination_currency_id -->
             <div class="o_row" invisible="currency_id == counterpart_currency_id" name="counterpart_currency_amount">
@@ -130,7 +132,18 @@
             <label for="payment_total" readonly="state != 'draft'" invisible="not use_payment_pro or is_internal_transfer"/>
             <div name="payment_total" invisible="not use_payment_pro or is_internal_transfer">
                 <field name="payment_total" class="oe_inline"/>
-                <span invisible="state != 'draft'" class="text-muted"> (difference <field name="payment_difference" class="oe_inline"/>)</span>
+                <span invisible="state != 'draft'" class="text-muted"> (difference <field name="payment_difference" class="oe_inline"/>
+                    <button name="action_adjust_amount_for_difference" type="object"
+                        class="btn btn-link btn-sm p-0 ms-1" title="Add the pending difference to the payment amount"
+                        invisible="not payment_difference or payment_method_code in ['in_third_party_checks', 'out_third_party_checks', 'new_third_party_checks', 'own_checks']">
+                        <i class="fa fa-arrow-left"/> Amount
+                    </button>
+                    <button name="action_adjust_writeoff_for_difference" type="object"
+                        class="btn btn-link btn-sm p-0 ms-1" title="Send the pending difference to write-off"
+                        invisible="not payment_difference or not write_off_available or payment_method_code in ['in_third_party_checks', 'out_third_party_checks', 'new_third_party_checks', 'own_checks']">
+                        <i class="fa fa-arrow-left"/> Write-off
+                    </button>
+                )</span>
             </div>
             <!-- Accounting rate: visible solo si A != C -->
             <label for="user_accounting_rate" string="Rate"


### PR DESCRIPTION
Cuando se registra un pago desde "Register Payment", el amount viaja en pesos calculados a la tasa de la factura. Si la tasa de hoy es distinta, el monto queda desactualizado y no cubre la deuda.

Se agrega _onchange_to_pay_lines_adjust_amount que recalcula amount usando payment_difference a la tasa actual. Funciona para cobros y pagos, con o sin l10n_ar_tax instalado.