### PR TITLE
[IMP] account_cashbox: Add muted decoration for balance_end_real field

### DIFF
--- a/account_cashbox/views/account_cashbox_session.xml
+++ b/account_cashbox/views/account_cashbox_session.xml
@@ -81,6 +81,7 @@
                                     column_invisible="parent.require_cash_control == False"/>
                                 <field name="balance_end_real"
                                     required="parent.state == 'closing_control'"
+                                    decoration-muted="balance_end_real == 0.0001"
                                     readonly="parent.state != 'closing_control'"
                                     invisible = "require_cash_control == False"
                                     column_invisible="parent.require_cash_control == False or parent.state not in ['closing_control', 'closed']"/>


### PR DESCRIPTION
- Add decoration-muted="balance_end_real == 0.0001" to the balance_end_real field in the cashbox session form view.
- Improves UI feedback for special balance values.

Change note: Ahora el campo "balance_end_real" en la vista de sesión de caja muestra un estilo atenuado cuando su valor es 0.0001, facilitando la identificación visual de este caso particular para los usuarios.