### PR TITLE
[IMP] account_payment_pro: clear to_pay_move_line_ids on partner change

### DIFF
--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -222,6 +222,12 @@ class AccountPayment(models.Model):
                 # la company_id se cambia correctamente.
                 if "company_id" in vals and "journal_id" in vals:
                     rec.move_id.journal_id = vals["journal_id"]
+
+        if "partner_id" in vals:
+            self.filtered(
+                lambda r: r.state == "draft" and r.company_id.use_payment_pro and r.partner_id.id != vals["partner_id"]
+            ).remove_all()
+
         return super().write(vals)
 
     ##############################


### PR DESCRIPTION
In AccountPayment.write, when partner_id is updated and the record is in draft with use_payment_pro active, and the new partner is different from the current one, the method remove_all() is called to clear to_pay_move_line_ids.

Change note:
Al modificar el partner en un pago en estado borrador y con Payment Pro activo, ahora se eliminan automáticamente las líneas a pagar si el partner realmente cambia. Esto evita que queden líneas asociadas al partner anterior, reduciendo errores y mejorando la consistencia de los datos.