### PR TITLE
[FIX] account_payment_pro: pay_now() asiento invertido en in_invoice e in_refund

### DIFF
--- a/account_payment_pro/models/account_move.py
+++ b/account_payment_pro/models/account_move.py
@@ -29,17 +29,27 @@ class AccountMove(models.Model):
                 and r.account_id.account_type in self.env["account.payment"]._get_valid_payment_account_types()
             )
 
+    # Map explícito move_type → (payment_type, partner_type).
+    # Se usa en pay_now() para setear el payment_type correcto desde el create,
+    # evitando el truco de "crear inbound y flipear" que dejó de funcionar en v19
+    # cuando _compute_selected_debt pasó a calcular el signo por payment_type en
+    # lugar de partner_type (refactor tri-currency).
+    _PAY_NOW_TYPE_MAP = {
+        "in_invoice": ("outbound", "supplier"),
+        "out_invoice": ("inbound", "customer"),
+        "in_refund": ("inbound", "supplier"),
+        "out_refund": ("outbound", "customer"),
+    }
+
     def pay_now(self):
         for rec in self.filtered(
-            lambda x: x.pay_now_journal_id and x.state == "posted" and x.payment_state in ("not_paid", "patial")
+            lambda x: x.pay_now_journal_id
+            and x.state == "posted"
+            and x.payment_state in ("not_paid", "partial")
+            and x.move_type in self._PAY_NOW_TYPE_MAP
         ):
             pay_journal = rec.pay_now_journal_id
-            if rec.move_type in ["in_invoice", "in_refund"]:
-                partner_type = "supplier"
-            else:
-                partner_type = "customer"
-
-            payment_type = "inbound"
+            payment_type, partner_type = self._PAY_NOW_TYPE_MAP[rec.move_type]
             payment_method = pay_journal._get_manual_payment_method_id(payment_type)
 
             payment = (
@@ -60,18 +70,7 @@ class AccountMove(models.Model):
                 )
             )
 
-            # compute payment_difference here to avoid lazy evaluation issues
-            difference = payment.payment_difference
-
-            # el difference es positivo para facturas (de cliente o proveedor) pero negativo para NC.
-            # para factura de proveedor o NC de cliente es outbound
-            # para factura de cliente o NC de proveedor es inbound
-            # igualmente lo hacemos con el difference y no con el type por las dudas de que facturas en negativo
-            if partner_type == "supplier" and difference >= 0.0 or partner_type == "customer" and difference < 0.0:
-                payment.payment_type = "outbound"
-                payment.payment_method_id = pay_journal._get_manual_payment_method_id(payment_type).id
-
-            payment.amount = abs(difference)
+            payment.amount = abs(payment.payment_difference)
             payment.action_post()
             rec.write({"matched_payment_ids": [(4, payment.id)]})
 

--- a/account_payment_pro/tests/__init__.py
+++ b/account_payment_pro/tests/__init__.py
@@ -1,1 +1,6 @@
-from . import test_account_paymet_pro_unit_test, test_payment_multimoneda, test_internal_transfer_multimoneda
+from . import (
+    test_account_paymet_pro_unit_test,
+    test_internal_transfer_multimoneda,
+    test_pay_now,
+    test_payment_multimoneda,
+)

--- a/account_payment_pro/tests/test_pay_now.py
+++ b/account_payment_pro/tests/test_pay_now.py
@@ -1,0 +1,126 @@
+"""Tests para el flujo pay_now_journal_id ("Diario de pago directo") del modelo
+account.move.
+
+Regresion cubierta:
+En v19 el refactor tri-currency cambio _compute_selected_debt para calcular el
+signo a partir de payment_type en lugar de partner_type. El codigo original de
+pay_now() creaba el account.payment con payment_type="inbound" hardcodeado y lo
+flipeaba despues a "outbound" segun el signo de payment_difference; en v19 ese
+flip nunca se activaba para in_invoice / in_refund, quedando un asiento
+invertido no reconciliable. Estos tests garantizan que los cuatro move_types
+generen pagos con payment_type correcto, asiento con el lado correcto, y
+factura en payment_state=paid tras el action_post.
+"""
+
+from odoo import Command, fields
+from odoo.tests import common, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestPayNowJournal(common.TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.today = fields.Date.today()
+        cls.company = cls.env.company
+        cls.company.use_payment_pro = True
+
+        # Journal bank con outstanding accounts seteados (igual que los otros tests)
+        cls.pay_journal = cls.env["account.journal"].search(
+            [("company_id", "=", cls.company.id), ("type", "=", "bank")], limit=1
+        )
+        outstanding_account = cls.env["account.account"].search(
+            [("company_ids", "=", cls.company.id), ("account_type", "=", "asset_current")], limit=1
+        )
+        if outstanding_account:
+            for pml in cls.pay_journal.inbound_payment_method_line_ids:
+                if not pml.payment_account_id:
+                    pml.payment_account_id = outstanding_account
+            for pml in cls.pay_journal.outbound_payment_method_line_ids:
+                if not pml.payment_account_id:
+                    pml.payment_account_id = outstanding_account
+
+        cls.sale_journal = cls.env["account.journal"].search(
+            [("company_id", "=", cls.company.id), ("type", "=", "sale")], limit=1
+        )
+        cls.purchase_journal = cls.env["account.journal"].search(
+            [("company_id", "=", cls.company.id), ("type", "=", "purchase")], limit=1
+        )
+
+        ar = cls.env.ref("base.ar", raise_if_not_found=False)
+        partner_vals = {"name": "Pay Now Partner"}
+        if ar:
+            partner_vals["country_id"] = ar.id
+        cls.partner = cls.env["res.partner"].create(partner_vals)
+        cls.product = cls.env.ref("product.product_product_16")
+
+    def _make_invoice(self, move_type, journal):
+        invoice = self.env["account.move"].create(
+            {
+                "partner_id": self.partner.id,
+                "invoice_date": self.today,
+                "move_type": move_type,
+                "journal_id": journal.id,
+                "company_id": self.company.id,
+                "pay_now_journal_id": self.pay_journal.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.product.id,
+                            "quantity": 1,
+                            "price_unit": 100.0,
+                            "tax_ids": False,
+                        }
+                    ),
+                ],
+            }
+        )
+        return invoice
+
+    def _assert_reconciled(self, invoice, expected_payment_type, expected_partner_type, expected_account_type):
+        """Verifica que la factura quedo paid y el pago asociado tiene el
+        payment_type esperado con el asiento correctamente reconciliado."""
+        self.assertEqual(invoice.state, "posted")
+        self.assertEqual(invoice.payment_state, "paid", f"Invoice {invoice.move_type} should be paid")
+        self.assertEqual(invoice.amount_residual, 0.0)
+        self.assertEqual(len(invoice.matched_payment_ids), 1)
+        payment = invoice.matched_payment_ids
+        self.assertEqual(payment.payment_type, expected_payment_type)
+        self.assertEqual(payment.partner_type, expected_partner_type)
+        self.assertTrue(payment.is_reconciled, "Payment should be fully reconciled")
+
+        # Las lineas del payment sobre la cuenta AP/AR deben quedar reconciliadas.
+        # Puede haber mas de una si hay diferencia de cambio / write-off, por eso
+        # validamos con all() para no caer en Expected singleton.
+        counterpart_line = payment.move_id.line_ids.filtered(
+            lambda l: l.account_id.account_type == expected_account_type
+        )
+        self.assertTrue(counterpart_line, "Payment should have a counterpart line on AP/AR account")
+        self.assertTrue(
+            all(counterpart_line.mapped("reconciled")),
+            "All AP/AR counterpart lines should be reconciled",
+        )
+
+    def test_pay_now_in_invoice(self):
+        """Factura de proveedor: pago outbound, Dr Payables / Cr Liquidity."""
+        invoice = self._make_invoice("in_invoice", self.purchase_journal)
+        invoice.action_post()
+        self._assert_reconciled(invoice, "outbound", "supplier", "liability_payable")
+
+    def test_pay_now_out_invoice(self):
+        """Factura de cliente: pago inbound, Dr Liquidity / Cr Receivables."""
+        invoice = self._make_invoice("out_invoice", self.sale_journal)
+        invoice.action_post()
+        self._assert_reconciled(invoice, "inbound", "customer", "asset_receivable")
+
+    def test_pay_now_in_refund(self):
+        """NC de proveedor: pago inbound (el proveedor te devuelve)."""
+        invoice = self._make_invoice("in_refund", self.purchase_journal)
+        invoice.action_post()
+        self._assert_reconciled(invoice, "inbound", "supplier", "liability_payable")
+
+    def test_pay_now_out_refund(self):
+        """NC de cliente: pago outbound (le devolves al cliente)."""
+        invoice = self._make_invoice("out_refund", self.sale_journal)
+        invoice.action_post()
+        self._assert_reconciled(invoice, "outbound", "customer", "asset_receivable")


### PR DESCRIPTION
Closes #1021.

## Summary

`account.move.pay_now()` (flujo "Diario de pago directo" vía `pay_now_journal_id`) generaba un `account.payment` con asiento invertido y no reconciliable para `in_invoice` e `in_refund` en `19.0`. Los casos `out_invoice` y `out_refund` funcionaban por casualidad.

## Root cause

En `18.0`, `_compute_selected_debt` calculaba el signo de `selected_debt` a partir de `partner_type`. `pay_now()` dependía de eso: creaba el `account.payment` con `payment_type="inbound"` hardcodeado y lo flipeaba a `"outbound"` en función del signo de `payment_difference`.

En `19.0`, el refactor tri-currency cambió `_compute_selected_debt` para calcular el signo por `payment_type`. Con `payment_type="inbound"` inicial, el signo de `selected_debt` queda invertido para facturas de proveedor, `payment_difference` resulta negativa, el condicional del flip nunca se cumple, y el pago queda `inbound` con asiento `Dr Liquidity / Cr Payables` — del mismo lado que la `Cr Payables` de la factura. No se puede reconciliar.

### Matriz previa al fix

| `move_type` | Comportamiento | Resultado |
|---|---|---|
| `in_invoice` | Queda `inbound`, asiento `Dr Liquidity / Cr Payables` | **ROTO** |
| `in_refund` | Flipea a `outbound` cuando `inbound` sería correcto | **ROTO** |
| `out_invoice` | Queda `inbound`, asiento correcto | OK por casualidad |
| `out_refund` | Flipea a `outbound`, asiento correcto | OK por casualidad |

## Solution

Setear `payment_type` y `partner_type` correctos desde el `create()`, eliminando el truco del flip post-create. El flip servía en `18.0` porque `_compute_selected_debt` dependía de `partner_type`; en `19.0` ya no es un workaround válido y genera el bug.

Se introduce `_PAY_NOW_TYPE_MAP` como mapa explícito `move_type → (payment_type, partner_type)`:

| `move_type` | `payment_type` | `partner_type` |
|---|---|---|
| `in_invoice` | `outbound` | `supplier` |
| `out_invoice` | `inbound` | `customer` |
| `in_refund` | `inbound` | `supplier` |
| `out_refund` | `outbound` | `customer` |

Con `payment_type` correcto desde el arranque, `_compute_selected_debt` calcula el signo correcto, `payment_difference` cuadra, `action_post()` genera el asiento correcto, y `_reconcile_after_post()` concilia.

## Cambios adicionales

- Typo `"patial"` → `"partial"` en el filtro de `payment_state`, que impedía que el flujo aplicara sobre facturas parcialmente pagadas.
- Filtro `x.move_type in self._PAY_NOW_TYPE_MAP` en el `filtered()` como fail-safe para no procesar `move_type` fuera de factura/NC.

## Tests

Nuevo `account_payment_pro/tests/test_pay_now.py` con cobertura de los cuatro `move_type`. Cada test valida:

- `payment.payment_type` correcto
- `payment.partner_type` correcto
- Asiento con `counterpart_line.reconciled=True` en la cuenta AP/AR correspondiente
- `payment.is_reconciled=True`
- `invoice.payment_state == "paid"`
- `invoice.amount_residual == 0`

La ausencia de test para este flujo es lo que permitió que la regresión del refactor tri-currency pasara el CI.

## Verificación manual

Verificado en producción sobre factura `in_invoice` de proveedor. Antes del fix:

```
selected_debt     = -N
to_pay_amount     = -N
payment_total     =  N
payment_difference= -2N  ← negativo, condicional nunca se cumple
```

Después del fix, mismo escenario:

```
selected_debt     =  N
to_pay_amount     =  N
payment_total     =  N
payment_difference=  0
```

Payment: `payment_type=outbound`, asiento `Dr Payables / Cr Liquidity`, `is_reconciled=True`, invoice `payment_state=paid`.
