### PR TITLE
[FIX] l10n_ar_payment_bundle: Fix payment difference calculation

### DIFF
--- a/l10n_ar_payment_bundle/models/account_payment.py
+++ b/l10n_ar_payment_bundle/models/account_payment.py
@@ -324,7 +324,7 @@ class AccountPayment(models.Model):
             amount_payments = abs(amount_inbound + amount_outbound)
 
             rec.payment_difference = (
-                rec.main_payment_id.selected_debt
+                abs(rec.main_payment_id.selected_debt)
                 - amount_payments
                 - rec.main_payment_id.withholdings_amount
                 - rec.main_payment_id.write_off_amount


### PR DESCRIPTION
When the payment difference is calculated, the amount of the payments is subtracted from the selected debt. This can lead to summing negative amounts in the case of credit notes, which results in a payment difference that is higher than it should be.