### PR TITLE
[FIX] l10n_latam_check_ux: force debited state when outstanding account is not reconcilable

### DIFF
--- a/l10n_latam_check_ux/models/__init__.py
+++ b/l10n_latam_check_ux/models/__init__.py
@@ -1,4 +1,5 @@
 from . import account_payment
 from . import account_journal
+from . import account_account
 from . import l10n_latam_check
 from . import res_partner

--- a/l10n_latam_check_ux/models/account_account.py
+++ b/l10n_latam_check_ux/models/account_account.py
@@ -1,0 +1,16 @@
+from odoo import models
+
+
+class AccountAccount(models.Model):
+    _inherit = "account.account"
+
+    def write(self, vals):
+        res = super().write(vals)
+        if "reconcile" in vals:
+            checks = self.env["l10n_latam.check"].search(
+                [
+                    ("outstanding_line_id.account_id", "in", self.ids),
+                ]
+            )
+            checks._compute_issue_state()
+        return res

--- a/l10n_latam_check_ux/models/l10n_latam_check.py
+++ b/l10n_latam_check_ux/models/l10n_latam_check.py
@@ -91,3 +91,10 @@ class l10nLatamAccountPaymentCheck(models.Model):
         partner_id_change = self._origin.payment_id.partner_id != self.payment_id.partner_id
         if payment_method_change or partner_id_change:
             super()._compute_issuer_vat()
+
+    def _compute_issue_state(self):
+        super()._compute_issue_state()
+        for rec in self:
+            account = rec.outstanding_line_id.account_id
+            if account and not account.reconcile:
+                rec.issue_state = "debited"


### PR DESCRIPTION

When an own check's outstanding account (payment_method_line_id.payment_account_id) is not marked as reconcilable, the base _compute_issue_state heuristic fails: it checks whether the matched debit lines belong to accounts of type liability_payable/asset_receivable to distinguish voided vs debited, but non-reconcilable accounts are never matched that way, causing the state to fall back to voided incorrectly.

Fix: override _compute_issue_state in the UX module to inspect the outstanding_line_id.account_id.reconcile flag directly. If the account is non-reconcilable and the line is fully settled (amount_residual == 0), the check must be debited, not voided.