### PR TITLE
[FIX] account_payment_pro: reset unreconciled_amount when partner cha…

### DIFF
--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -186,6 +186,28 @@ class AccountPayment(models.Model):
                 # la company_id se cambia correctamente.
                 if "company_id" in vals and "journal_id" in vals:
                     rec.move_id.journal_id = vals["journal_id"]
+
+        # On partner change, the web client may include a stale to_pay_amount (computed for the
+        # old partner) in the same write. If _inverse_to_pay_amount runs before to_pay_move_line_ids
+        # is recomputed for the new partner, selected_debt is still from the old partner and
+        # unreconciled_amount ends up negative. Fix: for records actually changing partner, drop
+        # to_pay_amount from vals and reset unreconciled_amount so the compute runs clean.
+        if "partner_id" in vals:
+            changing = self.filtered(
+                lambda r: r.state == "draft" and r.company_id.use_payment_pro and r.partner_id.id != vals["partner_id"]
+            )
+            if changing:
+                not_changing = self - changing
+                changing_vals = dict(vals)
+                changing_vals.pop("to_pay_amount", None)
+                changing_vals["unreconciled_amount"] = 0
+                result = True
+                if not_changing:
+                    result = super(AccountPayment, not_changing).write(vals) and result
+                if changing:
+                    result = super(AccountPayment, changing).write(changing_vals) and result
+                return result
+
         return super().write(vals)
 
     ##############################

--- a/account_payment_pro/tests/test_account_paymet_pro_unit_test.py
+++ b/account_payment_pro/tests/test_account_paymet_pro_unit_test.py
@@ -239,3 +239,43 @@ class TestAccountPaymentProUnitTest(common.TransactionCase):
             places=2,
             msg="balance on write-off line should be the write_off_amount in company currency",
         )
+
+    def test_partner_change_does_not_reset_unreconciled_amount_on_other_payments(self):
+        """Multi-record write: changing partner_id on one payment must not reset unreconciled_amount
+        on payments whose partner is not changing."""
+        partner2 = self.env["res.partner"].create({"name": "Partner B"})
+
+        payment_changing = self.env["account.payment"].create(
+            {
+                "payment_type": "outbound",
+                "partner_type": "supplier",
+                "partner_id": self.partner_ri.id,
+                "journal_id": self.company_bank_journal.id,
+                "amount": 100.0,
+            }
+        )
+        payment_not_changing = self.env["account.payment"].create(
+            {
+                "payment_type": "outbound",
+                "partner_type": "supplier",
+                "partner_id": partner2.id,
+                "journal_id": self.company_bank_journal.id,
+                "amount": 200.0,
+            }
+        )
+        # Set a non-zero unreconciled_amount on the payment that should NOT be touched
+        payment_not_changing.unreconciled_amount = 50.0
+
+        # Write partner_id change targeting the first payment's new partner, batched with the second
+        (payment_changing | payment_not_changing).write({"partner_id": partner2.id})
+
+        self.assertEqual(
+            payment_not_changing.unreconciled_amount,
+            50.0,
+            "unreconciled_amount must not be reset on payments that did not change partner",
+        )
+        self.assertEqual(
+            payment_changing.unreconciled_amount,
+            0.0,
+            "unreconciled_amount must be reset to 0 on payments that changed partner",
+        )


### PR DESCRIPTION
…nges

- In `write()`, when `partner_id` changes on a draft payment with `use_payment_pro`, strip `to_pay_amount` from `vals` and set `unreconciled_amount = 0` before calling `super().write()`
- This prevents `_inverse_to_pay_amount` from running with a stale `selected_debt` (still from the old partner), which was causing `unreconciled_amount` to become negative and `to_pay_amount` to reset to 0 after saving

Change note: Se corrige un error en los pagos: al cambiar el proveedor en un pago borrador, el campo "To Pay Amount" se ponía en 0 al guardar en lugar de mostrar la deuda del nuevo proveedor.