### PR TITLE
[REF] payment_pro, payment_bundle: payment report refactor

### DIFF
--- a/account_payment_pro/__manifest__.py
+++ b/account_payment_pro/__manifest__.py
@@ -28,6 +28,7 @@
         "views/account_move.xml",
         "views/account_write_off_type_views.xml",
         "views/res_company_setting.xml",
+        "views/report_payment_receipt_templates.xml",
     ],
     "demo": [],
     "post_init_hook": "_post_init_hooks",

--- a/account_payment_pro/models/__init__.py
+++ b/account_payment_pro/models/__init__.py
@@ -1,4 +1,5 @@
 from . import account_payment
+from . import account_payment_report
 from . import account_move_line
 from . import account_move
 from . import account_journal

--- a/account_payment_pro/models/account_payment_report.py
+++ b/account_payment_pro/models/account_payment_report.py
@@ -1,0 +1,41 @@
+from collections import defaultdict
+
+from odoo import models
+
+
+class AccountPayment(models.Model):
+    _inherit = "account.payment"
+
+    def _get_name_receipt_report(self, report_xml_id):
+        """Return the QWeb template to use for the payment receipt.
+
+        Kept generic in account_payment_pro so localizations can override it,
+        similar to l10n_latam_invoice_document's invoice report selection.
+        """
+        self.ensure_one()
+        return report_xml_id
+
+    def _get_payment_bundle_key(self):
+        """Default grouping key: one receipt per payment.
+
+        Bundle modules can override this key under specific contexts.
+        """
+        self.ensure_one()
+        return self.id
+
+    def _get_payment_bundles(self):
+        """Return payment recordsets grouped by receipt.
+
+        The default implementation does not group payments together. It exists
+        so modules such as l10n_ar_payment_bundle can extend it without needing
+        a localization module to provide the base method.
+        """
+        bundles = defaultdict(lambda: self.env["account.payment"])
+        for payment in self:
+            bundles[payment._get_payment_bundle_key()] += payment
+        return bundles
+
+    def _select_bundle(self, bundles):
+        """Select the receipt payment set for the current payment."""
+        self.ensure_one()
+        return bundles.get(self._get_payment_bundle_key(), self)

--- a/account_payment_pro/views/report_payment_receipt_templates.xml
+++ b/account_payment_pro/views/report_payment_receipt_templates.xml
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="report_payment_receipt" inherit_id="account.report_payment_receipt">
+        <t t-call="account.report_payment_receipt_document" position="attributes">
+            <attribute name="t-call">#{ o._get_name_receipt_report('account_payment_pro.report_payment_receipt_document') }</attribute>
+        </t>
+        <t t-set="lang" position="after">
+            <t t-set="payment_bundle" t-value="o"/>
+        </t>
+    </template>
+
+    <template id="report_payment_receipt_document" inherit_id="account.report_payment_receipt_document" primary="True" priority="16">
+        <t t-set="o" position="after">
+            <t t-set="report_date" t-value="o.date"/>
+            <t t-set="report_number" t-value="o.name"/>
+            <t t-set="report_name" t-value="o.payment_type == 'outbound' and 'Payment Order' or 'Payment Receipt'"/>
+        </t>
+
+        <div class="page" position="replace">
+            <div class="page">
+                <div id="informations" class="row mt8 mb8">
+                    <div class="col-6" name="payment_pro_partner_info">
+                        <strong>
+                            <span t-if="o.partner_type == 'supplier'">Supplier: </span>
+                            <span t-if="o.partner_type == 'customer'">Customer: </span>
+                        </strong>
+                        <span t-field="o.partner_id.commercial_partner_id.name"/>
+                        <br/>
+                        <span t-out="o.partner_id" t-options='{"widget": "contact", "fields": ["address"], "no_marker": True, "no_tag_br": True}'/>
+                        <t t-if="o.partner_id.vat">
+                            <br/>
+                            <strong><span t-out="o.company_id.country_id.vat_label or 'Tax ID'"/>: </strong>
+                            <span t-field="o.partner_id.vat"/>
+                        </t>
+                    </div>
+                </div>
+            </div>
+
+            <br/>
+            <table class="table table-sm o_main_table" name="payments_table">
+                <t t-set="show_amount_col" t-value="any(doc.currency_id != o.destination_currency_id for doc in payment_bundle)"/>
+                <thead>
+                    <tr>
+                        <th><span>Payments</span></th>
+                        <th class="text-right" t-if="show_amount_col"><span>Amount</span></th>
+                        <th class="text-right">
+                            <span>Total</span><span t-if="show_amount_col"> (<span t-field="o.destination_currency_id.name"/>)</span>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <t t-foreach="payment_bundle" t-as="doc">
+                        <t t-foreach="doc._get_latam_checks()" t-as="check">
+                            <tr>
+                                <td>
+                                    <span t-out="'Check no. %s' % (check.name)">Check no. 123456</span>
+                                    <span t-if="check.bank_id" t-out="' - %s' % (check.bank_id.name)"> - Bank</span>
+                                    <span t-out="' (%s)' % (check.payment_method_line_id.name)"> (Check)</span>
+                                    <span t-if="check.payment_date"> - Due <span t-field="check.payment_date"/></span>
+                                </td>
+                                <td class="text-right" t-if="show_amount_col">
+                                    <span class="text-nowrap" t-out="check.amount" t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/>
+                                </td>
+                                <td class="text-right o_price_total">
+                                    <span class="text-nowrap" t-out="doc.destination_currency_id.round(check.amount * (doc.counterpart_rate or 1.0) if doc.counterpart_currency_id == doc.destination_currency_id else (check.amount / doc.accounting_rate if doc.accounting_rate else check.amount))" t-options='{"widget": "monetary", "display_currency": doc.destination_currency_id}'/>
+                                </td>
+                            </tr>
+                        </t>
+                    </t>
+
+                    <t t-set="payment_pro_extra_payment_lines"/>
+
+                    <t t-foreach="payment_bundle.filtered('write_off_amount')" t-as="doc" name="payment_pro_writeoff_lines">
+                        <tr>
+                            <td>
+                                <span t-out="doc.write_off_type_id.label or doc.write_off_type_id.name"/>
+                            </td>
+                            <td class="text-right" t-if="show_amount_col">
+                                <span class="text-nowrap" t-field="doc.write_off_amount"/>
+                            </td>
+                            <td class="text-right o_price_total">
+                                <span class="text-nowrap" t-field="doc.write_off_amount"/>
+                            </td>
+                        </tr>
+                    </t>
+
+                    <t t-set="all_same_type" t-value="len(set(payment_bundle.mapped('payment_type'))) == 1"/>
+                    <t t-foreach="payment_bundle.filtered(lambda x: not x._is_latam_check_payment() and x.amount != 0.0)" t-as="doc" name="payment_pro_standard_payment_lines">
+                        <t t-set="display_amount_a" t-value="abs(doc.amount_signed) if all_same_type else doc.amount_signed"/>
+                        <t t-set="display_amount_b_raw" t-value="doc.counterpart_currency_amount if doc.counterpart_currency_id == doc.destination_currency_id else (doc.amount / doc.accounting_rate if doc.accounting_rate else doc.amount)"/>
+                        <t t-set="display_amount_b" t-value="abs(display_amount_b_raw) if all_same_type else (display_amount_b_raw if doc.payment_type == 'inbound' else -display_amount_b_raw)"/>
+                        <tr>
+                            <td>
+                                <span t-field="doc.journal_id.name"/>
+                                <span t-field="doc.payment_method_line_id.name"/>
+                            </td>
+                            <td class="text-right" t-if="show_amount_col">
+                                <span class="text-nowrap" t-out="display_amount_a" t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/>
+                            </td>
+                            <td class="text-right o_price_total">
+                                <span class="text-nowrap" t-out="display_amount_b" t-options='{"widget": "monetary", "display_currency": doc.destination_currency_id}'/>
+                            </td>
+                        </tr>
+                    </t>
+                </tbody>
+                <tfoot>
+                    <tr>
+                        <td><strong><span>Total Paid</span></strong></td>
+                        <td t-if="show_amount_col"/>
+                        <td class="text-right">
+                            <strong><span class="text-nowrap" t-field="o.payment_total"/></strong>
+                        </td>
+                    </tr>
+                </tfoot>
+            </table>
+
+            <br/>
+            <t t-set="matched_lines" t-value="payment_bundle.with_context(matched_payment_ids=payment_bundle.ids).mapped('matched_move_line_ids')"/>
+            <table class="table table-sm o_main_table" name="matching_table">
+                <thead>
+                    <tr>
+                        <th><span>Imputed Vouchers</span></th>
+                        <th class="text-center"><span>Due Date</span></th>
+                        <th class="text-right"><span>Original Amount</span></th>
+                        <th class="text-right"><span>Imputed Amount</span></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <t t-foreach="matched_lines" t-as="line">
+                        <tr>
+                            <td><span t-field="line.move_id.display_name"/></td>
+                            <td class="text-center">
+                                <span class="text-nowrap" t-field="line.date_maturity"/>
+                            </td>
+                            <td class="text-right o_price_total">
+                                <span class="text-nowrap" t-out="(o.payment_type == 'outbound' and -1.0 or 1.0) * line.amount_currency" t-options='{"widget": "monetary", "display_currency": line.currency_id}'/>
+                            </td>
+                            <td class="text-right o_price_total">
+                                <span class="text-nowrap" t-out="(o.payment_type == 'outbound' and -1.0 or 1.0) * line.payment_matched_amount" t-options='{"widget": "monetary", "display_currency": line.payment_matched_currency_id}'/>
+                            </td>
+                        </tr>
+                        <span class="reversal_move_lines"/>
+                    </t>
+                    <tr t-if="sum(payment_bundle.mapped('unmatched_amount'))">
+                        <td>On account</td>
+                        <td class="text-center"/>
+                        <td class="text-right o_price_total"/>
+                        <td class="text-right o_price_total">
+                            <span class="text-nowrap" t-out="sum(payment_bundle.mapped('unmatched_amount'))" t-options="{'widget': 'monetary', 'display_currency': o.destination_currency_id}"/>
+                        </td>
+                    </tr>
+                </tbody>
+                <tfoot>
+                    <tr>
+                        <td colspan="3"><strong><span>Total Imputed</span></strong></td>
+                        <td class="text-right">
+                            <strong><span class="text-nowrap" t-out="o.matched_amount + o.unmatched_amount" t-options='{"widget": "monetary", "display_currency": o.destination_currency_id}'/></strong>
+                        </td>
+                    </tr>
+                </tfoot>
+            </table>
+
+            <br/>
+            <t t-set="payment_pro_after_matching_table"/>
+
+            <div name="payment_pro_observations" t-if="o.memo">
+                <strong>Observations: </strong><span t-field="o.memo"/>
+            </div>
+        </div>
+    </template>
+
+    <template id="report_payment_receipt_reversal_moves" active="False" inherit_id="account_payment_pro.report_payment_receipt_document">
+        <xpath expr="//span[hasclass('reversal_move_lines')]" position="replace">
+            <t t-foreach="line.move_id.reversal_move_ids" t-as="reversal_move_id">
+                <t t-set="imputed_amount" t-value="[item['amount'] for item in reversal_move_id.sudo()._get_all_reconciled_invoice_partials() if item['aml_id'] == line.id]"/>
+                <tr>
+                    <td><span style="padding-left: 20px;">└</span> <span t-field="reversal_move_id.display_name"/></td>
+                    <td class="text-center">
+                        <span class="text-nowrap" t-field="reversal_move_id.invoice_date"/>
+                    </td>
+                    <td class="text-right o_price_total">
+                        <span class="text-nowrap" t-out="(o.partner_type == 'supplier' and 1.0 or -1.0) * sum(imputed_amount)" t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'/>
+                    </td>
+                    <td class="text-right o_price_total"/>
+                </tr>
+            </t>
+        </xpath>
+    </template>
+</odoo>

--- a/l10n_ar_payment_bundle/__manifest__.py
+++ b/l10n_ar_payment_bundle/__manifest__.py
@@ -23,6 +23,7 @@
         "views/payment_rename_wizard_view.xml",
         "data/account_payment_method_data.xml",
         "views/account_payment_view.xml",
+        "views/report_payment_receipt_templates.xml",
     ],
     "installable": True,
     "auto_install": False,

--- a/l10n_ar_payment_bundle/models/account_payment.py
+++ b/l10n_ar_payment_bundle/models/account_payment.py
@@ -213,6 +213,16 @@ class AccountPayment(models.Model):
 
             rec.warnings = warnings
 
+    def _get_payment_bundle_key(self):
+        """Group selected payments only when printing the bundled receipt action."""
+        self.ensure_one()
+        if self.env.context.get("print_in_bundles"):
+            bundle_currency = (
+                self.currency_id if self.currency_id != self.company_currency_id else self.counterpart_currency_id
+            )
+            return f"{self.company_id.id}-{self.partner_id.id}-{self.payment_type}-{bundle_currency.id}"
+        return super()._get_payment_bundle_key()
+
     def _get_payment_bundles(self):
         main_payments = self.filtered("is_main_payment")
         bundles = super(AccountPayment, self - main_payments)._get_payment_bundles()

--- a/l10n_ar_payment_bundle/views/report_payment_receipt_templates.xml
+++ b/l10n_ar_payment_bundle/views/report_payment_receipt_templates.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="report_payment_receipt" inherit_id="account.report_payment_receipt" priority="20">
+        <xpath expr="//t[@t-foreach='docs']" position="before">
+            <t t-set="payment_bundles" t-value="docs._get_payment_bundles()"/>
+        </xpath>
+        <xpath expr="//t[@t-set='payment_bundle']" position="attributes">
+            <attribute name="t-value">o._select_bundle(payment_bundles)</attribute>
+        </xpath>
+    </template>
+
+    <template id="report_payment_receipt_bundle">
+        <t t-call="web.html_container">
+            <t t-foreach="docs.with_context(print_in_bundles=True)._get_payment_bundles().values()" t-as="payment_bundle">
+                <t t-set="o" t-value="payment_bundle[0]"/>
+                <t t-set="lang" t-value="o.partner_id.lang or o.company_id.partner_id.lang"/>
+                <t t-call="#{ o._get_name_receipt_report('account_payment_pro.report_payment_receipt_document') }" t-lang="lang"/>
+            </t>
+        </t>
+    </template>
+
+    <record id="action_report_receipt_bundle" model="ir.actions.report">
+        <field name="name">Payment Receipt bundled</field>
+        <field name="model">account.payment</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">l10n_ar_payment_bundle.report_payment_receipt_bundle</field>
+        <field name="report_file">l10n_ar_payment_bundle.report_payment_receipt_bundle</field>
+        <field name="binding_model_id" ref="model_account_payment"/>
+        <field name="binding_type">report</field>
+        <field name="binding_view_types">list</field>
+    </record>
+</odoo>


### PR DESCRIPTION
**account_payment_pro (nuevo módulo base para el reporte)**
- Nuevo account_payment_pro/models/account_payment_report.py: métodos base _get_name_receipt_report, _get_payment_bundle_key, _get_payment_bundles, _select_bundle 
- Modificado account_payment_pro/models/init.py: agrega from . import account_payment_report 
- Nuevo account_payment_pro/views/report_payment_receipt_templates.xml: layout base del recibo (multimoneda, cheques LATAM, write-off, imputaciones) Modificado account_payment_pro/manifest.py: agrega el nuevo archivo de vista 

 **l10n_ar_payment_bundle (responsable del agrupado/bundled)**

- Nuevo l10n_ar_payment_bundle/views/report_payment_receipt_templates.xml: herencia del report_payment_receipt para setear payment_bundles, template report_payment_receipt_bundle + acción de reporte
- Modificado l10n_ar_payment_bundle/models/account_payment.py: agrega override de _get_payment_bundle_key (lógica AR-específica, antes en l10n_ar_tax) 
- Modificado l10n_ar_payment_bundle/manifest.py: agrega el nuevo archivo de vista 

**l10n_ar_tax (solo Argentina/AFIP/retenciones)**

- Reemplazado l10n_ar_tax/views/report_payment_receipt_templates.xml: ahora hereda de account_payment_pro.report_payment_receipt_document en lugar de account.report_payment_receipt_document
- Modificado l10n_ar_tax/models/account_payment.py: eliminados _get_payment_bundle_key, _get_payment_bundles, _select_bundle y el import de defaultdict (ya no necesario)