### PR TITLE
[IMP] l10n_latam_check_ux: prevent deletion of payment methods with a…

### DIFF
--- a/l10n_latam_check_ux/i18n/es.po
+++ b/l10n_latam_check_ux/i18n/es.po
@@ -426,6 +426,12 @@ msgstr "account.check.to_date.report.wizard"
 msgid "or"
 msgstr "o"
 
+#. module: l10n_latam_check_ux
+#. odoo-python
+#: code:addons/l10n_latam_check_ux/models/account_payment_method_line.py:0
+msgid "You cannot delete this payment method because it has associated checks. You must first delete or reassign all related checks."
+msgstr "No puede eliminar este método de pago porque tiene cheques asociados. Primero debe eliminar o reasignar todos los cheques relacionados."
+
 #~ msgid ""
 #~ "Operation not allowed: To transfer the checks, you must be operating in "
 #~ "the same company where the checks are registered. Please switch to the "

--- a/l10n_latam_check_ux/i18n/l10n_latam_check_ux.pot
+++ b/l10n_latam_check_ux/i18n/l10n_latam_check_ux.pot
@@ -391,6 +391,12 @@ msgid "Total"
 msgstr ""
 
 #. module: l10n_latam_check_ux
+#. odoo-python
+#: code:addons/l10n_latam_check_ux/models/account_payment_method_line.py:0
+msgid "You cannot delete this payment method because it has associated checks. You must first delete or reassign all related checks."
+msgstr ""
+
+#. module: l10n_latam_check_ux
 #: model:ir.model,name:l10n_latam_check_ux.model_account_check_to_date_report_wizard
 msgid "account.check.to_date.report.wizard"
 msgstr ""

--- a/l10n_latam_check_ux/models/__init__.py
+++ b/l10n_latam_check_ux/models/__init__.py
@@ -2,3 +2,4 @@ from . import account_payment
 from . import account_journal
 from . import l10n_latam_check
 from . import res_partner
+from . import account_payment_method_line

--- a/l10n_latam_check_ux/models/account_payment_method_line.py
+++ b/l10n_latam_check_ux/models/account_payment_method_line.py
@@ -1,0 +1,25 @@
+from odoo import _, models
+from odoo.exceptions import UserError
+
+
+class AccountPaymentMethodLine(models.Model):
+    _inherit = "account.payment.method.line"
+
+    def unlink(self):
+        """Prevenir eliminación si hay cheques pendientes asociados."""
+        for rec in self:
+            if rec.code in ["new_third_party_checks", "own_checks", "issued_checks"]:
+                checks = (
+                    self.env["l10n_latam.check"]
+                    .sudo()
+                    .search([("current_journal_id", "=", rec.journal_id.id)], limit=1)
+                )
+                if checks:
+                    raise UserError(
+                        _(
+                            "You cannot delete this payment method because it has "
+                            "associated checks. You must first delete or reassign "
+                            "all related checks."
+                        )
+                    )
+        return super().unlink()


### PR DESCRIPTION
- Create account_payment_method_line.py model inheriting account.payment.method.line
- Override unlink() method to validate payment method deletion
- Search for checks by current_journal_id (journal-based association)
- Apply validation to check-related payment methods (new_third_party_checks, own_checks, issued_checks)
- Display user-friendly error message when deletion is blocked
- Update translations for error messages

The validation prevents accidental deletion of payment methods when there are
active checks associated with the journal. The implementation overrides unlink()
directly instead of using @api.ondelete to ensure proper execution, as the base
model filters records before calling super().

Change note: Se agregó protección para evitar eliminar métodos de pago de cheques (propios, de terceros, emitidos) de un diario cuando hay cheques activos asociados. Al intentar eliminar un método de pago con cheques pendientes, el sistema muestra un mensaje de error indicando que primero debe eliminar o reasignar todos los cheques relacionados.