### PR TITLE
[IMP] account_cashbox: allow forced currency rate in rounding adjustment wizard

### DIFF
--- a/account_cashbox/i18n/account_cashbox.pot
+++ b/account_cashbox/i18n/account_cashbox.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-23 18:51+0000\n"
-"PO-Revision-Date: 2026-02-23 18:51+0000\n"
+"POT-Creation-Date: 2026-04-22 17:40+0000\n"
+"PO-Revision-Date: 2026-04-22 17:40+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -196,6 +196,13 @@ msgid "Cashbox session associated with this move."
 msgstr ""
 
 #. module: account_cashbox
+#: model:ir.model.fields,help:account_cashbox.field_account_cashbox_rounding_adjustment_wizard__force_rate
+msgid ""
+"Check to manually set the exchange rate. If unchecked, the system will use "
+"the current currency exchange rate."
+msgstr ""
+
+#. module: account_cashbox
 #: model_terms:ir.ui.view,arch_db:account_cashbox.view_account_cashbox_session_form
 msgid "Close"
 msgstr ""
@@ -347,6 +354,26 @@ msgid "Font awesome icon e.g. fa-tasks"
 msgstr ""
 
 #. module: account_cashbox
+#: model:ir.model.fields,field_description:account_cashbox.field_account_cashbox_rounding_adjustment_wizard__force_rate
+msgid "Force Rate"
+msgstr ""
+
+#. module: account_cashbox
+#: model_terms:ir.ui.view,arch_db:account_cashbox.view_account_cashbox_rounding_adjustment_wizard
+msgid "Force rate?"
+msgstr ""
+
+#. module: account_cashbox
+#: model:ir.model.fields,field_description:account_cashbox.field_account_cashbox_rounding_adjustment_wizard__forced_rate
+msgid "Forced Rate"
+msgstr ""
+
+#. module: account_cashbox
+#: model:ir.model.fields,field_description:account_cashbox.field_account_cashbox_rounding_adjustment_wizard__has_currency
+msgid "Has Currency"
+msgstr ""
+
+#. module: account_cashbox
 #: model:ir.model.fields,field_description:account_cashbox.field_account_cashbox_session__has_message
 msgid "Has Message"
 msgstr ""
@@ -470,6 +497,11 @@ msgstr ""
 #. module: account_cashbox
 #: model_terms:ir.ui.view,arch_db:account_cashbox.view_account_cashbox_kanban
 msgid "List Sessions"
+msgstr ""
+
+#. module: account_cashbox
+#: model:ir.model.fields,help:account_cashbox.field_account_cashbox_rounding_adjustment_wizard__forced_rate
+msgid "Manually set the currency exchange rate for the adjustment"
 msgstr ""
 
 #. module: account_cashbox

--- a/account_cashbox/i18n/es.po
+++ b/account_cashbox/i18n/es.po
@@ -833,3 +833,42 @@ msgstr "Requiere control de efectivo"
 #: model:ir.model,name:account_cashbox.model_account_cashbox_session_line
 msgid "session journal"
 msgstr "Diario de la sesión"
+
+#. module: account_cashbox
+#: model_terms:ir.ui.view,arch_db:account_cashbox.view_account_cashbox_rounding_adjustment_wizard
+msgid "Currency Rate"
+msgstr "Tasa de cambio"
+
+#. module: account_cashbox
+#: model:ir.model.fields,help:account_cashbox.field_account_cashbox_rounding_adjustment_wizard__force_rate
+msgid ""
+"Check to manually set the exchange rate. If unchecked, the system will use "
+"the current currency exchange rate."
+msgstr ""
+"Marque para establecer manualmente la tasa de cambio. Si no está marcado, "
+"el sistema usará la tasa de cambio actual."
+
+#. module: account_cashbox
+#: model_terms:ir.ui.view,arch_db:account_cashbox.view_account_cashbox_rounding_adjustment_wizard
+msgid "Force rate?"
+msgstr "¿Forzar tasa?"
+
+#. module: account_cashbox
+#: model:ir.model.fields,field_description:account_cashbox.field_account_cashbox_rounding_adjustment_wizard__force_rate
+msgid "Force Rate"
+msgstr "Forzar tasa"
+
+#. module: account_cashbox
+#: model:ir.model.fields,field_description:account_cashbox.field_account_cashbox_rounding_adjustment_wizard__forced_rate
+msgid "Forced Rate"
+msgstr "Tasa forzada"
+
+#. module: account_cashbox
+#: model:ir.model.fields,field_description:account_cashbox.field_account_cashbox_rounding_adjustment_wizard__has_currency
+msgid "Has Currency"
+msgstr "Tiene moneda"
+
+#. module: account_cashbox
+#: model:ir.model.fields,help:account_cashbox.field_account_cashbox_rounding_adjustment_wizard__forced_rate
+msgid "Manually set the currency exchange rate for the adjustment"
+msgstr "Establecer manualmente la tasa de cambio para el ajuste"

--- a/account_cashbox/wizards/account_cashbox_rounding_adjustment.py
+++ b/account_cashbox/wizards/account_cashbox_rounding_adjustment.py
@@ -1,4 +1,4 @@
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class AccountCashboxRoundingAdjustment(models.TransientModel):
@@ -6,6 +6,18 @@ class AccountCashboxRoundingAdjustment(models.TransientModel):
     _description = "Cashbox Rounding Adjustment"
 
     cashbox_session_id = fields.Many2one("account.cashbox.session")
+    forced_rate = fields.Float(
+        help="Manually set the currency exchange rate for the adjustment",
+        store=True,
+        readonly=False,
+    )
+    force_rate = fields.Boolean(
+        help="Check to manually set the exchange rate. If unchecked, the system will use the current currency exchange rate.",
+    )
+    has_currency = fields.Boolean(
+        compute="_compute_has_currency",
+        store=False,
+    )
 
     def action_create_journal_entries(self):
         """
@@ -17,7 +29,10 @@ class AccountCashboxRoundingAdjustment(models.TransientModel):
             lambda x: x.balance_difference != 0 and x.require_cash_control
         ):
             currency = line.journal_id.currency_id or self.cashbox_session_id.company_id.currency_id
-            if currency != self.cashbox_session_id.company_id.currency_id:
+            if self.force_rate and self.forced_rate:
+                negative_amount = abs(min(line.balance_difference, 0.0)) * self.forced_rate
+                positive_amount = max(line.balance_difference, 0.0) * self.forced_rate
+            elif currency != self.cashbox_session_id.company_id.currency_id:
                 negative_amount = abs(min(line.balance_difference, 0.0)) / currency.rate
                 positive_amount = max(line.balance_difference, 0.0) / currency.rate
             else:
@@ -65,6 +80,15 @@ class AccountCashboxRoundingAdjustment(models.TransientModel):
 
         self.cashbox_session_id.write({"state": "closed"})
         return True
+
+    @api.depends("cashbox_session_id.line_ids.journal_id.currency_id", "cashbox_session_id.company_id.currency_id")
+    def _compute_has_currency(self):
+        for rec in self:
+            comp_currency = rec.cashbox_session_id.company_id.currency_id
+            rec.has_currency = any(
+                j.currency_id and j.currency_id != comp_currency
+                for j in rec.cashbox_session_id.line_ids.mapped("journal_id")
+            )
 
     def action_close_without_entries(self):
         """

--- a/account_cashbox/wizards/account_cashbox_rounding_adjustment.xml
+++ b/account_cashbox/wizards/account_cashbox_rounding_adjustment.xml
@@ -11,6 +11,9 @@
                         To resolve this, you can automatically generate journal entries for the rounding difference by clicking <b>Create Journal Entries</b>.<br/>
                         If you prefer not to create these entries, click <b>Don't create entries and close</b> to exit without changes.
                     </p>
+                    <label for="force_rate" string="Force rate?" invisible="not has_currency"/>
+                    <field name="force_rate" invisible="not has_currency"/>
+                    <field name="forced_rate" invisible="not has_currency or not force_rate"/>
                 <footer>
                     <button name="action_create_journal_entries"
                             string="Create Journal Entries"


### PR DESCRIPTION

- Add forced_rate and force_rate fields to AccountCashboxRoundingAdjustment wizard
- Add has_currency computed field to control visibility
- Update action_create_journal_entries to use forced rate if set
- Add _compute_has_currency method
- Update XML form to show forced_rate field when applicable

Change note: Ahora el asistente de ajuste de redondeo en caja permite ingresar manualmente una tasa de cambio para los asientos de ajuste, cuando la caja opera en moneda extranjera. Esto brinda mayor flexibilidad para reflejar el tipo de cambio real utilizado en la operación.