### PR TITLE
[FIX] l10n_ar_payment_bundle: set default_amount to 0 when bundle jou…

### DIFF
--- a/l10n_ar_payment_bundle/models/__init__.py
+++ b/l10n_ar_payment_bundle/models/__init__.py
@@ -4,3 +4,4 @@ from . import account_payment
 from . import account_payment_method
 from . import account_journal
 from . import account_payment_register
+from . import account_move_line

--- a/l10n_ar_payment_bundle/models/account_move_line.py
+++ b/l10n_ar_payment_bundle/models/account_move_line.py
@@ -1,0 +1,22 @@
+from odoo import models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    def action_register_payment(self, ctx=None):
+        action = super().action_register_payment(ctx=ctx)
+        # Si el diario por defecto es bundle
+        journal = self.env["account.journal"].search(
+            [
+                *self.env["account.journal"]._check_company_domain(self.company_id),
+                ("type", "in", ["bank", "cash", "credit"]),
+            ],
+            limit=1,
+        )
+
+        if "payment_bundle" in (
+            journal.inbound_payment_method_line_ids + journal.outbound_payment_method_line_ids
+        ).mapped("code"):
+            action.setdefault("context", {})["default_amount"] = 0
+        return action


### PR DESCRIPTION
…rnal is default

Add AccountMoveLine inherit to override action_register_payment. When the first available journal has the payment_bundle payment method (inbound or outbound), set default_amount to 0 in the action context so the payment wizard opens with an empty amount instead of the line's residual amount. Use setdefault to ensure context key is created if not present.

Change note: Al registrar un pago desde una línea de asiento, si el diario por defecto tiene configurado el método de pago Bundle, el monto sugerido en el formulario de pago se establece en 0.