### PR TITLE
[FIX] account_payment_pro: preserve paired transfer rate

### DIFF
--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -764,16 +764,23 @@ class AccountPayment(models.Model):
             # inverse durante create, sobreescribiendo amount.
             vals["counterpart_currency_amount"] = self.amount_exact if self.amount_exact else self.amount
 
-            # Fijar accounting_rate del paired para que refleje la tasa implícita
-            # real de la operación (balance_in_c / paired_amount), no la del día.
-            if dest_currency != self.company_currency_id and balance_in_c:
-                vals["accounting_rate"] = paired_amount / balance_in_c
+            # Fijar rates del paired desde las tasas exactas del pago original.
+            # Si los calculamos desde paired_amount, una moneda de 2 decimales
+            # puede convertir un TC manual de 1500 en 10000 / 6.67 = 1499.25.
+            if dest_currency == self.counterpart_currency_id and self.counterpart_rate:
+                vals["accounting_rate"] = self.accounting_rate * self.counterpart_rate
+                vals["counterpart_rate"] = 1.0 / self.counterpart_rate
+            else:
+                # Fijar accounting_rate del paired para que refleje la tasa implícita
+                # real de la operación (balance_in_c / paired_amount), no la del día.
+                if dest_currency != self.company_currency_id and balance_in_c:
+                    vals["accounting_rate"] = paired_amount / balance_in_c
 
-            # Fijar counterpart_rate del paired: la contraparte del paired es la
-            # moneda del journal original (B1_paired = self.currency_id).
-            # rate = original_amount / paired_amount = B1/A del paired.
-            if paired_amount:
-                vals["counterpart_rate"] = (self.amount_exact if self.amount_exact else self.amount) / paired_amount
+                # Fijar counterpart_rate del paired: la contraparte del paired es la
+                # moneda del journal original (B1_paired = self.currency_id).
+                # rate = original_amount / paired_amount = B1/A del paired.
+                if paired_amount:
+                    vals["counterpart_rate"] = (self.amount_exact if self.amount_exact else self.amount) / paired_amount
 
         return vals
 

--- a/account_payment_pro/tests/test_payment_multimoneda.py
+++ b/account_payment_pro/tests/test_payment_multimoneda.py
@@ -379,6 +379,29 @@ class TestPaymentMultimoneda(TestArCommon):
         )
         self.assertIn(invoice.payment_state, ["paid", "in_payment"])
 
+    def test_internal_transfer_paired_values_keep_manual_rate_after_currency_rounding(self):
+        """El paired de una transferencia interna debe heredar el TC manual exacto."""
+        payment = self._create_payment(
+            self.bank_ars,
+            partner_type="supplier",
+            payment_type="outbound",
+            amount=10_000,
+            is_internal_transfer=True,
+            destination_journal_id=self.bank_usd.id,
+        )
+
+        # TC visual: 1 USD = 1500 ARS. El importe destino redondea a 6.67 USD.
+        payment.counterpart_rate = 1 / 1500.0
+
+        self.assertAlmostEqual(payment.counterpart_currency_amount, 6.67, places=2)
+
+        vals = payment._prepare_paired_payment_values()
+
+        self.assertAlmostEqual(vals["amount"], 6.67, places=2)
+        self.assertAlmostEqual(vals["accounting_rate"], 1 / 1500.0, places=12)
+        self.assertAlmostEqual(1 / vals["accounting_rate"], 1500.0, places=2)
+        self.assertAlmostEqual(vals["counterpart_rate"], 1500.0, places=2)
+
     def test_caso4_venta_de_divisa(self):
         """Caso 4 · USD → ARS → ARS  (venta de divisa)
         Pago en USD para cancelar deuda en ARS. Verifica:


### PR DESCRIPTION
Compute paired internal transfer rates from the original stored rates when the destination currency matches the original counterpart currency.

This avoids deriving the displayed exchange rate from a rounded paired amount, for example 10000 ARS / 6.67 USD = 1499.25 instead of the manually entered 1500.

Change note: el pago emparejado conserva la tasa manual original aunque el importe en moneda destino se redondee.