### PR TITLE
[IMP] account_payment_pro: payment pro register wizard

### DIFF
--- a/account_payment_pro/__manifest__.py
+++ b/account_payment_pro/__manifest__.py
@@ -24,6 +24,7 @@
         "security/payment_security.xml",
         "security/ir.model.access.csv",
         "wizards/account_payment_invoice_wizard_view.xml",
+        "wizards/account_payment_register_pro_wizard_view.xml",
         "views/account_payment_view.xml",
         "views/account_move.xml",
         "views/account_write_off_type_views.xml",

--- a/account_payment_pro/models/account_move_line.py
+++ b/account_payment_pro/models/account_move_line.py
@@ -97,57 +97,85 @@ class AccountMoveLine(models.Model):
         # usamos payment pro si lo pasamos forzado (Caso pay and new donde todavia no tenemos company) o si estoy
         # pagando deuda de una sola cia y tiene payment pro
         # y si ademas estoy pagando solo deuda de un partner
-        if payment_pro is not False and ((payment_pro or company_pay_pro) and len(to_pay_partners) <= 1):
+
+        # Caso 1: tiene payment pro
+        if payment_pro is not False and (payment_pro or company_pay_pro):
             to_pay_move_lines = self.filtered(
                 lambda r: not r.reconciled and r.account_id.account_type in ["asset_receivable", "liability_payable"]
             )
-            if not to_pay_move_lines:
-                partner_type = self.env.context.get("default_partner_type")
-                to_pay_partner_id = self.env.context.get("default_partner_id")
-                company_id = self.env.context.get("default_company_id")
-                if not partner_type or not to_pay_partner_id:
-                    raise UserError(_("Nothing to be paid on selected entries"))
-            else:
-                to_pay_partner_id = to_pay_partners.id
+
+            # Caso 1.1: tiene payment pro y solo un partner a pagar, abrimos form payment pro
+            if len(to_pay_partners) <= 1:
+                if not to_pay_move_lines:
+                    partner_type = self.env.context.get("default_partner_type")
+                    to_pay_partner_id = self.env.context.get("default_partner_id")
+                    company_id = self.env.context.get("default_company_id")
+                    if not partner_type or not to_pay_partner_id:
+                        raise UserError(_("Nothing to be paid on selected entries"))
+                else:
+                    to_pay_partner_id = to_pay_partners.id
+
                 partner_type = (
                     "customer" if to_pay_move_lines[0].account_id.account_type == "asset_receivable" else "supplier"
                 )
                 company_id = self.company_id.id
-            to_pay_amount = sum(line.amount_residual for line in to_pay_move_lines)
-            if to_pay_amount > 0:
-                payment_type = "inbound"
-            elif to_pay_amount < 0:
-                payment_type = "outbound"
+
+                to_pay_amount = sum(line.amount_residual for line in to_pay_move_lines)
+                if to_pay_amount > 0:
+                    payment_type = "inbound"
+                elif to_pay_amount < 0:
+                    payment_type = "outbound"
+                else:
+                    payment_type = "inbound" if partner_type == "customer" else "outbound"
+                create_and_new = True if self.env.context.get("create_and_new") else False
+                context = {
+                    "active_model": "account.move.line",
+                    "active_ids": self.ids,
+                    "default_payment_type": payment_type,
+                    "default_partner_type": partner_type,
+                    "default_partner_id": to_pay_partner_id,
+                    "default_amount": abs(to_pay_amount),
+                    "default_amount_exact": abs(to_pay_amount),
+                    "default_to_pay_move_line_ids": to_pay_move_lines.ids,
+                    # We set this because if became from other view and in the context has 'create=False'
+                    # you can't crate payment lines (for ej: subscription)
+                    "create": True,
+                    "create_and_new": create_and_new,
+                    "default_company_id": company_id,
+                }
+                if self.env.context.get("default_l10n_ar_fiscal_position_id") is not None:
+                    context["default_l10n_ar_fiscal_position_id"] = self.env.context.get(
+                        "default_l10n_ar_fiscal_position_id"
+                    )
+                return {
+                    "name": _("Register Payment"),
+                    "res_model": "account.payment",
+                    "view_mode": "form",
+                    "views": [[False, "form"]],
+                    "context": context,
+                    "target": "current",
+                    "type": "ir.actions.act_window",
+                }
+
+            # Caso 1.2: tiene payment pro y más de un partner a pagar, abrimos wizard payment pro
             else:
-                payment_type = "inbound" if partner_type == "customer" else "outbound"
-            create_and_new = True if self.env.context.get("create_and_new") else False
-            context = {
-                "active_model": "account.move.line",
-                "active_ids": self.ids,
-                "default_payment_type": payment_type,
-                "default_partner_type": partner_type,
-                "default_partner_id": to_pay_partner_id,
-                "default_amount": abs(to_pay_amount),
-                "default_amount_exact": abs(to_pay_amount),
-                "default_to_pay_move_line_ids": to_pay_move_lines.ids,
-                # We set this because if became from other view and in the context has 'create=False'
-                # you can't crate payment lines (for ej: subscription)
-                "create": True,
-                "create_and_new": create_and_new,
-                "default_company_id": company_id,
-            }
-            if self.env.context.get("default_l10n_ar_fiscal_position_id") is not None:
-                context["default_l10n_ar_fiscal_position_id"] = self.env.context.get(
-                    "default_l10n_ar_fiscal_position_id"
-                )
-            return {
-                "name": _("Register Payment"),
-                "res_model": "account.payment",
-                "view_mode": "form",
-                "views": [[False, "form"]],
-                "context": context,
-                "target": "current",
-                "type": "ir.actions.act_window",
-            }
+                if not to_pay_move_lines:
+                    raise UserError(_("Nothing to be paid on selected entries"))
+
+                return {
+                    "name": _("Register Payment"),
+                    "type": "ir.actions.act_window",
+                    "res_model": "account.payment.register",
+                    "view_mode": "form",
+                    "views": [[False, "form"]],
+                    "target": "new",
+                    "context": {
+                        "active_model": "account.move.line",
+                        "active_ids": to_pay_move_lines.ids,
+                        "default_company_id": self.company_id.id,
+                        "payment_pro": True,
+                    },
+                }
+        # Caso 2: no tiene payment pro
         else:
             return super().action_register_payment(ctx=ctx)

--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -1035,10 +1035,11 @@ class AccountPayment(models.Model):
     # We dont set 'is_internal_transfer' as a dependencies as it could leed to recompute to_pay_move_line_ids
     @api.depends("partner_id", "partner_type", "company_id")
     def _compute_to_pay_move_lines(self):
-        # TODO ?
-        # # if payment group is being created from a payment we dont want to compute to_pay_move_lines
-        # if self.env.context.get('created_automatically'):
-        #     return
+        # When creating payments from the bulk payment wizard, we explicitly set
+        # to_pay_move_line_ids to the selected lines only, so we skip auto-computation
+        # to avoid _add_all() adding unrelated lines of different currencies.
+        if self.env.context.get("skip_to_pay_compute"):
+            return
         # Se recomputan las lienas solo si la deuda que esta seleccionada solo si
         # cambio el partner, compania o partner_type
         records = self.filtered(lambda x: x.state == "draft")

--- a/account_payment_pro/tests/test_account_paymet_pro_unit_test.py
+++ b/account_payment_pro/tests/test_account_paymet_pro_unit_test.py
@@ -351,3 +351,174 @@ class TestAccountPaymentProUnitTest(common.TransactionCase):
 
         self.assertIn(payment.state, ["paid", "in_process"], "El pago invertido debe poder postearse")
         self.assertIn(credit_note.payment_state, ["paid", "in_payment"], "La nota de crédito debe quedar pagada")
+
+    def test_action_register_payment_single_partner_opens_account_payment(self):
+        """Single partner: action_register_payment should open `account.payment` form."""
+        invoice = self.env["account.move"].create(
+            {
+                "partner_id": self.partner_ri.id,
+                "invoice_date": self.today,
+                "move_type": "out_invoice",
+                "journal_id": self.company_journal.id,
+                "company_id": self.company.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.env.ref("product.product_product_16").id,
+                            "quantity": 1,
+                            "price_unit": 120,
+                        }
+                    ),
+                ],
+            }
+        )
+        invoice.action_post()
+
+        action = invoice.action_register_payment()
+        self.assertEqual(action.get("res_model"), "account.payment")
+        self.assertEqual(action.get("target"), "current")
+        ctx = action.get("context") or {}
+        self.assertIn("default_to_pay_move_line_ids", ctx)
+        self.assertTrue(ctx.get("default_to_pay_move_line_ids"))
+
+    def test_action_register_payment_multiple_partners_opens_register_wizard(self):
+        """Multiple partners: should open `account.payment.register` wizard with `payment_pro` context."""
+        partner_other = self.env.ref("base.res_partner_12")
+        invoice_1 = self.env["account.move"].create(
+            {
+                "partner_id": self.partner_ri.id,
+                "invoice_date": self.today,
+                "move_type": "out_invoice",
+                "journal_id": self.company_journal.id,
+                "company_id": self.company.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.env.ref("product.product_product_16").id,
+                            "quantity": 1,
+                            "price_unit": 50,
+                        }
+                    ),
+                ],
+            }
+        )
+        invoice_2 = self.env["account.move"].create(
+            {
+                "partner_id": partner_other.id,
+                "invoice_date": self.today,
+                "move_type": "out_invoice",
+                "journal_id": self.company_journal.id,
+                "company_id": self.company.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.env.ref("product.product_product_16").id,
+                            "quantity": 1,
+                            "price_unit": 75,
+                        }
+                    ),
+                ],
+            }
+        )
+        invoice_1.action_post()
+        invoice_2.action_post()
+
+        action = (invoice_1 + invoice_2).action_register_payment()
+        self.assertEqual(action.get("res_model"), "account.payment.register")
+        self.assertEqual(action.get("target"), "new")
+        ctx = action.get("context") or {}
+        self.assertTrue(ctx.get("payment_pro"))
+        self.assertIn("active_ids", ctx)
+        self.assertTrue(ctx.get("active_ids"))
+
+    def test_create_payments_and_grouping(self):
+        """Create payments from register wizard and assert payments are posted and grouped per partner when enabled."""
+        # Create two invoices for partner_ri and two for another partner
+        partner_other = self.env.ref("base.res_partner_12")
+        invoices = self.env["account.move"]
+        amounts = [30, 40, 50, 60]
+        partners = [self.partner_ri, self.partner_ri, partner_other, partner_other]
+        for amt, partner in zip(amounts, partners):
+            inv = self.env["account.move"].create(
+                {
+                    "partner_id": partner.id,
+                    "invoice_date": self.today,
+                    "move_type": "out_invoice",
+                    "journal_id": self.company_journal.id,
+                    "company_id": self.company.id,
+                    "invoice_line_ids": [
+                        Command.create(
+                            {
+                                "product_id": self.env.ref("product.product_product_16").id,
+                                "quantity": 1,
+                                "price_unit": amt,
+                            }
+                        ),
+                    ],
+                }
+            )
+            inv.action_post()
+            invoices |= inv
+
+        # Open register wizard for all invoice lines
+        action = invoices.line_ids.action_register_payment()
+        ctx = action.get("context") or {}
+        # Create the wizard record as the UI would do
+        wiz = self.env["account.payment.register"].with_context(**ctx).create({})
+
+        # By default, don't group payments: create one payment per move
+        # Simulate clicking 'Create payments' (Public API: action_create_payments)
+        # Call the method and collect created payments
+        payments = wiz._create_payments()
+        # payments can be recordset or list depending on implementation; ensure recordset
+        payments = self.env["account.payment"].browse(payments.ids if hasattr(payments, "ids") else [])
+
+        # All payments should be posted (state in 'posted' -> payment.state 'posted' or 'paid')
+        self.assertTrue(payments, "Payments should be created")
+        for p in payments:
+            self.assertIn(p.state, ["posted", "in_process", "paid"], "Payment should be posted or paid")
+
+        # Now test grouping: when grouping is enabled we expect one payment per partner
+        # Recreate wizard with grouping context
+        # Prepare new invoices for grouping test
+        invoices2 = self.env["account.move"]
+        for amt, partner in zip([10, 20, 30, 40], [self.partner_ri, self.partner_ri, partner_other, partner_other]):
+            inv = self.env["account.move"].create(
+                {
+                    "partner_id": partner.id,
+                    "invoice_date": self.today,
+                    "move_type": "out_invoice",
+                    "journal_id": self.company_journal.id,
+                    "company_id": self.company.id,
+                    "invoice_line_ids": [
+                        Command.create(
+                            {
+                                "product_id": self.env.ref("product.product_product_16").id,
+                                "quantity": 1,
+                                "price_unit": amt,
+                            }
+                        )
+                    ],
+                }
+            )
+            inv.action_post()
+            invoices2 |= inv
+
+        action2 = invoices2.line_ids.action_register_payment()
+        ctx2 = action2.get("context") or {}
+        # Simulate a grouped run by setting group_payment on the wizard if available
+        wiz2 = self.env["account.payment.register"].with_context(**ctx2).create({})
+        # try to set group_payment on wizard if exists, or in context
+        if hasattr(wiz2, "group_payment"):
+            wiz2.group_payment = True
+        else:
+            wiz2 = self.env["account.payment.register"].with_context(**{**ctx2, "group_payment": True}).create({})
+
+        payments2 = wiz2._create_payments()
+        payments2 = self.env["account.payment"].browse(payments2.ids if hasattr(payments2, "ids") else [])
+        self.assertTrue(payments2, "Payments should be created when grouping")
+
+        # There should be exactly one payment per partner
+        partners_created = payments2.mapped("partner_id")
+        unique_partners = partners_created
+        self.assertEqual(len(payments2), len(unique_partners), "There should be one payment per partner when grouping")

--- a/account_payment_pro/wizards/__init__.py
+++ b/account_payment_pro/wizards/__init__.py
@@ -2,3 +2,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import account_payment_invoice_wizard
+from . import account_payment_register_pro_wizard

--- a/account_payment_pro/wizards/account_payment_register_pro_wizard.py
+++ b/account_payment_pro/wizards/account_payment_register_pro_wizard.py
@@ -1,0 +1,167 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in root directory
+##############################################################################
+from odoo import Command, _, api, fields, models
+
+_CHECK_CODES = frozenset(
+    [
+        "own_checks",
+        "new_third_party_checks",
+        "in_third_party_checks",
+        "out_third_party_checks",
+        "return_third_party_checks",
+        "payment_bundle",
+    ]
+)
+
+
+class AccountPaymentRegisterProWizard(models.TransientModel):
+    """Thin extension of account.payment.register that adds:
+    - fiscal_position_mode: Automatic / Manual selector (supplier-only)
+    - action_create_and_confirm: create + post all payments
+    - action_create_draft: create in draft and navigate to list view
+    """
+
+    _inherit = "account.payment.register"
+
+    fiscal_position_mode = fields.Selection(
+        [("automatic", "Automatic"), ("manual", "Manual")],
+        default="automatic",
+        required=True,
+    )
+    fiscal_position_id = fields.Many2one(
+        "account.fiscal.position",
+        string="Fiscal Position (Payment Pro)",
+        check_company=True,
+    )
+    is_payment_pro = fields.Boolean(
+        default=lambda self: bool(self.env.context.get("payment_pro")),
+    )
+
+    @api.depends("is_payment_pro")
+    def _compute_available_journal_ids(self):
+        super()._compute_available_journal_ids()
+        for wizard in self:
+            if not wizard.is_payment_pro:
+                continue
+            # Exclude journals that have NO method outside check/bundle (purely check/bundle journals).
+            # Mixed journals (e.g. Bank with Manual + own_checks) are kept;
+            # the method filter below removes individual check/bundle lines.
+            wizard.available_journal_ids = wizard.available_journal_ids.filtered(
+                lambda j: (
+                    set(
+                        j.inbound_payment_method_line_ids.payment_method_id.mapped("code")
+                        + j.outbound_payment_method_line_ids.payment_method_id.mapped("code")
+                    )
+                    - _CHECK_CODES
+                )
+            )
+
+    @api.depends("is_payment_pro")
+    def _compute_payment_method_line_fields(self):
+        super()._compute_payment_method_line_fields()
+        for wizard in self:
+            if not wizard.is_payment_pro:
+                continue
+            wizard.available_payment_method_line_ids = wizard.available_payment_method_line_ids.filtered(
+                lambda l: l.payment_method_id.code not in _CHECK_CODES
+            )
+
+    def _get_debt_line_ids_cmd(self, batch_result):
+        valid_types = {"asset_receivable", "liability_payable"}
+        debt_lines = batch_result["lines"].filtered(lambda l: l.account_id.account_type in valid_types)
+        return [Command.set(debt_lines.ids)] if debt_lines else []
+
+    def _create_payment_vals_from_wizard(self, batch_result):
+        payment_vals = super()._create_payment_vals_from_wizard(batch_result)
+        if not self.is_payment_pro:
+            return payment_vals
+        # Strip withholding write_off entries — the payment's l10n_ar_withholding_line_ids
+        # creates the journal lines via _prepare_move_withholding_lines at action_post time.
+        payment_vals["write_off_line_vals"] = [
+            v
+            for v in payment_vals.get("write_off_line_vals", [])
+            if not v.get("tax_repartition_line_id") and not v.get("tax_ids")
+        ]
+        # Embed to_pay_move_line_ids so l10n_ar_fiscal_position_id resolves at payment
+        # creation time, triggering withholding computation before action_post.
+        debt_cmd = self._get_debt_line_ids_cmd(batch_result)
+        if debt_cmd:
+            payment_vals.setdefault("to_pay_move_line_ids", debt_cmd)
+        return payment_vals
+
+    def _create_payment_vals_from_batch(self, batch_result):
+        payment_vals = super()._create_payment_vals_from_batch(batch_result)
+        if not self.is_payment_pro:
+            return payment_vals
+        # Same as wizard path: embed to_pay_move_line_ids for multi-partner batches.
+        debt_cmd = self._get_debt_line_ids_cmd(batch_result)
+        if debt_cmd:
+            payment_vals.setdefault("to_pay_move_line_ids", debt_cmd)
+        return payment_vals
+
+    def _init_payments(self, to_process, edit_mode=False):
+        if self.env.context.get("payment_pro_draft"):
+            for vals in to_process:
+                for key in ("write_off_line_vals", "force_balance", "line_ids"):
+                    vals["create_vals"].pop(key, None)
+        payments = super()._init_payments(to_process, edit_mode=edit_mode)
+        if not self.is_payment_pro:
+            return payments
+        # Flush pending stored computed fields (l10n_ar_withholding_line_ids,
+        # withholdings_amount) triggered by to_pay_move_line_ids set at creation.
+        self.env.flush_all()
+        # amount must equal (to_pay_amount - withholdings_amount) so that:
+        #   payment_total = amount + withholdings_amount == to_pay_amount
+        # For single-partner, l10n_ar_withholding already reduces the wizard amount;
+        # for multi-partner batches the wizard carries no withholdings, so we correct here.
+        for vals in to_process:
+            payment = vals["payment"]
+            withholdings = getattr(payment, "withholdings_amount", 0.0)
+            if not withholdings:
+                continue
+            net = payment.to_pay_amount - withholdings
+            if net > 0 and not payment.currency_id.is_zero(net - payment.amount):
+                payment.write({"amount": net, "amount_exact": net})
+        return payments
+
+    def _post_payments(self, to_process, edit_mode=False):
+        if not self.env.context.get("payment_pro_draft"):
+            return super()._post_payments(to_process, edit_mode=edit_mode)
+
+    def _reconcile_payments(self, to_process, edit_mode=False):
+        valid_types = {"asset_receivable", "liability_payable"}
+        for vals in to_process:
+            payment = vals["payment"]
+            if payment.company_id.use_payment_pro:
+                debt_lines = vals["to_reconcile"].filtered(lambda l: l.account_id.account_type in valid_types)
+                if debt_lines and not payment.to_pay_move_line_ids:
+                    payment.to_pay_move_line_ids = [Command.set(debt_lines.ids)]
+        if not self.env.context.get("payment_pro_draft"):
+            return super()._reconcile_payments(to_process, edit_mode=edit_mode)
+
+    def _create_payments(self):
+        payments = super(
+            AccountPaymentRegisterProWizard, self.with_context(skip_to_pay_compute=True)
+        )._create_payments()
+        if self.fiscal_position_mode == "manual" and self.fiscal_position_id:
+            if hasattr(payments, "fiscal_position_id"):
+                payments.fiscal_position_id = self.fiscal_position_id
+            if hasattr(payments, "l10n_ar_fiscal_position_id"):
+                payments.l10n_ar_fiscal_position_id = self.fiscal_position_id
+        return payments
+
+    def action_create_and_confirm(self):
+        return self.action_create_payments()
+
+    def action_create_draft(self):
+        payments = self.with_context(payment_pro_draft=True)._create_payments()
+        return {
+            "name": _("Payments"),
+            "type": "ir.actions.act_window",
+            "res_model": "account.payment",
+            "view_mode": "list,form",
+            "domain": [("id", "in", payments.ids)],
+            "context": {"create": False},
+            "target": "current",
+        }

--- a/account_payment_pro/wizards/account_payment_register_pro_wizard_view.xml
+++ b/account_payment_pro/wizards/account_payment_register_pro_wizard_view.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Extend the standard payment register form to add fiscal_position_mode
+         and replace the footer buttons when opened from payment_pro context. -->
+    <record id="view_account_payment_register_pro_wizard" model="ir.ui.view">
+        <field name="name">account.payment.register.pro.form</field>
+        <field name="model">account.payment.register</field>
+        <field name="inherit_id" ref="account.view_account_payment_register_form"/>
+        <field name="priority">100</field>
+        <field name="arch" type="xml">
+            <!-- Add fiscal_position_mode in group2 (right column) -->
+            <group name="group2" position="inside">
+                <field name="is_payment_pro" invisible="1" force_save="1"/>
+                <field name="payment_type" invisible="1"/>
+                <field name="country_code" invisible="1"/>
+                <label for="fiscal_position_mode" invisible="not is_payment_pro"/>
+                <field name="fiscal_position_mode" widget="radio" nolabel="1"/>
+                <label for="fiscal_position_id" string="Fiscal Position" invisible="fiscal_position_mode != 'manual'"/>
+
+                <field name="fiscal_position_id"
+                    nolabel="1"
+                    string="Fiscal Position"
+                    options="{'no_create': True}"
+                    invisible="not is_payment_pro or fiscal_position_mode != 'manual'"
+                    required="is_payment_pro and fiscal_position_mode == 'manual'"/>
+            </group>
+            <!-- Replace full footer to control buttons per mode -->
+            <footer position="replace">
+                <footer>
+                    <!-- Standard buttons (only when NOT payment_pro) -->
+                    <button string="Create Payments" name="action_create_payments" type="object"
+                            class="oe_highlight" data-hotkey="q"
+                            invisible="is_payment_pro or total_payments_amount == 1"/>
+                    <button string="Create Payment" name="action_create_payments" type="object"
+                            class="oe_highlight" data-hotkey="q"
+                            invisible="is_payment_pro or total_payments_amount != 1"/>
+                    <!-- payment_pro buttons -->
+                    <button name="action_create_and_confirm"
+                            string="Create and Confirm"
+                            type="object"
+                            class="oe_highlight"
+                            invisible="not is_payment_pro"/>
+                    <button name="action_create_draft"
+                            string="Create as Draft"
+                            type="object"
+                            class="btn-secondary"
+                            invisible="not is_payment_pro"/>
+                    <button string="Discard" class="btn btn-secondary" special="cancel" data-hotkey="x"/>
+                </footer>
+            </footer>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION

- Replace custom `_create_payments` full reimplementation with `super()` call
  using `skip_to_pay_compute` context to prevent `_add_all()` from adding
  unrelated lines
- Add `_init_payments` override: strip write-off/balance vals when
  `payment_pro_draft` context is active to allow creating payments in draft
- Skip reconciliation in `_reconcile_payments` when `payment_pro_draft` is set
- Remove `group_payment` / `can_group_payments` fields from wizard (handled by core)
- Move `fiscal_position_id` field to `group2` (right column) in register form view
- `action_register_payment`: open standard `account.payment.register` wizard
  (with `payment_pro` context) when multiple partners are selected, instead of
  raising an error or requiring a single partner

Change note: Ahora es posible registrar pagos desde facturas de múltiples partners a la vez usando el asistente de pago masivo de Odoo, con las opciones de Payment Pro disponibles (posición fiscal manual, modo borrador). Anteriormente, al seleccionar facturas de distintos proveedores o clientes, el sistema no permitía continuar; ahora abre el asistente correspondiente y genera los pagos correctamente sin agregar líneas no relacionadas.
