### PR TITLE
[IMP] account_payment_pro: add amount_exact field to preserve full decimal precision

### DIFF
--- a/account_payment_pro/models/account_move.py
+++ b/account_payment_pro/models/account_move.py
@@ -72,6 +72,7 @@ class AccountMove(models.Model):
                 payment.payment_method_id = pay_journal._get_manual_payment_method_id(payment_type).id
 
             payment.amount = abs(difference)
+            payment.amount_exact = abs(difference)
             payment.action_post()
             rec.write({"matched_payment_ids": [(4, payment.id)]})
 

--- a/account_payment_pro/models/account_move_line.py
+++ b/account_payment_pro/models/account_move_line.py
@@ -72,6 +72,7 @@ class AccountMoveLine(models.Model):
                 "default_partner_type": partner_type,
                 "default_partner_id": to_pay_partner_id,
                 "default_amount": abs(to_pay_amount),
+                "default_amount_exact": abs(to_pay_amount),
                 "default_to_pay_move_line_ids": to_pay_move_lines.ids,
                 # We set this because if became from other view and in the context has 'create=False'
                 # you can't crate payment lines (for ej: subscription)

--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -132,6 +132,33 @@ class AccountPayment(models.Model):
     use_payment_pro = fields.Boolean(compute="_compute_use_payment_pro")
 
     open_move_line_ids = fields.One2many(related="move_id.open_move_line_ids")
+    # Campo técnico para round-trip del onchange: el cliente lo devuelve en cada llamada,
+    # evitando depender de _origin (que no se actualiza entre onchanges y no existe en registros nuevos).
+    previous_currency_id = fields.Many2one(
+        "res.currency",
+        store=True,
+        copy=False,
+    )
+    amount_exact = fields.Float(
+        string="Amount (Exact)",
+        digits=0,
+        copy=False,
+        help="Exact value of amount with full precision, used internally for conversions to avoid rounding errors.",
+    )
+
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        if "previous_currency_id" in fields_list and "previous_currency_id" not in res:
+            currency_id = res.get("currency_id")
+            if not currency_id:
+                journal_id = res.get("journal_id") or self._context.get("default_journal_id")
+                if journal_id:
+                    journal = self.env["account.journal"].browse(journal_id)
+                    currency_id = (journal.currency_id or journal.company_id.currency_id).id
+            if currency_id:
+                res["previous_currency_id"] = currency_id
+        return res
 
     @api.depends("journal_id")
     def _compute_counterpart_currency_id(self):
@@ -167,7 +194,16 @@ class AccountPayment(models.Model):
             self.move_id.posted_before = False
         super().action_draft()
 
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if "amount" in vals and "amount_exact" not in vals:
+                vals["amount_exact"] = vals["amount"]
+        return super().create(vals_list)
+
     def write(self, vals):
+        if "amount" in vals and "amount_exact" not in vals:
+            vals["amount_exact"] = vals["amount"]
         for rec in self:
             if rec.company_id.use_payment_pro or (
                 "company_id" in vals and rec.env["res.company"].browse(vals["company_id"]).use_payment_pro
@@ -290,7 +326,50 @@ class AccountPayment(models.Model):
         if self._origin.company_id and self.company_id != self._origin.company_id and self.state == "draft":
             self.remove_all()
 
-    @api.depends("amount", "other_currency", "force_amount_company_currency")
+    @api.onchange("amount")
+    def _onchange_amount_update_exact(self):
+        for rec in self:
+            if not rec.currency_id.is_zero(rec.amount - rec.amount_exact):
+                rec.amount_exact = rec.amount
+
+    @api.onchange("currency_id")
+    def _onchange_currency_recompute_amount(self):
+        """Al cambiar la moneda del diario, reconvertir amount a la nueva moneda A."""
+        for rec in self:
+            new_currency = rec.currency_id
+            # previous_currency_id se round-tripea desde el cliente en cada onchange,
+            # por eso refleja la moneda real anterior (funciona en registros nuevos y
+            # en cambios consecutivos A→B→C sin guardar, donde _origin no sirve).
+            old_currency = rec.previous_currency_id or rec._origin.currency_id
+            if not old_currency:
+                old_currency = rec.company_currency_id
+            # Actualizar para el próximo onchange antes de cualquier continue
+            rec.previous_currency_id = new_currency
+            if rec.state != "draft" or not rec.amount:
+                continue
+
+            old_amount = rec.amount_exact or rec.amount
+            if not old_amount:
+                old_amount = rec.env.context.get("default_amount", 0.0)
+            amount = abs(
+                old_currency._convert(
+                    old_amount,
+                    new_currency,
+                    rec.company_id,
+                    rec.date or fields.Date.context_today(rec),
+                    False,
+                )
+            )
+            if (
+                rec.env.context.get("default_amount")
+                and rec.currency_id == rec.company_currency_id
+                and rec.amount_exact == rec._origin.amount_exact
+                and not rec.currency_id.is_zero(amount - rec.env.context.get("default_amount"))
+            ):
+                amount = rec.env.context.get("default_amount")
+            rec.update({"amount_exact": amount, "amount": amount})
+
+    @api.depends("amount", "amount_exact", "other_currency", "force_amount_company_currency")
     def _compute_amount_company_currency(self):
         """
         * Si las monedas son iguales devuelve 1
@@ -298,13 +377,14 @@ class AccountPayment(models.Model):
         * sino, devuelve el amount convertido a la moneda de la cia
         """
         for rec in self:
+            amount = rec.amount_exact or rec.amount
             if not rec.other_currency:
-                amount_company_currency = rec.amount
+                amount_company_currency = amount
             elif rec.force_amount_company_currency:
                 amount_company_currency = rec.force_amount_company_currency
             else:
                 amount_company_currency = rec.currency_id._convert(
-                    rec.amount, rec.company_id.currency_id, rec.company_id, rec.date
+                    amount, rec.company_id.currency_id, rec.company_id, rec.date
                 )
             rec.amount_company_currency = amount_company_currency
 

--- a/account_payment_pro/views/account_payment_view.xml
+++ b/account_payment_pro/views/account_payment_view.xml
@@ -57,6 +57,9 @@
 
         <div name="amount_div" position="after">
             <field name="company_currency_id" invisible="True"/>
+            <!-- Campo técnico: round-trip de la moneda anterior para _onchange_currency_recompute_amount -->
+            <field name="previous_currency_id" invisible="True"/>
+            <field name="amount_exact" invisible="True"/>
             <field name="other_currency" invisible="True"/>
             <field name="force_amount_company_currency" invisible="True"/>
             <div class="o_row" name="exchange_rate_div" invisible="not other_currency">


### PR DESCRIPTION


When the payment amount is stored in the Monetary field, it gets rounded to the currency's decimal places. This causes precision loss during currency conversions (e.g. ARS → USD → ARS) where intermediate values lose significant decimals.

Add amount_exact (Float, digits=0) to store the unrounded amount value. This field is automatically synced via create/write overrides and used in:
- _compute_amount_company_currency: convert using exact amount
- _onchange_currency_recompute_amount: reconvert using exact amount when the journal currency changes

Also add previous_currency_id to properly track the old currency across consecutive onchange calls without relying on _origin.