### PR TITLE
[FIX] l10n_ar_payment_bundle: prevent onchange from overriding linked payment amounts

### DIFF
--- a/l10n_ar_payment_bundle/models/account_payment.py
+++ b/l10n_ar_payment_bundle/models/account_payment.py
@@ -355,4 +355,5 @@ class AccountPayment(models.Model):
 
     @api.onchange("to_pay_move_line_ids")
     def _onchange_amount(self):
-        super(AccountPayment, self.filtered(lambda r: r.payment_method_code != "payment_bundle"))._onchange_amount()
+        payments = self.filtered(lambda r: r.payment_method_code != "payment_bundle" and not r.main_payment_id)
+        super(AccountPayment, payments)._onchange_amount()

--- a/l10n_ar_payment_bundle/tests/test_payment_difference.py
+++ b/l10n_ar_payment_bundle/tests/test_payment_difference.py
@@ -357,3 +357,57 @@ class TestPaymentDifference(TransactionCase):
             places=2,
             msg="Payment difference should be 0 when amounts match exactly",
         )
+
+    def test_link_payment_onchange_does_not_override_remaining_amount(self):
+        """Linked payments should keep the remaining amount suggested by the x2many context."""
+        invoice = self._create_invoice(10511.35)
+        invoice.action_post()
+
+        payment = self._create_payment_bundle()
+        payment.to_pay_move_line_ids = invoice.line_ids.filtered(
+            lambda l: l.account_id.account_type in ("asset_receivable", "liability_payable")
+        )
+
+        self.env["account.payment"].create(
+            {
+                "payment_type": "inbound",
+                "partner_type": "customer",
+                "partner_id": self.partner.id,
+                "journal_id": self.bank_journal.id,
+                "amount": 500.0,
+                "main_payment_id": payment.id,
+            }
+        )
+
+        virtual_payment = self.env["account.payment"].new(
+            {
+                "payment_type": "inbound",
+                "partner_type": "customer",
+                "partner_id": self.partner.id,
+                "journal_id": self.bundle_journal.id,
+                "payment_method_line_id": self.payment_method_line.id,
+                "amount": 0.0,
+                "to_pay_move_line_ids": [
+                    Command.set(
+                        invoice.line_ids.filtered(
+                            lambda l: l.account_id.account_type in ("asset_receivable", "liability_payable")
+                        ).ids
+                    )
+                ],
+            }
+        )
+        linked_payment = self.env["account.payment"].new(
+            {
+                "payment_type": "inbound",
+                "partner_type": "customer",
+                "partner_id": self.partner.id,
+                "journal_id": self.bank_journal.id,
+                "amount": 10011.35,
+                "main_payment_id": virtual_payment,
+            }
+        )
+        self.assertFalse(linked_payment.main_payment_id._origin)
+
+        linked_payment._onchange_amount()
+
+        self.assertAlmostEqual(linked_payment.amount, 10011.35, places=2)


### PR DESCRIPTION
- Modified _onchange_amount method to exclude linked payments (with main_payment_id)
- Linked payments now keep the amount suggested by x2many context
- Added test_link_payment_onchange_does_not_override_remaining_amount test
- Test validates that linked payments maintain their suggested amount

Change note: Se corrigió un problema donde al crear pagos vinculados dentro de un payment bundle, el monto se sobrescribía incorrectamente. Ahora los pagos vinculados mantienen automáticamente el monto que les corresponde según el saldo pendiente.