### PR TITLE
[FIX] account_payment_pro: sync payment amount when to_pay_move_line_ids changes

### DIFF
--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -645,6 +645,12 @@ class AccountPayment(models.Model):
         for rec in self:
             rec.to_pay_amount = rec.selected_debt + rec.unreconciled_amount
 
+    @api.onchange("to_pay_move_line_ids")
+    def _onchange_amount(self):
+        for rec in self.filtered(lambda r: r.company_id.use_payment_pro):
+            if rec.amount != abs(rec.to_pay_amount):
+                rec.amount = abs(rec.to_pay_amount)
+
     @api.onchange("to_pay_amount")
     def _inverse_to_pay_amount(self):
         for rec in self:


### PR DESCRIPTION
- Added `_onchange_to_pay_move_line_ids` onchange in `account.payment`
- When debt lines are added/removed in the UI, `amount` is updated to match `to_pay_amount` (= selected_debt + unreconciled_amount)
- Only applies when `use_payment_pro` is enabled
- Fixes case where removing all debt lines (with no withholdings) left `amount` stale

**Change note:**
Al agregar o quitar líneas de deuda en un pago, el importe del pago ahora se actualiza automáticamente. Antes, al sacar todas las líneas sin retenciones, el importe quedaba con el valor anterior en lugar de reflejar el nuevo total.