### PR TITLE
[FIX] account_cashbox_l10n_latam_check:fix filtering of cashbox sessions

### DIFF
--- a/account_cashbox_l10n_latam_check/wizards/l10n_latam_payment_mass_transfer.py
+++ b/account_cashbox_l10n_latam_check/wizards/l10n_latam_payment_mass_transfer.py
@@ -26,8 +26,10 @@ class L10nLatamPaymentMassTransfer(models.TransientModel):
     @api.depends("destination_journal_id")
     def _compute_cashbox_session_id(self):
         for rec in self:
-            session_ids = self.env["account.cashbox.session"].search(
-                [("state", "=", "opened"), "|", ("user_ids", "=", self.env.uid), ("user_ids", "=", False)]
+            session_ids = (
+                self.env["account.cashbox.session"]
+                .search([("state", "=", "opened"), "|", ("user_ids", "=", self.env.uid), ("user_ids", "=", False)])
+                .filtered(lambda x: rec.destination_journal_id in x.cashbox_id.journal_ids)
             )
             if len(session_ids) == 1:
                 rec.cashbox_session_id = session_ids.id


### PR DESCRIPTION
Filtering of cashbox sessions is now correctly based on the destination journal. This ensures that only cashbox sessions associated with the selected destination journal are considered.