### PR TITLE
[FIX] l10n_latam_check:  allow check transfers between branch companies

### DIFF
--- a/l10n_latam_check_ux/models/l10n_latam_check.py
+++ b/l10n_latam_check_ux/models/l10n_latam_check.py
@@ -17,6 +17,7 @@ class l10nLatamAccountPaymentCheck(models.Model):
         readonly=True,
     )
     operation_ids = fields.Many2many(check_company=False)
+    outstanding_line_id = fields.Many2one(check_company=False)
 
     @api.depends("operation_ids.state", "payment_id.state")
     def _compute_company_id(self):

--- a/l10n_latam_check_ux/tests/test_check_transfers.py
+++ b/l10n_latam_check_ux/tests/test_check_transfers.py
@@ -87,9 +87,13 @@ class TestL10nLatamCheckUxTransfers(AccountTestInvoicingCommon):
 
         cls.assertTrue(cls.company_bank_journal.ids, "A bank journal is required to run this test")
         cls.assertTrue(
-            cls.third_party_check_journal.ids, "Third party check journal was not created so we can run the tests"
+            cls.third_party_check_journal.ids,
+            "Third party check journal was not created so we can run the tests",
         )
-        cls.assertTrue(cls.rejected_check_journal.ids, "Rejected check journal was not created so we can run the tests")
+        cls.assertTrue(
+            cls.rejected_check_journal.ids,
+            "Rejected check journal was not created so we can run the tests",
+        )
 
         outbound_method_commands = []
         if not cls.company_bank_journal.outbound_payment_method_line_ids.filtered(


### PR DESCRIPTION
- Override `outstanding_line_id` on `l10n_latam.check` with `check_company=False` to prevent a false "company crossover" UserError when transferring third-party checks between journals belonging to different branch companies (same root company). The field already existed in core with `check_company=True`; `operation_ids` was already overridden the same way.
- Add unit test `test_check_transfer_between_branches_no_company_crossover_error` in `TestL10nLatamCheckUxTransfers` to assert the transfer completes without error and the check lands in the branch journal.

Change note: Se corrigió un error que impedía transferir cheques de terceros entre sucursales de la misma empresa. Ahora la transferencia se realiza correctamente sin mostrar el mensaje "no company crossover is allowed".