### PR TITLE
[FIX] account_payment_pro_receiptbook: enforce receiptbook prefix when generating payment sequence

### DIFF
--- a/account_payment_pro_receiptbook/models/account_move.py
+++ b/account_payment_pro_receiptbook/models/account_move.py
@@ -36,10 +36,36 @@ class AccountMove(models.Model):
 
     def _get_next_sequence_format(self):
         if self.receiptbook_id:
+            starting_sequence = self._get_starting_sequence()
+            format_string, starting_values = self._get_sequence_format_param(starting_sequence)
+            expected_prefix = starting_values.get("prefix1", "")
+
             last_sequence = self._get_last_sequence()
-            new = not last_sequence
-            if new:
-                last_sequence = self._get_last_sequence(relaxed=True) or self._get_starting_sequence()
+
+            if last_sequence:
+                _, last_values = self._get_sequence_format_param(last_sequence)
+                if last_values.get("prefix1") != expected_prefix:
+                    # La última secuencia tiene un formato incorrecto (por error previo).
+                    # Buscamos en la BD la última secuencia válida para este receiptbook
+                    # filtrando directamente por el sequence_prefix correcto.
+                    self.flush_model(["name", "sequence_number", "sequence_prefix"])
+                    self.env.cr.execute(
+                        """
+                        SELECT name FROM account_move
+                        WHERE receiptbook_id = %s
+                          AND name != '/'
+                          AND sequence_prefix = %s
+                        ORDER BY sequence_number DESC
+                        LIMIT 1
+                        """,
+                        [self.receiptbook_id.id, expected_prefix],
+                    )
+                    row = self.env.cr.fetchone()
+                    last_sequence = row[0] if row else None
+
+            if not last_sequence:
+                starting_values["seq"] = 0
+                return format_string, starting_values
 
             format_string, format_values = self._get_sequence_format_param(last_sequence)
             return format_string, format_values

--- a/l10n_ar_payment_bundle/models/account_payment.py
+++ b/l10n_ar_payment_bundle/models/account_payment.py
@@ -284,11 +284,29 @@ class AccountPayment(models.Model):
         )
 
     def _generate_journal_entry(self, write_off_line_vals=None, force_balance=None, line_ids=None):
-        super(AccountPayment, self - self._bypass_journal_entry())._generate_journal_entry(
+        bypassed = self._bypass_journal_entry()
+        super(AccountPayment, self - bypassed)._generate_journal_entry(
             write_off_line_vals=write_off_line_vals,
             force_balance=force_balance,
             line_ids=line_ids,
         )
+        # For bypassed main payments with a receiptbook, create a temporary move so the
+        # sequence mixin's _get_next_sequence_format (receiptbook override) is used to
+        # derive the correct name instead of falling back to ir.sequence.next_by_code.
+        for rec in bypassed.filtered(lambda x: x.receiptbook_id and (not x.name or x.name == "/") and x.journal_id):
+            dummy_move = self.env["account.move"].create(
+                {
+                    "move_type": "entry",
+                    "date": rec.date,
+                    "journal_id": rec.journal_id.id,
+                    "company_id": rec.company_id.id,
+                    "currency_id": rec.currency_id.id,
+                    "origin_payment_id": rec.id,
+                }
+            )
+            dummy_move._set_next_sequence()
+            rec.name = dummy_move.name
+            dummy_move.unlink()
 
     @api.depends("partner_id", "amount", "date", "payment_type")
     def _compute_duplicate_payment_ids(self):


### PR DESCRIPTION


- Override _get_next_sequence_format() in AccountMove to always use the nomenclature defined in the receiptbook when generating the next sequence number for payments.
- Before picking the last sequence, extract the expected prefix from _get_starting_sequence() (document_type prefix + receiptbook prefix).
- If the last sequence found in DB has a different prefix (e.g. due to a previous error where the move got a journal sequence instead), fall back to a direct SQL query filtering by receiptbook_id AND sequence_prefix to find the last valid sequence with the correct format.
- If no valid sequence exists yet, reset to starting_sequence with seq=0 so _locked_increment begins at the correct initial_sequence value.
- Remove debug pdb.set_trace() that was blocking payment posting.

Change note: Al confirmar un pago, el número asignado ahora siempre respeta el formato definido en el talonario de recibos (prefijo del tipo de documento + prefijo del talonario). Si existían pagos anteriores con numeración incorrecta, el sistema los ignora y continúa la secuencia correcta a partir del último número válido del talonario.