### PR TITLE
[18.0][FIX] l10n_latam_check_ux: correct menuitem parent

### DIFF
--- a/l10n_latam_check_ux/wizards/checks_to_date_view.xml
+++ b/l10n_latam_check_ux/wizards/checks_to_date_view.xml
@@ -29,7 +29,7 @@
             id="menu_account_check_to_date_report"
             name="Cheques a fecha"
             sequence="20"
-            parent="account_reports.account_reports_audit_reports_menu"
+            parent="account.account_reports_management_menu"
             action="action_account_check_to_date_report"
             />
 


### PR DESCRIPTION
The parent menu of the wizard "Cheques a la Fecha" is wrong.
The installation fails because of this.