### PR TITLE
[FIX] payment_pro: fix receive en suppliers, send on customers

### DIFF
--- a/account_payment_pro/i18n/account_payment_pro.pot
+++ b/account_payment_pro/i18n/account_payment_pro.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-01 20:27+0000\n"
-"PO-Revision-Date: 2026-04-01 20:27+0000\n"
+"POT-Creation-Date: 2026-04-02 14:06+0000\n"
+"PO-Revision-Date: 2026-04-02 14:06+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -93,6 +93,12 @@ msgid "All to pay lines must be of the same partner"
 msgstr ""
 
 #. module: account_payment_pro
+#: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__matched_amount
+#: model_terms:ir.ui.view,arch_db:account_payment_pro.latam_check_view_account_payment_form_inherited
+msgid "Allocated Amount"
+msgstr ""
+
+#. module: account_payment_pro
 #: model:res.groups,name:account_payment_pro.group_pay_now_customer_invoices
 msgid "Allow pay now on customer invoices"
 msgstr ""
@@ -147,6 +153,31 @@ msgid "Amount in"
 msgstr ""
 
 #. module: account_payment_pro
+#: model_terms:ir.ui.view,arch_db:account_payment_pro.view_account_payment_form
+msgid "Amount to Pay"
+msgstr ""
+
+#. module: account_payment_pro
+#: model_terms:ir.ui.view,arch_db:account_payment_pro.view_account_payment_form
+msgid "Amount to Receive"
+msgstr ""
+
+#. module: account_payment_pro
+#: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__selected_debt
+msgid "Amount to Reconcile"
+msgstr ""
+
+#. module: account_payment_pro
+#: model_terms:ir.ui.view,arch_db:account_payment_pro.view_account_payment_form
+msgid "Amount to Recover"
+msgstr ""
+
+#. module: account_payment_pro
+#: model_terms:ir.ui.view,arch_db:account_payment_pro.view_account_payment_form
+msgid "Amount to Refund"
+msgstr ""
+
+#. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment_invoice_wizard__analytic_distribution
 msgid "Analytic Distribution"
 msgstr ""
@@ -195,11 +226,6 @@ msgid "Confirm"
 msgstr ""
 
 #. module: account_payment_pro
-#: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__counterpart_currency_id
-msgid "Counterpart Currency"
-msgstr ""
-
-#. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__counterpart_currency_amount
 msgid "Counterpart Currency Amount"
 msgstr ""
@@ -243,17 +269,13 @@ msgstr ""
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment_invoice_wizard__currency_id
+#: model_terms:ir.ui.view,arch_db:account_payment_pro.latam_check_view_account_payment_form_inherited
 msgid "Currency"
 msgstr ""
 
 #. module: account_payment_pro
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.view_account_payment_form
 msgid "Customer Bank Account"
-msgstr ""
-
-#. module: account_payment_pro
-#: model_terms:ir.ui.view,arch_db:account_payment_pro.latam_check_view_account_payment_form_inherited
-msgid "Debt Currency"
 msgstr ""
 
 #. module: account_payment_pro
@@ -451,11 +473,6 @@ msgid "Manual Number"
 msgstr ""
 
 #. module: account_payment_pro
-#: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__matched_amount
-msgid "Matched Amount"
-msgstr ""
-
-#. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__matched_move_line_ids
 msgid "Matched Move Line"
 msgstr ""
@@ -474,6 +491,12 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_payment_pro/models/account_move_line.py:0
 msgid "Nothing to be paid on selected entries"
+msgstr ""
+
+#. module: account_payment_pro
+#: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__unmatched_amount
+#: model_terms:ir.ui.view,arch_db:account_payment_pro.latam_check_view_account_payment_form_inherited
+msgid "Open Balance"
 msgstr ""
 
 #. module: account_payment_pro
@@ -584,6 +607,11 @@ msgid "Reason"
 msgstr ""
 
 #. module: account_payment_pro
+#: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__counterpart_currency_id
+msgid "Reconciliation Currency"
+msgstr ""
+
+#. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment_invoice_wizard__invoice_date
 msgid "Refund Date"
 msgstr ""
@@ -612,11 +640,6 @@ msgstr ""
 #. module: account_payment_pro
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.view_move_line_tree
 msgid "Residual amount in company currency"
-msgstr ""
-
-#. module: account_payment_pro
-#: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__selected_debt
-msgid "Selected Debt"
 msgstr ""
 
 #. module: account_payment_pro
@@ -702,11 +725,6 @@ msgstr ""
 msgid ""
 "True when the destination account does not force a specific currency, "
 "allowing the user to choose counterpart_currency_id from the form view."
-msgstr ""
-
-#. module: account_payment_pro
-#: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__unmatched_amount
-msgid "Unmatched Amount"
 msgstr ""
 
 #. module: account_payment_pro

--- a/account_payment_pro/i18n/es.po
+++ b/account_payment_pro/i18n/es.po
@@ -84,6 +84,26 @@ msgid "Add All / Refresh"
 msgstr "Añadir Todo / Refrescar"
 
 #. module: account_payment_pro
+#: model_terms:ir.ui.view,arch_db:account_payment_pro.latam_check_view_account_payment_form_inherited
+msgid "Amount to Pay"
+msgstr "Importe a Pagar"
+
+#. module: account_payment_pro
+#: model_terms:ir.ui.view,arch_db:account_payment_pro.latam_check_view_account_payment_form_inherited
+msgid "Amount to Receive"
+msgstr "Importe a Cobrar"
+
+#. module: account_payment_pro
+#: model_terms:ir.ui.view,arch_db:account_payment_pro.latam_check_view_account_payment_form_inherited
+msgid "Amount to Recover"
+msgstr "Importe a Recuperar"
+
+#. module: account_payment_pro
+#: model_terms:ir.ui.view,arch_db:account_payment_pro.latam_check_view_account_payment_form_inherited
+msgid "Amount to Refund"
+msgstr "Importe a Reembolsar"
+
+#. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__unreconciled_amount
 msgid "Adjustment / Advance"
 msgstr "Ajuste / Adelanto"
@@ -211,8 +231,8 @@ msgstr "Confirmar"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__counterpart_currency_id
-msgid "Counterpart Currency"
-msgstr "Moneda de Imputación"
+msgid "Reconciliation Currency"
+msgstr "Moneda de Conciliación"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__counterpart_currency_amount
@@ -265,16 +285,6 @@ msgstr "Moneda"
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.view_account_payment_form
 msgid "Customer Bank Account"
 msgstr ""
-
-#. module: account_payment_pro
-#: model_terms:ir.ui.view,arch_db:account_payment_pro.latam_check_view_account_payment_form_inherited
-msgid "Debt Currency"
-msgstr ""
-
-#. module: account_payment_pro
-#: model_terms:ir.ui.view,arch_db:account_payment_pro.latam_check_view_account_payment_form_inherited
-msgid "Debts"
-msgstr "Deudas"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__destination_currency_id
@@ -479,8 +489,8 @@ msgstr "Número Manual"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__matched_amount
-msgid "Matched Amount"
-msgstr "Importe Conciliado"
+msgid "Allocated Amount"
+msgstr "Importe Imputado"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__matched_move_line_ids
@@ -653,8 +663,8 @@ msgstr ""
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__selected_debt
-msgid "Selected Debt"
-msgstr "Deuda Seleccionada"
+msgid "Amount to Reconcile"
+msgstr "Importe a Conciliar"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment_invoice_wizard__tax_ids
@@ -743,8 +753,8 @@ msgstr ""
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__unmatched_amount
-msgid "Unmatched Amount"
-msgstr "Importe Desconciliado"
+msgid "Open Balance"
+msgstr "Saldo Abierto"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment_invoice_wizard__amount_untaxed

--- a/account_payment_pro/i18n/es.po
+++ b/account_payment_pro/i18n/es.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-01 20:27+0000\n"
-"PO-Revision-Date: 2025-12-26 17:10+0000\n"
+"POT-Creation-Date: 2026-04-02 14:07+0000\n"
+"PO-Revision-Date: 2026-04-02 14:07+0000\n"
 "Last-Translator: carla spiaggi <sca@adhoc.inc>\n"
 "Language-Team: Spanish <https://translation.dev-adhoc.com/projects/account-"
 "payment-19-0/account-payment-19-0-account_payment_pro/es/>\n"
@@ -41,17 +41,17 @@ msgstr "+ Nota de Débito"
 #. module: account_payment_pro
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.view_account_payment_form
 msgid "<span> Exch. Diff</span>"
-msgstr ""
+msgstr "<span> Dif. Cambio</span>"
 
 #. module: account_payment_pro
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.view_account_payment_form
 msgid "<span>1</span>"
-msgstr ""
+msgstr "<span>1</span>"
 
 #. module: account_payment_pro
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.view_account_payment_form
 msgid "<span>=</span>"
-msgstr ""
+msgstr "<span>=</span>"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_write_off_type__account_id
@@ -66,12 +66,12 @@ msgstr "Fecha Contable"
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__accounting_rate
 msgid "Accounting Rate"
-msgstr ""
+msgstr "Tasa Contable"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__accounting_rate_inverted
 msgid "Accounting Rate Inverted"
-msgstr ""
+msgstr "Tasa Contable Invertida"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_write_off_type__active
@@ -84,26 +84,6 @@ msgid "Add All / Refresh"
 msgstr "Añadir Todo / Refrescar"
 
 #. module: account_payment_pro
-#: model_terms:ir.ui.view,arch_db:account_payment_pro.latam_check_view_account_payment_form_inherited
-msgid "Amount to Pay"
-msgstr "Importe a Pagar"
-
-#. module: account_payment_pro
-#: model_terms:ir.ui.view,arch_db:account_payment_pro.latam_check_view_account_payment_form_inherited
-msgid "Amount to Receive"
-msgstr "Importe a Cobrar"
-
-#. module: account_payment_pro
-#: model_terms:ir.ui.view,arch_db:account_payment_pro.latam_check_view_account_payment_form_inherited
-msgid "Amount to Recover"
-msgstr "Importe a Recuperar"
-
-#. module: account_payment_pro
-#: model_terms:ir.ui.view,arch_db:account_payment_pro.latam_check_view_account_payment_form_inherited
-msgid "Amount to Refund"
-msgstr "Importe a Reembolsar"
-
-#. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__unreconciled_amount
 msgid "Adjustment / Advance"
 msgstr "Ajuste / Adelanto"
@@ -112,13 +92,19 @@ msgstr "Ajuste / Adelanto"
 #. odoo-python
 #: code:addons/account_payment_pro/models/account_payment.py:0
 msgid "All selected debt lines must have the same currency. Found: %s"
-msgstr ""
+msgstr "Todas las líneas de deuda seleccionadas deben tener la misma moneda. Se encontraron: %s"
 
 #. module: account_payment_pro
 #. odoo-python
 #: code:addons/account_payment_pro/models/account_payment.py:0
 msgid "All to pay lines must be of the same partner"
 msgstr "Todas las líneas a pagar deben ser del mismo contacto."
+
+#. module: account_payment_pro
+#: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__matched_amount
+#: model_terms:ir.ui.view,arch_db:account_payment_pro.latam_check_view_account_payment_form_inherited
+msgid "Allocated Amount"
+msgstr "Importe Imputado"
 
 #. module: account_payment_pro
 #: model:res.groups,name:account_payment_pro.group_pay_now_customer_invoices
@@ -151,16 +137,16 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.res_config_settings_view_form
 msgid "Allow to pay vendor invoices automatically on invoice validation."
 msgstr ""
-"Permitir pagar las facturas de los proveedores automáticamente al validar la "
-"factura."
+"Permitir pagar las facturas de los proveedores automáticamente al validar la"
+" factura."
 
 #. module: account_payment_pro
 #: model:ir.model.fields,help:account_payment_pro.field_res_config_settings__group_pay_now_vendor_invoices
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.res_config_settings_view_form
 msgid ""
 "Allow users to choose a payment journal on invoices so that invoice is "
-"automatically paid after invoice validation. A payment will be created using "
-"choosen journal"
+"automatically paid after invoice validation. A payment will be created using"
+" choosen journal"
 msgstr ""
 "Permitir a los usuarios elegir un diario de pagos en las facturas para que "
 "la factura se pague automáticamente después de su validación. Se creará un "
@@ -174,12 +160,37 @@ msgstr "Monto"
 #. module: account_payment_pro
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.view_move_line_tree
 msgid "Amount CC"
-msgstr ""
+msgstr "Importe MC"
 
 #. module: account_payment_pro
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.view_account_payment_form
 msgid "Amount in"
-msgstr ""
+msgstr "Importe en"
+
+#. module: account_payment_pro
+#: model_terms:ir.ui.view,arch_db:account_payment_pro.view_account_payment_form
+msgid "Amount to Pay"
+msgstr "Importe a Pagar"
+
+#. module: account_payment_pro
+#: model_terms:ir.ui.view,arch_db:account_payment_pro.view_account_payment_form
+msgid "Amount to Receive"
+msgstr "Importe a Cobrar"
+
+#. module: account_payment_pro
+#: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__selected_debt
+msgid "Amount to Reconcile"
+msgstr "Importe a Conciliar"
+
+#. module: account_payment_pro
+#: model_terms:ir.ui.view,arch_db:account_payment_pro.view_account_payment_form
+msgid "Amount to Recover"
+msgstr "Importe a Recuperar"
+
+#. module: account_payment_pro
+#: model_terms:ir.ui.view,arch_db:account_payment_pro.view_account_payment_form
+msgid "Amount to Refund"
+msgstr "Importe Reembolso"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment_invoice_wizard__analytic_distribution
@@ -230,11 +241,6 @@ msgid "Confirm"
 msgstr "Confirmar"
 
 #. module: account_payment_pro
-#: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__counterpart_currency_id
-msgid "Reconciliation Currency"
-msgstr "Moneda de Conciliación"
-
-#. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__counterpart_currency_amount
 msgid "Counterpart Currency Amount"
 msgstr "Importe total a imputar"
@@ -242,17 +248,17 @@ msgstr "Importe total a imputar"
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__counterpart_currency_editable
 msgid "Counterpart Currency Editable"
-msgstr ""
+msgstr "Moneda de Contrapartida Editable"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__counterpart_rate
 msgid "Counterpart Rate"
-msgstr ""
+msgstr "Tasa de Contrapartida"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__counterpart_rate_inverted
 msgid "Counterpart Rate Inverted"
-msgstr ""
+msgstr "Tasa de Contrapartida Invertida"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment_invoice_wizard__create_uid
@@ -278,18 +284,24 @@ msgstr "Nota de Crédito"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment_invoice_wizard__currency_id
+#: model_terms:ir.ui.view,arch_db:account_payment_pro.latam_check_view_account_payment_form_inherited
 msgid "Currency"
 msgstr "Moneda"
 
 #. module: account_payment_pro
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.view_account_payment_form
 msgid "Customer Bank Account"
-msgstr ""
+msgstr "Cuenta Bancaria del Cliente"
+
+#. module: account_payment_pro
+#: model_terms:ir.ui.view,arch_db:account_payment_pro.latam_check_view_account_payment_form_inherited
+msgid "Debts"
+msgstr "Deudas"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__destination_currency_id
 msgid "Destination Currency"
-msgstr ""
+msgstr "Moneda de Destino"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__destination_journal_currency_id
@@ -300,7 +312,7 @@ msgstr "Moneda del diario de destino"
 #: model:ir.model.fields,help:account_payment_pro.field_account_payment__payment_difference
 msgid "Difference between 'To Pay Amount' and 'Payment Total'"
 msgstr ""
-"Diferencia entre Deuda Seleccionada (o Importe a Pagar) e Importe de Pago"
+"Diferencia entre el 'Importe a Pagar' y el 'Total Pago'"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_journal__display_name
@@ -313,7 +325,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:account_payment_pro.field_res_company__display_name
 #: model:ir.model.fields,field_description:account_payment_pro.field_res_config_settings__display_name
 msgid "Display Name"
-msgstr "Nombre a Mostrar"
+msgstr "Nombre en pantalla"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment_invoice_wizard__distribution_analytic_account_ids
@@ -334,18 +346,18 @@ msgstr "Tipo de Documentos"
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__exchange_diff_move_ids
 msgid "Exchange Diff Move"
-msgstr ""
+msgstr "Asiento de Diferencia de Cambio"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__exchange_diff_move_count
 msgid "Exchange Diff Move Count"
-msgstr ""
+msgstr "Cantidad de Asientos de Diferencia de Cambio"
 
 #. module: account_payment_pro
 #. odoo-python
 #: code:addons/account_payment_pro/models/account_payment.py:0
 msgid "Exchange Differences"
-msgstr ""
+msgstr "Diferencias de Cambio"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,help:account_payment_pro.field_account_payment__exchange_diff_move_ids
@@ -353,11 +365,13 @@ msgid ""
 "Exchange difference journal entries generated when reconciling this payment "
 "in foreign currency."
 msgstr ""
+"Asientos de diferencia de cambio generados al conciliar este pago en moneda "
+"extranjera."
 
 #. module: account_payment_pro
 #: model:ir.model.fields,help:account_payment_pro.field_account_payment__accounting_rate
 msgid "Exchange rate A→C in Odoo native format (e.g., 0.000667 for ARS/USD)"
-msgstr ""
+msgstr "Tasa de cambio A→C en formato nativo de Odoo (ej.: 0,000667 para ARS/USD)"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__has_outstanding
@@ -380,8 +394,8 @@ msgstr "ID"
 #. module: account_payment_pro
 #: model:ir.model.fields,help:account_payment_pro.field_account_payment_invoice_wizard__use_documents
 msgid ""
-"If active: will be using for legal invoicing (invoices, debit/credit notes). "
-"If not set means that will be used to register accounting entries not "
+"If active: will be using for legal invoicing (invoices, debit/credit notes)."
+" If not set means that will be used to register accounting entries not "
 "related to invoicing legal documents. For Example: Receipts, Tax Payments, "
 "Register journal entries"
 msgstr ""
@@ -399,13 +413,13 @@ msgid ""
 "journals with manual method are shown."
 msgstr ""
 "Si configura un diario aquí, después de la validación de la factura, la "
-"factura se pagará automáticamente con este diario. Como se utiliza el método "
-"de pago manual, solo se muestran los diarios con método manual."
+"factura se pagará automáticamente con este diario. Como se utiliza el método"
+" de pago manual, solo se muestran los diarios con método manual."
 
 #. module: account_payment_pro
 #: model:ir.model,name:account_payment_pro.model_base_language_install
 msgid "Install Language"
-msgstr ""
+msgstr "Instalar idioma"
 
 #. module: account_payment_pro
 #: model:ir.model,name:account_payment_pro.model_account_journal
@@ -422,7 +436,7 @@ msgstr "Moneda del Diario"
 #: model:ir.model,name:account_payment_pro.model_account_move
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.view_move_line_tree
 msgid "Journal Entry"
-msgstr "Asiento Contable"
+msgstr "Asiento contable"
 
 #. module: account_payment_pro
 #: model:ir.model,name:account_payment_pro.model_account_move_line
@@ -444,9 +458,10 @@ msgstr "Diario debe contener un método de pago \"Manual\""
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.latam_check_view_account_payment_form_inherited
 msgid ""
 "La deuda seleccionada tiene múltiples monedas.\n"
-"                    Seleccione la moneda de cancelación para filtrar las "
-"líneas."
+"                    Seleccione la moneda de cancelación para filtrar las líneas."
 msgstr ""
+"La deuda seleccionada tiene múltiples monedas.\n"
+"                    Seleccione la moneda de cancelación para filtrar las líneas."
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_write_off_type__label
@@ -456,7 +471,8 @@ msgstr "Etiqueta"
 #. module: account_payment_pro
 #: model:ir.model.fields,help:account_payment_pro.field_account_write_off_type__label
 msgid ""
-"Label to be used on journal items labels, if not configured name will be used"
+"Label to be used on journal items labels, if not configured name will be "
+"used"
 msgstr ""
 "Etiqueta que se utilizará en el detalle de los apuntes contables, si no se "
 "configura se utilizará el nombre por defecto."
@@ -488,11 +504,6 @@ msgid "Manual Number"
 msgstr "Número Manual"
 
 #. module: account_payment_pro
-#: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__matched_amount
-msgid "Allocated Amount"
-msgstr "Importe Imputado"
-
-#. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__matched_move_line_ids
 msgid "Matched Move Line"
 msgstr "Líneas conciliadas"
@@ -500,7 +511,7 @@ msgstr "Líneas conciliadas"
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__multi_currency_debt
 msgid "Multi Currency Debt"
-msgstr ""
+msgstr "Deuda Multimoneda"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_write_off_type__name
@@ -512,6 +523,12 @@ msgstr "Nombre"
 #: code:addons/account_payment_pro/models/account_move_line.py:0
 msgid "Nothing to be paid on selected entries"
 msgstr "Nada por pagar de los asientos seleccionados"
+
+#. module: account_payment_pro
+#: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__unmatched_amount
+#: model_terms:ir.ui.view,arch_db:account_payment_pro.latam_check_view_account_payment_form_inherited
+msgid "Open Balance"
+msgstr "Saldo Abierto"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_bank_statement_line__open_move_line_ids
@@ -549,22 +566,22 @@ msgstr "Importe Conciliado del Pago"
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_move_line__payment_matched_currency_id
 msgid "Payment Matched Currency"
-msgstr ""
+msgstr "Moneda de Conciliación del Pago"
 
 #. module: account_payment_pro
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.res_config_settings_view_form
 msgid ""
-"Payment Pro incorpora funcionalidades que permiten llevar un flujo de "
-"cobros                         y pagos con retenciones, especificamente "
-"utilizado en Argentina. Al activarlo a                         ​su ​vez, se "
-"pierden algunas funcionalidades nativas como descuento por pronto "
-"pago                         y sugerencias de diferencia de cambio"
+"Payment Pro incorpora funcionalidades que permiten llevar un flujo de cobros"
+"                         y pagos con retenciones, especificamente utilizado "
+"en Argentina. Al activarlo a                         ​su ​vez, se pierden "
+"algunas funcionalidades nativas como descuento por pronto pago"
+"                         y sugerencias de diferencia de cambio"
 msgstr ""
-"Payment Pro incorpora funcionalidades que permiten llevar un flujo de "
-"cobros                         y pagos con retenciones, especificamente "
-"utilizado en Argentina. Al activarlo a                         ​su ​vez, se "
-"pierden algunas funcionalidades nativas como descuento por pronto "
-"pago                         y sugerencias de diferencia de cambio"
+"Payment Pro incorpora funcionalidades que permiten llevar un flujo de cobros"
+"                         y pagos con retenciones, especificamente utilizado "
+"en Argentina. Al activarlo a                         ​su ​vez, se pierden "
+"algunas funcionalidades nativas como descuento por pronto pago"
+"                         y sugerencias de diferencia de cambio"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__payment_total
@@ -588,8 +605,8 @@ msgstr ""
 #. module: account_payment_pro
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.latam_check_view_account_payment_form_inherited
 msgid ""
-"Payment will be automatically matched with the oldest lines of this list (by "
-"maturity date). You can remove any line you dont want to be matched."
+"Payment will be automatically matched with the oldest lines of this list (by"
+" maturity date). You can remove any line you dont want to be matched."
 msgstr ""
 "El pago se emparejará automáticamente con las líneas más antiguas de esta "
 "lista (por fecha de vencimiento). Puedes eliminar cualquier línea que no "
@@ -608,7 +625,7 @@ msgstr "Diferencia de Pago"
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__previous_currency_id
 msgid "Previous Currency"
-msgstr ""
+msgstr "Moneda Anterior"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment_invoice_wizard__product_id
@@ -623,12 +640,17 @@ msgstr "Cuenta del producto"
 #. module: account_payment_pro
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.view_account_payment_form
 msgid "Rate"
-msgstr ""
+msgstr "Tasa"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment_invoice_wizard__description
 msgid "Reason"
 msgstr "Razón"
+
+#. module: account_payment_pro
+#: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__counterpart_currency_id
+msgid "Reconciliation Currency"
+msgstr "Moneda de Conciliación"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment_invoice_wizard__invoice_date
@@ -649,22 +671,17 @@ msgstr "Eliminar Todo"
 #. module: account_payment_pro
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.view_move_line_tree
 msgid "Residual"
-msgstr ""
+msgstr "Residual"
 
 #. module: account_payment_pro
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.view_move_line_tree
 msgid "Residual CC"
-msgstr ""
+msgstr "Residual MC"
 
 #. module: account_payment_pro
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.view_move_line_tree
 msgid "Residual amount in company currency"
-msgstr ""
-
-#. module: account_payment_pro
-#: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__selected_debt
-msgid "Amount to Reconcile"
-msgstr "Importe a Conciliar"
+msgstr "Importe residual en moneda de la compañía"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment_invoice_wizard__tax_ids
@@ -681,7 +698,7 @@ msgstr "La moneda utilizada para ingresar el estado"
 #. odoo-python
 #: code:addons/account_payment_pro/models/account_payment.py:0
 msgid "The payment journal must match the journal of its journal entry."
-msgstr ""
+msgstr "El diario de pago debe coincidir con el diario de su asiento contable."
 
 #. module: account_payment_pro
 #: model:ir.model.fields,help:account_payment_pro.field_account_payment_invoice_wizard__currency_id
@@ -723,12 +740,12 @@ msgstr "Importe Total"
 #. module: account_payment_pro
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.view_move_line_tree
 msgid "Total debt"
-msgstr ""
+msgstr "Deuda total"
 
 #. module: account_payment_pro
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.view_move_line_tree
 msgid "Total debt amount in company currency"
-msgstr ""
+msgstr "Importe de deuda total en moneda de la compañía"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,help:account_payment_pro.field_account_payment__counterpart_rate_inverted
@@ -736,6 +753,8 @@ msgid ""
 "True si el rate teórico A→B1 < 1.0 (B1 es la moneda fuerte). Determina la "
 "dirección de visualización de user_counterpart_rate."
 msgstr ""
+"True si el rate teórico A→B1 < 1.0 (B1 es la moneda fuerte). Determina la "
+"dirección de visualización de user_counterpart_rate."
 
 #. module: account_payment_pro
 #: model:ir.model.fields,help:account_payment_pro.field_account_payment__accounting_rate_inverted
@@ -743,6 +762,8 @@ msgid ""
 "True si el rate teórico A→C < 1.0 (C es la moneda fuerte). Determina la "
 "dirección de visualización de user_accounting_rate."
 msgstr ""
+"True si el rate teórico A→C < 1.0 (C es la moneda fuerte). Determina la "
+"dirección de visualización de user_accounting_rate."
 
 #. module: account_payment_pro
 #: model:ir.model.fields,help:account_payment_pro.field_account_payment__counterpart_currency_editable
@@ -750,11 +771,8 @@ msgid ""
 "True when the destination account does not force a specific currency, "
 "allowing the user to choose counterpart_currency_id from the form view."
 msgstr ""
-
-#. module: account_payment_pro
-#: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__unmatched_amount
-msgid "Open Balance"
-msgstr "Saldo Abierto"
+"Verdadero cuando la cuenta de destino no fuerza una moneda específica, "
+"permitiendo al usuario elegir la moneda de conciliación desde la vista de formulario."
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment_invoice_wizard__amount_untaxed
@@ -781,17 +799,17 @@ msgstr "Uso del modulo de Payment Pro"
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__user_accounting_rate
 msgid "User Accounting Rate"
-msgstr ""
+msgstr "Tasa Contable del Usuario"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment__user_counterpart_rate
 msgid "User Counterpart Rate"
-msgstr ""
+msgstr "Tasa de Contrapartida del Usuario"
 
 #. module: account_payment_pro
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.view_account_payment_form
 msgid "Vendor Bank Account"
-msgstr ""
+msgstr "Cuenta Bancaria del Proveedor"
 
 #. module: account_payment_pro
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.view_account_payment_form
@@ -834,15 +852,16 @@ msgstr ""
 #. module: account_payment_pro
 #. odoo-python
 #: code:addons/account_payment_pro/models/account_payment.py:0
-msgid "You can't create payments for entries belonging to different companies."
+msgid ""
+"You can't create payments for entries belonging to different companies."
 msgstr ""
-"No se pueden crear pagos para asientos que pertenezcan a diferentes compañías"
+"No se pueden crear pagos para asientos que pertenezcan a diferentes "
+"compañías"
 
 #. module: account_payment_pro
 #: model:ir.model,name:account_payment_pro.model_account_payment_invoice_wizard
 msgid "account.payment.invoice.wizard"
-msgstr ""
-"account.payment.invoice.wizard\n"
+msgstr "account.payment.invoice.wizard"
 " "
 
 #. module: account_payment_pro
@@ -854,34 +873,4 @@ msgstr "Tipo de Write Off"
 #. odoo-python
 #: code:addons/account_payment_pro/models/account_payment.py:0
 msgid "id"
-msgstr ""
-
-#~ msgid "<span><strong>Rate = </strong></span>"
-#~ msgstr "<span><strong>Tasa de Cambio = </strong></span>"
-
-#~ msgid "Amount Company Currency Signed Pro"
-#~ msgstr "Importe"
-
-#~ msgid "Amount on Company Currency"
-#~ msgstr "Importe"
-
-#~ msgid "Counterpart Exchange Rate"
-#~ msgstr "Tasa de Imputación"
-
-#~ msgid "Exchange Rate"
-#~ msgstr "Tipo de Cambio"
-
-#~ msgid "Forced Amount on Company Currency"
-#~ msgstr "Forzar importe en moneda de la Compañía"
-
-#~ msgid "Other Currency"
-#~ msgstr "Otra Moneda"
-
-#~ msgid "Payment Total (SC)"
-#~ msgstr "Total del pago (Moneda Secundaria)"
-
-#~ msgid "Rate ="
-#~ msgstr "Cotización ="
-
-#~ msgid "Secondary Currency"
-#~ msgstr "Moneda de Imputación"
+msgstr "id"

--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -16,6 +16,7 @@ class AccountPayment(models.Model):
     )
     counterpart_currency_id = fields.Many2one(
         "res.currency",
+        string="Reconciliation Currency",
         compute="_compute_counterpart_currency_id",
         store=True,
         readonly=False,
@@ -92,14 +93,17 @@ class AccountPayment(models.Model):
     available_journal_ids = fields.Many2many(comodel_name="account.journal", compute="_compute_available_journal_ids")
     # desde account_payment_group, modelo account.payment.group
     matched_amount = fields.Monetary(
+        string="Allocated Amount",
         compute="_compute_matched_amounts",
         currency_field="destination_currency_id",
     )
     unmatched_amount = fields.Monetary(
+        string="Open Balance",
         compute="_compute_matched_amounts",
         currency_field="destination_currency_id",
     )
     selected_debt = fields.Monetary(
+        string="Amount to Reconcile",
         compute="_compute_selected_debt",
         currency_field="destination_currency_id",
     )

--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -852,10 +852,14 @@ class AccountPayment(models.Model):
             rec.payment_difference = rec.to_pay_amount - rec.payment_total
 
     # En el pasado se contaba con to_pay_move_line_ids.amount_residual dentro de los depends,  y no deberiamos por cuestiones de performance, ya que ademas no era necesario
-    @api.depends("to_pay_move_line_ids", "destination_currency_id")
+    @api.depends("to_pay_move_line_ids", "destination_currency_id", "payment_type")
     def _compute_selected_debt(self):
         for rec in self:
-            sign = -1.0 if rec.partner_type == "supplier" else 1.0
+            # Usamos payment_type (no partner_type) porque cubre tanto los casos normales
+            # (outbound+supplier, inbound+customer) como los invertidos (outbound+customer,
+            # inbound+supplier). amount_residual es negativo para créditos y positivo para
+            # débitos; multiplicar por -1 en outbound normaliza ambos a positivo.
+            sign = -1.0 if rec.payment_type == "outbound" else 1.0
             if rec.destination_currency_id and rec.destination_currency_id != rec.company_currency_id:
                 amount = sum(rec.to_pay_move_line_ids._origin.mapped("amount_residual_currency"))
             else:

--- a/account_payment_pro/tests/test_account_paymet_pro_unit_test.py
+++ b/account_payment_pro/tests/test_account_paymet_pro_unit_test.py
@@ -16,6 +16,18 @@ class TestAccountPaymentProUnitTest(common.TransactionCase):
         cls.company_bank_journal = cls.env["account.journal"].search(
             [("company_id", "=", cls.company.id), ("type", "=", "bank")], limit=1
         )
+        # Configurar cuentas outstanding en el diario de banco para que al postear
+        # se genere asiento contable (sin esto Odoo no crea journal entry)
+        outstanding_account = cls.env["account.account"].search(
+            [("company_ids", "=", cls.company.id), ("account_type", "=", "asset_current")], limit=1
+        )
+        if outstanding_account:
+            for pml in cls.company_bank_journal.inbound_payment_method_line_ids:
+                if not pml.payment_account_id:
+                    pml.payment_account_id = outstanding_account
+            for pml in cls.company_bank_journal.outbound_payment_method_line_ids:
+                if not pml.payment_account_id:
+                    pml.payment_account_id = outstanding_account
         cls.company_journal = cls.env["account.journal"].search(
             [("company_id", "=", cls.company.id), ("type", "=", "sale")], limit=1
         )
@@ -178,3 +190,164 @@ class TestAccountPaymentProUnitTest(common.TransactionCase):
 
         # Verify payment is in draft state
         self.assertEqual(payment.state, "draft", "Payment should be in draft state after action_draft")
+
+    # ==================================================================
+    # Tests para payment_type invertido (outbound+customer, inbound+supplier)
+    # ==================================================================
+
+    def test_inbound_supplier_selected_debt_positive(self):
+        """Pago de tipo inbound + supplier (nota de crédito de proveedor / reembolso).
+        selected_debt, to_pay_amount y payment_difference deben calcularse
+        correctamente con valores positivos."""
+        purchase_journal = self.env["account.journal"].search(
+            [("company_id", "=", self.company.id), ("type", "=", "purchase")], limit=1
+        )
+        # Crear nota de crédito de proveedor (in_refund genera débito en AP → amount_residual > 0)
+        credit_note = self.env["account.move"].create(
+            {
+                "partner_id": self.partner_ri.id,
+                "invoice_date": self.today,
+                "move_type": "in_refund",
+                "journal_id": purchase_journal.id,
+                "company_id": self.company.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.env.ref("product.product_product_16").id,
+                            "quantity": 1,
+                            "price_unit": 500,
+                        }
+                    ),
+                ],
+            }
+        )
+        credit_note.action_post()
+
+        # payment_type=inbound con partner_type=supplier (caso invertido)
+        debt_lines = credit_note.line_ids.filtered(lambda l: l.account_id.account_type == "liability_payable")
+        payment = self.env["account.payment"].create(
+            {
+                "journal_id": self.company_bank_journal.id,
+                "partner_id": self.partner_ri.id,
+                "partner_type": "supplier",
+                "payment_type": "inbound",
+                "date": self.today,
+                "amount": credit_note.amount_total,
+                "to_pay_move_line_ids": [Command.set(debt_lines.ids)],
+            }
+        )
+
+        # selected_debt debe ser positivo (amount_residual > 0 * sign(inbound)=+1)
+        self.assertGreater(payment.selected_debt, 0, "selected_debt debe ser positivo para inbound+supplier")
+        self.assertGreater(payment.to_pay_amount, 0, "to_pay_amount debe ser positivo para inbound+supplier")
+        self.assertAlmostEqual(
+            payment.payment_total,
+            payment.to_pay_amount,
+            places=2,
+            msg="payment_total debe cubrir to_pay_amount",
+        )
+        self.assertAlmostEqual(
+            payment.payment_difference,
+            0,
+            places=2,
+            msg="payment_difference debe ser ≈ 0 cuando amount cubre la deuda",
+        )
+
+    def test_outbound_customer_selected_debt_positive(self):
+        """Pago de tipo outbound + customer (nota de crédito a cliente / reembolso).
+        selected_debt, to_pay_amount y payment_difference deben calcularse
+        correctamente con valores positivos."""
+        # Crear nota de crédito de cliente (genera crédito en AR → amount_residual < 0)
+        credit_note = self.env["account.move"].create(
+            {
+                "partner_id": self.partner_ri.id,
+                "invoice_date": self.today,
+                "move_type": "out_refund",
+                "journal_id": self.company_journal.id,
+                "company_id": self.company.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.env.ref("product.product_product_16").id,
+                            "quantity": 1,
+                            "price_unit": 300,
+                        }
+                    ),
+                ],
+            }
+        )
+        credit_note.action_post()
+
+        # payment_type=outbound con partner_type=customer (caso invertido)
+        debt_lines = credit_note.line_ids.filtered(lambda l: l.account_id.account_type == "asset_receivable")
+        payment = self.env["account.payment"].create(
+            {
+                "journal_id": self.company_bank_journal.id,
+                "partner_id": self.partner_ri.id,
+                "partner_type": "customer",
+                "payment_type": "outbound",
+                "date": self.today,
+                "amount": credit_note.amount_total,
+                "to_pay_move_line_ids": [Command.set(debt_lines.ids)],
+            }
+        )
+
+        # selected_debt debe ser positivo (amount_residual < 0 * sign(outbound)=-1 = positivo)
+        self.assertGreater(payment.selected_debt, 0, "selected_debt debe ser positivo para outbound+customer")
+        self.assertGreater(payment.to_pay_amount, 0, "to_pay_amount debe ser positivo para outbound+customer")
+        self.assertAlmostEqual(
+            payment.payment_total,
+            payment.to_pay_amount,
+            places=2,
+            msg="payment_total debe cubrir to_pay_amount",
+        )
+        self.assertAlmostEqual(
+            payment.payment_difference,
+            0,
+            places=2,
+            msg="payment_difference debe ser ≈ 0 cuando amount cubre la deuda",
+        )
+
+    def test_reversed_payment_type_post(self):
+        """Verificar que pagos con payment_type invertido se pueden postear
+        y concilian la deuda correctamente."""
+        purchase_journal = self.env["account.journal"].search(
+            [("company_id", "=", self.company.id), ("type", "=", "purchase")], limit=1
+        )
+        # Nota de crédito de proveedor (in_refund genera débito en AP → amount_residual > 0)
+        credit_note = self.env["account.move"].create(
+            {
+                "partner_id": self.partner_ri.id,
+                "invoice_date": self.today,
+                "move_type": "in_refund",
+                "journal_id": purchase_journal.id,
+                "company_id": self.company.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.env.ref("product.product_product_16").id,
+                            "quantity": 1,
+                            "price_unit": 1000,
+                        }
+                    ),
+                ],
+            }
+        )
+        credit_note.action_post()
+
+        debt_lines = credit_note.line_ids.filtered(lambda l: l.account_id.account_type == "liability_payable")
+        payment = self.env["account.payment"].create(
+            {
+                "journal_id": self.company_bank_journal.id,
+                "partner_id": self.partner_ri.id,
+                "partner_type": "supplier",
+                "payment_type": "inbound",
+                "date": self.today,
+                "amount": credit_note.amount_total,
+                "to_pay_move_line_ids": [Command.set(debt_lines.ids)],
+            }
+        )
+        payment.action_post()
+
+        self.assertIn(payment.state, ["paid", "in_process"], "El pago invertido debe poder postearse")
+        self.assertIn(credit_note.payment_state, ["paid", "in_payment"], "La nota de crédito debe quedar pagada")

--- a/account_payment_pro/views/account_payment_view.xml
+++ b/account_payment_pro/views/account_payment_view.xml
@@ -63,8 +63,15 @@
 
 
         <!-- movemos amount a la columna 2 para que quede todo lo relativo al metodo de pago junto -->
+        <!-- ocultamos la label original y agregamos 4 variantes según partner_type + payment_type -->
+        <label for="amount" position="attributes">
+            <attribute name="invisible">True</attribute>
+        </label>
         <group name="group2">
-            <label for="amount" position="move"/>
+            <label for="amount" name="label_amount_receive" string="Amount to Receive" invisible="partner_type != 'customer' or payment_type != 'inbound'"/>
+            <label for="amount" name="label_amount_refund" string="Amount to Refund" invisible="partner_type != 'customer' or payment_type != 'outbound'"/>
+            <label for="amount" name="label_amount_pay" string="Amount to Pay" invisible="partner_type != 'supplier' or payment_type != 'outbound'"/>
+            <label for="amount" name="label_amount_recover" string="Amount to Recover" invisible="partner_type != 'supplier' or payment_type != 'inbound'"/>
             <div name="amount_div" position="move"/>
         </group>
 
@@ -172,7 +179,7 @@
                     <group>
                         <!-- Moneda de contrapartida: editable solo cuando la cuenta no fuerza moneda -->
                         <field name="counterpart_currency_id"
-                            string="Debt Currency"
+                            string="Currency"
                             readonly="state != 'draft' or not counterpart_currency_editable"
                             required="use_payment_pro"
                             options="{'no_create': True, 'no_open': True}"/>
@@ -197,10 +204,10 @@
             <page string="Paid" name="paid" invisible="state == 'draft' or is_internal_transfer or not use_payment_pro">
                 <group>
                     <group>
-                        <field name="matched_amount" invisible="not matched_amount"/>
+                        <field name="matched_amount" string="Allocated Amount" invisible="not matched_amount"/>
                     </group>
                     <group>
-                        <field name="unmatched_amount" invisible="not unmatched_amount"/>
+                        <field name="unmatched_amount" string="Open Balance" invisible="not unmatched_amount"/>
                     </group>
                 </group>
                 <field name="matched_move_line_ids" context="{'list_view_ref': 'account_payment_pro.view_move_line_with_matched_tree'}"/>

--- a/l10n_ar_payment_bundle/i18n/es.po
+++ b/l10n_ar_payment_bundle/i18n/es.po
@@ -34,8 +34,8 @@ msgstr "Monto"
 
 #. module: l10n_ar_payment_bundle
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_custom_list
-msgid "Amount (DC)"
-msgstr ""
+msgid "Amount (RC)"
+msgstr "Importe (MC)"
 
 #. module: l10n_ar_payment_bundle
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_custom_list
@@ -44,8 +44,8 @@ msgstr ""
 
 #. module: l10n_ar_payment_bundle
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_custom_list
-msgid "Amount in Debt Currency"
-msgstr ""
+msgid "Amount in Reconciliation Currency"
+msgstr "Importe en Moneda de Conciliación"
 
 #. module: l10n_ar_payment_bundle
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_custom_list

--- a/l10n_ar_payment_bundle/i18n/es.po
+++ b/l10n_ar_payment_bundle/i18n/es.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-01 20:27+0000\n"
-"PO-Revision-Date: 2025-12-26 17:10+0000\n"
+"POT-Creation-Date: 2026-04-02 14:07+0000\n"
+"PO-Revision-Date: 2026-04-02 14:07+0000\n"
 "Last-Translator: carla spiaggi <sca@adhoc.inc>\n"
 "Language-Team: Spanish <https://translation.dev-adhoc.com/projects/account-"
 "payment-19-0/account-payment-19-0-l10n_ar_payment_bundle/es/>\n"
@@ -25,7 +25,7 @@ msgstr ""
 #. module: l10n_ar_payment_bundle
 #: model:ir.model,name:l10n_ar_payment_bundle.model_account_chart_template
 msgid "Account Chart Template"
-msgstr "Plantilla de plan contable"
+msgstr "Plantilla de plan de cuentas"
 
 #. module: l10n_ar_payment_bundle
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_custom_list
@@ -34,13 +34,13 @@ msgstr "Monto"
 
 #. module: l10n_ar_payment_bundle
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_custom_list
-msgid "Amount (RC)"
-msgstr "Importe (MC)"
+msgid "Amount (JC)"
+msgstr "Importe (MD)"
 
 #. module: l10n_ar_payment_bundle
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_custom_list
-msgid "Amount (JC)"
-msgstr ""
+msgid "Amount (RC)"
+msgstr "Importe (MC)"
 
 #. module: l10n_ar_payment_bundle
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_custom_list
@@ -50,7 +50,7 @@ msgstr "Importe en Moneda de Conciliación"
 #. module: l10n_ar_payment_bundle
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_custom_list
 msgid "Amount on journal currency"
-msgstr ""
+msgstr "Importe en moneda del diario"
 
 #. module: l10n_ar_payment_bundle
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_payment_rename_wizard_form
@@ -61,11 +61,6 @@ msgstr "Cancelar"
 #: model:ir.model,name:l10n_ar_payment_bundle.model_res_company
 msgid "Companies"
 msgstr "Empresas"
-
-#. module: l10n_ar_payment_bundle
-#: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_payment__counterpart_currency_id
-msgid "Counterpart Currency"
-msgstr ""
 
 #. module: l10n_ar_payment_bundle
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_payment_rename_wizard__create_uid
@@ -97,7 +92,7 @@ msgstr "Cliente/Proveedor"
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_payment_rename_wizard__display_name
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_res_company__display_name
 msgid "Display Name"
-msgstr "Nombre a Mostrar"
+msgstr "Nombre para mostrar"
 
 #. module: l10n_ar_payment_bundle
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_payment_rename_wizard_form
@@ -120,8 +115,8 @@ msgstr "ID"
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_from_bundle_form
 msgid ""
 "IMPORTANT: Linked draft validation must be done from main receipt. Draft "
-"validation of a linked payment is only used for corrections and advanced use "
-"cases. Are you sure you want to continue?"
+"validation of a linked payment is only used for corrections and advanced use"
+" cases. Are you sure you want to continue?"
 msgstr ""
 "IMPORTANTE: La validación del borrador vinculado debe realizarse desde el "
 "recibo principal. La validación del borrador de un pago vinculado solo se "
@@ -132,8 +127,8 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_form
 msgid ""
 "IMPORTANT: Linked payment validation must be done from main receipt. Manual "
-"validation of a linked payment is only used for corrections and advanced use "
-"cases. Are you sure you want to continue?"
+"validation of a linked payment is only used for corrections and advanced use"
+" cases. Are you sure you want to continue?"
 msgstr ""
 "IMPORTANTE: La validación de un pago vinculado debe realizarse desde el "
 "recibo principal. La validación manual de un pago vinculado solo se utiliza "
@@ -216,7 +211,7 @@ msgstr "Facturas pagadas"
 #. module: l10n_ar_payment_bundle
 #: model:ir.model,name:l10n_ar_payment_bundle.model_account_payment_register
 msgid "Pay"
-msgstr ""
+msgstr "Pagar"
 
 #. module: l10n_ar_payment_bundle
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_payment_rename_wizard__payment_id
@@ -236,7 +231,7 @@ msgstr "Asistente para Renombrar Pago"
 #. module: l10n_ar_payment_bundle
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_payment__payment_total
 msgid "Payment Total"
-msgstr ""
+msgstr "Total Pago"
 
 #. module: l10n_ar_payment_bundle
 #. odoo-python
@@ -245,6 +240,8 @@ msgid ""
 "Payment bundle method requires Payment PRO to be enabled in the company "
 "configuration."
 msgstr ""
+"El método de pago múltiple requiere que Payment PRO esté habilitado en la "
+"configuración de la compañía."
 
 #. module: l10n_ar_payment_bundle
 #: model:account.payment.method,name:l10n_ar_payment_bundle.account_payment_in_payment_bundle
@@ -268,7 +265,7 @@ msgstr "Pagos"
 #. module: l10n_ar_payment_bundle
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_form
 msgid "Payments Amount"
-msgstr ""
+msgstr "Importe de Pagos"
 
 #. module: l10n_ar_payment_bundle
 #. odoo-python
@@ -277,9 +274,14 @@ msgid "Please enter a new name for the payment."
 msgstr "Por favor ingrese un nuevo nombre para el pago."
 
 #. module: l10n_ar_payment_bundle
+#: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_payment__counterpart_currency_id
+msgid "Reconciliation Currency"
+msgstr "Moneda de Conciliación"
+
+#. module: l10n_ar_payment_bundle
 #: model:ir.model,name:l10n_ar_payment_bundle.model_account_resequence_wizard
 msgid "Remake the sequence of Journal Entries."
-msgstr "Rehacer la secuencia de los Asientos Contables."
+msgstr "Rehaga la secuencia de los asientos contables."
 
 #. module: l10n_ar_payment_bundle
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_form
@@ -310,18 +312,20 @@ msgid ""
 "The counterpart currency of a linked payment must match the main payment's "
 "counterpart currency."
 msgstr ""
+"La moneda de conciliación del pago vinculado debe coincidir con la del pago "
+"principal."
 
 #. module: l10n_ar_payment_bundle
 #. odoo-python
 #: code:addons/l10n_ar_payment_bundle/models/account_payment.py:0
 msgid "The main payment and linked payment must belong to the same company."
-msgstr ""
+msgstr "El pago principal y el pago vinculado deben pertenecer a la misma compañía."
 
 #. module: l10n_ar_payment_bundle
 #. odoo-python
 #: code:addons/l10n_ar_payment_bundle/models/account_payment.py:0
 msgid "The main payment and linked payments must belong to the same company."
-msgstr ""
+msgstr "El pago principal y los pagos vinculados deben pertenecer a la misma compañía."
 
 #. module: l10n_ar_payment_bundle
 #. odoo-python
@@ -353,7 +357,7 @@ msgstr ""
 #. module: l10n_ar_payment_bundle
 #: model:ir.model.fields,help:l10n_ar_payment_bundle.field_account_payment__to_pay_move_line_ids
 msgid "This lines are the ones the user has selected to be paid."
-msgstr "Estas líneas son las que el usuario ha seleccionado para pagar."
+msgstr "Estas líneas son las que el usuario ha seleccionado para pagar"
 
 #. module: l10n_ar_payment_bundle
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_payment__to_pay_move_line_ids
@@ -368,7 +372,7 @@ msgstr "Total"
 #. module: l10n_ar_payment_bundle
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_payment_register__use_payment_pro
 msgid "Use Payment Pro"
-msgstr ""
+msgstr "Usar Payment Pro"
 
 #. module: l10n_ar_payment_bundle
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_from_bundle_form
@@ -377,8 +381,8 @@ msgid ""
 "corrections or advanced scenarios. It is recommended to validate linked "
 "payments through the main receipt. Do you want to proceed?"
 msgstr ""
-"ADVERTENCIA: La validación directa de un pago vinculado solo se utiliza para "
-"correcciones o casos de uso avanzados. Se recomienda validar los pagos "
+"ADVERTENCIA: La validación directa de un pago vinculado solo se utiliza para"
+" correcciones o casos de uso avanzados. Se recomienda validar los pagos "
 "vinculados a través del recibo principal. ¿Desea continuar?"
 
 #. module: l10n_ar_payment_bundle
@@ -390,8 +394,8 @@ msgstr "Advertencias"
 #. odoo-python
 #: code:addons/l10n_ar_payment_bundle/models/account_journal.py:0
 msgid ""
-"You cannot assign a currency to journals that use the payment bundle payment "
-"method."
+"You cannot assign a currency to journals that use the payment bundle payment"
+" method."
 msgstr ""
 "No puede asignar una Moneda a los diarios que utilizan el método de pago de "
 "Múltiples Pagos."
@@ -405,27 +409,3 @@ msgid ""
 msgstr ""
 "No puede resecuenciar movimientos vinculados a un pago múltiple. Por favor "
 "resecuencie el pago en su lugar."
-
-#~ msgid "<strong><span>Total Imputed</span></strong>"
-#~ msgstr "<strong><span>Total Imputado</span></strong>"
-
-#~ msgid "<strong><span>Total Paid</span></strong>"
-#~ msgstr "<strong><span>Total Pagado</span></strong>"
-
-#~ msgid "Amount in SC"
-#~ msgstr "Monto en Moneda Secundaria"
-
-#~ msgid "Counterpart Exchange Rate"
-#~ msgstr "Tasa de Imputación"
-
-#~ msgid "Payment Total (SC)"
-#~ msgstr "Total del pago (Moneda Secundaria)"
-
-#~ msgid "Rate"
-#~ msgstr "Tasa de Cambio"
-
-#~ msgid "This action is only available for bundle payments."
-#~ msgstr "Esta acción solo está disponible para pagos múltiples."
-
-#~ msgid "You cannot rename canceled payments."
-#~ msgstr "No puede renombrar pagos cancelados."

--- a/l10n_ar_payment_bundle/i18n/l10n_ar_payment_bundle.pot
+++ b/l10n_ar_payment_bundle/i18n/l10n_ar_payment_bundle.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-01 20:27+0000\n"
-"PO-Revision-Date: 2026-04-01 20:27+0000\n"
+"POT-Creation-Date: 2026-04-02 14:07+0000\n"
+"PO-Revision-Date: 2026-04-02 14:07+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -27,17 +27,17 @@ msgstr ""
 
 #. module: l10n_ar_payment_bundle
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_custom_list
-msgid "Amount (DC)"
-msgstr ""
-
-#. module: l10n_ar_payment_bundle
-#: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_custom_list
 msgid "Amount (JC)"
 msgstr ""
 
 #. module: l10n_ar_payment_bundle
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_custom_list
-msgid "Amount in Debt Currency"
+msgid "Amount (RC)"
+msgstr ""
+
+#. module: l10n_ar_payment_bundle
+#: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_custom_list
+msgid "Amount in Reconciliation Currency"
 msgstr ""
 
 #. module: l10n_ar_payment_bundle
@@ -53,11 +53,6 @@ msgstr ""
 #. module: l10n_ar_payment_bundle
 #: model:ir.model,name:l10n_ar_payment_bundle.model_res_company
 msgid "Companies"
-msgstr ""
-
-#. module: l10n_ar_payment_bundle
-#: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_payment__counterpart_currency_id
-msgid "Counterpart Currency"
 msgstr ""
 
 #. module: l10n_ar_payment_bundle
@@ -260,6 +255,11 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_ar_payment_bundle/wizard/payment_rename.py:0
 msgid "Please enter a new name for the payment."
+msgstr ""
+
+#. module: l10n_ar_payment_bundle
+#: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_payment__counterpart_currency_id
+msgid "Reconciliation Currency"
 msgstr ""
 
 #. module: l10n_ar_payment_bundle

--- a/l10n_ar_payment_bundle/views/account_payment_view.xml
+++ b/l10n_ar_payment_bundle/views/account_payment_view.xml
@@ -137,8 +137,18 @@
                             readonly="state != 'draft'"/>
                 </page>
             </page>
-            <label for="amount" position="attributes">
-                <attribute name="invisible">is_main_payment</attribute>
+            <!-- Hide the 4 conditional amount labels added by account_payment_pro for bundle main payments -->
+            <label name="label_amount_receive" position="attributes">
+                <attribute name="invisible" separator=" or " add="is_main_payment"/>
+            </label>
+            <label name="label_amount_refund" position="attributes">
+                <attribute name="invisible" separator=" or " add="is_main_payment"/>
+            </label>
+            <label name="label_amount_pay" position="attributes">
+                <attribute name="invisible" separator=" or " add="is_main_payment"/>
+            </label>
+            <label name="label_amount_recover" position="attributes">
+                <attribute name="invisible" separator=" or " add="is_main_payment"/>
             </label>
             <div name="amount_div" position="attributes">
                 <attribute name="invisible">is_main_payment</attribute>
@@ -200,7 +210,7 @@
                 <field name="payment_type" optional="hide"/>
                 <field name="amount" string="Amount (JC)" help="Amount on journal currency" optional="hide"/>
                 <field name="payment_total" string="Amount" sum="Total"/>
-                <field name="counterpart_currency_amount" string="Amount (DC)" sum="Total" help="Amount in Debt Currency" optional="hide" column_invisible="parent.destination_currency_id == parent.counterpart_currency_id"/>
+                <field name="counterpart_currency_amount" string="Amount (RC)" sum="Total" help="Amount in Reconciliation Currency" optional="hide" column_invisible="parent.destination_currency_id == parent.counterpart_currency_id"/>
                 <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-warning="state == 'in_process'" decoration-success="state == 'paid'"/>
             </list>
         </field>


### PR DESCRIPTION
Lógica del fix
Con el refactor, payment_total pasó a ser siempre positivo (ya no usa amount_company_currency_signed_pro). Sin embargo, _compute_selected_debt seguía usando partner_type para el signo, lo cual producía selected_debt negativo en los casos invertidos (inbound+supplier, outbound+customer). Esto generaba un payment_difference enorme y desbalanceado.

Usar payment_type como base del signo funciona para los 4 combos porque amount_residual es negativo para créditos (AP normal, AR refund) y positivo para débitos (AR normal, AP refund):

Combo	amount_residual	sign(outbound)	selected_debt outbound+supplier	< 0	-1	> 0 ✓
inbound+customer	> 0	+1	> 0 ✓
outbound+customer	< 0	-1	> 0 ✓
inbound+supplier	> 0	+1	> 0 ✓
l10n_ar_payment_bundle — sin cambios necesarios
Este módulo no tiene lógica de signo propia basada en partner_type. Su _compute_payment_difference usa selected_debt, payment_total, withholdings_amount y write_off_amount del main payment, que ahora son todos positivos.