### PR TITLE
[FIX] account_cashbox: only adjust rounding on cash control journals

### DIFF
--- a/account_cashbox/wizards/account_cashbox_rounding_adjustment.py
+++ b/account_cashbox/wizards/account_cashbox_rounding_adjustment.py
@@ -13,7 +13,9 @@ class AccountCashboxRoundingAdjustment(models.TransientModel):
         """
 
         # Create journal entries for each line with a rounding difference
-        for line in self.cashbox_session_id.line_ids.filtered(lambda x: x.balance_difference != 0):
+        for line in self.cashbox_session_id.line_ids.filtered(
+            lambda x: x.balance_difference != 0 and x.require_cash_control
+        ):
             currency = line.journal_id.currency_id or self.cashbox_session_id.company_id.currency_id
             if currency != self.cashbox_session_id.company_id.currency_id:
                 negative_amount = abs(min(line.balance_difference, 0.0)) / currency.rate


### PR DESCRIPTION
- Filter rounding adjustment by require_cash_control flag
- Skip creating journal entries for non-cash-control journals
- Modified action_create_journal_entries in AccountCashboxRoundingAdjustment wizard

Change note: Al cerrar una sesión de caja, ahora solo se crean ajustes de redondeo para los diarios que tienen control de efectivo activado. Esto evita que se generen asientos contables innecesarios en diarios que no requieren verificación de saldo.