### PR TITLE
[FIX] _payment_pro: fixes with bundle payments

### DIFF
--- a/account_payment_pro/views/account_payment_view.xml
+++ b/account_payment_pro/views/account_payment_view.xml
@@ -63,11 +63,13 @@
         <div name="amount_div" position="after">
             <!-- Rate de contrapartida: visible solo si A != B1 AND B1 != C -->
             <label for="user_counterpart_rate" string="Rate"
-                invisible="currency_id == counterpart_currency_id
+                invisible="not counterpart_currency_id
+                        or currency_id == counterpart_currency_id
                         or counterpart_currency_id == company_currency_id"/>
             <!-- Caso invertido (B1 fuerte): "1 B1 = X A" -->
             <div name="counterpart_rate_lt1" class="d-flex gap-1 text-muted"
-                invisible="currency_id == counterpart_currency_id
+                invisible="not counterpart_currency_id
+                        or currency_id == counterpart_currency_id
                         or counterpart_currency_id == company_currency_id
                         or not counterpart_rate_inverted">
                 <span>1</span>
@@ -81,7 +83,8 @@
             </div>
             <!-- Caso directo (A fuerte): "1 A = X B1" -->
             <div name="counterpart_rate_gte1" class="d-flex gap-1 text-muted"
-                invisible="currency_id == counterpart_currency_id
+                invisible="not counterpart_currency_id
+                        or currency_id == counterpart_currency_id
                         or counterpart_currency_id == company_currency_id
                         or counterpart_rate_inverted">
                 <span>1</span>

--- a/l10n_ar_payment_bundle/models/account_payment.py
+++ b/l10n_ar_payment_bundle/models/account_payment.py
@@ -129,6 +129,15 @@ class AccountPayment(models.Model):
         main_paments.amount = 0.0
         super(AccountPayment, self - main_paments)._compute_amount()
 
+    @api.onchange("to_pay_move_line_ids")
+    def _onchange_to_pay_lines_adjust_amount(self):
+        """Para pagos principales del bundle, amount siempre debe ser 0; evita que
+        la lógica de account_payment_pro intente ajustar el amount y dispare la
+        constraint _check_amount_in_main_payment."""
+        main_payments = self.filtered("is_main_payment")
+        main_payments.amount = 0
+        super(AccountPayment, self - main_payments)._onchange_to_pay_lines_adjust_amount()
+
     @api.onchange("withholdings_amount")
     def _onchange_withholdings(self):
         """dejamos este onchange además del compute_amount porque "le gana" en ejecución y, si cambian retenciones le asignaba un amount"""

--- a/l10n_ar_payment_bundle/views/account_payment_view.xml
+++ b/l10n_ar_payment_bundle/views/account_payment_view.xml
@@ -58,6 +58,13 @@
             <xpath expr="//div[@name='write_off_amount']" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>
+            <!-- En el modal de linked payment no tiene sentido ajustar amount ni write-off individualmente -->
+            <button name="action_adjust_amount_for_difference" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </button>
+            <button name="action_adjust_writeoff_for_difference" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </button>
 
             <field name="counterpart_currency_id" position="attributes">
                 <attribute name="readonly">1</attribute>
@@ -143,6 +150,10 @@
             <div name="amount_div" position="attributes">
                 <attribute name="invisible">is_main_payment</attribute>
             </div>
+            <!-- Ocultar botón "→ Amount" en pago principal: amount siempre debe ser 0 -->
+            <button name="action_adjust_amount_for_difference" position="attributes">
+                <attribute name="invisible" separator=" or " add="is_main_payment"/>
+            </button>
             <div name="counterpart_currency_amount" position="attributes">
                 <attribute name="invisible" separator=" or " add="is_main_payment"></attribute>
             </div>


### PR DESCRIPTION
- Ocultar campo "Tasa" cuando counterpart_currency_id no está definido
- Ocultar botón "→ Amount" en pago principal Bundle (amount siempre es 0)
- Ocultar botones "→ Amount" y "→ Write-off" en modal de pago vinculado
- Sobreescribir _onchange_to_pay_lines_adjust_amount en bundle para prevenir que la lógica de account_payment_pro ajuste el amount del pago principal y dispare la constraint _check_amount_in_main_payment