### PR TITLE
[FIX] l10n_ar_payment_bundle: avoid duplicated bundle payment difference

### DIFF
--- a/l10n_ar_payment_bundle/models/account_payment.py
+++ b/l10n_ar_payment_bundle/models/account_payment.py
@@ -43,9 +43,10 @@ class AccountPayment(models.Model):
 
     @api.depends("link_payment_ids")
     def _compute_payment_total(self):
-        super()._compute_payment_total()
-        for rec in self:
-            rec.payment_total += sum(rec.link_payment_ids.mapped("payment_total"))
+        main_payments = self.filtered("is_main_payment")
+        super(AccountPayment, self - main_payments)._compute_payment_total()
+        for rec in main_payments:
+            rec.payment_total = sum(rec.link_payment_ids.mapped("payment_total"))
 
     @api.depends("counterpart_currency_amount", "link_payment_ids.counterpart_currency_amount")
     def _compute_bundle_counterpart_currency_amount(self):
@@ -317,8 +318,10 @@ class AccountPayment(models.Model):
             rec.partner_id = rec.main_payment_id.partner_id
 
     def _compute_payment_difference(self):
-        for rec in self.filtered("main_payment_id"):
-            payments = rec.main_payment_id.link_payment_ids
+        bundle_payments = self.filtered(lambda payment: payment.is_main_payment or payment.main_payment_id)
+        for rec in bundle_payments:
+            main_payment = rec.main_payment_id or rec
+            payments = main_payment.link_payment_ids
             amount_outbound = sum(
                 payments.filtered(lambda p: p.payment_type == "outbound").mapped("amount_company_currency_signed")
             )
@@ -326,16 +329,14 @@ class AccountPayment(models.Model):
                 payments.filtered(lambda p: p.payment_type == "inbound").mapped("amount_company_currency_signed")
             )
             amount_payments = abs(amount_inbound + amount_outbound)
-
             rec.payment_difference = (
-                abs(rec.main_payment_id.selected_debt)
+                abs(main_payment.selected_debt)
                 - amount_payments
-                - rec.main_payment_id.withholdings_amount
-                - rec.main_payment_id.write_off_amount
+                - main_payment.withholdings_amount
+                - main_payment.write_off_amount
             )
 
-        for rec in self - self.filtered("main_payment_id"):
-            return super()._compute_payment_difference()
+        super(AccountPayment, self - bundle_payments)._compute_payment_difference()
 
     @api.depends("payment_type", "link_payment_ids.payment_type")
     def _compute_warnings(self):

--- a/l10n_ar_payment_bundle/tests/test_payment_difference.py
+++ b/l10n_ar_payment_bundle/tests/test_payment_difference.py
@@ -358,6 +358,28 @@ class TestPaymentDifference(TransactionCase):
             msg="Payment difference should be 0 when amounts match exactly",
         )
 
+    def test_main_bundle_payment_total_ignores_suggested_amount(self):
+        """Main bundle total should ignore the invoice amount suggested by register payment."""
+        invoice = self._create_invoice(1000000.0)
+        invoice.action_post()
+
+        payment = self.env["account.payment"].new(
+            {
+                "payment_type": "inbound",
+                "partner_type": "customer",
+                "partner_id": self.partner.id,
+                "journal_id": self.bundle_journal.id,
+                "payment_method_line_id": self.payment_method_line.id,
+                "amount": 1000000.0,
+                "to_pay_move_line_ids": [Command.set(invoice.line_ids.filtered("amount_residual").ids)],
+            }
+        )
+        payment._compute_is_main_payment()
+
+        payment._compute_payment_total()
+
+        self.assertAlmostEqual(payment.payment_total, 0.0, places=2)
+
     def test_link_payment_onchange_does_not_override_remaining_amount(self):
         """Linked payments should keep the remaining amount suggested by the x2many context."""
         invoice = self._create_invoice(10511.35)


### PR DESCRIPTION
…eck changes

- In _compute_payment_total, changed @api.depends from 'link_payment_ids' to 'link_payment_ids', 'link_payment_ids.payment_total'
- The previous dependency only triggered recomputation when records were added/removed from the O2M, not when an existing linked payment's amount changed (e.g. adding/modifying third-party checks in a sub-form)
- This caused a stale payment_difference, leading to a spurious validation error 'amount does not match check amount' when paying with multiple checks

Change note: Se corrige un error intermitente al registrar un pago con múltiples cheques de terceros. El sistema ahora recalcula correctamente el total del pago cada vez que se modifica el monto de un pago vinculado, eliminando la diferencia fantasma que impedía validar el comprobante.