### PR TITLE
[IMP] account_payment_pro_receiptbook: volver a numerar con ir.sequence

### DIFF
--- a/account_payment_pro_receiptbook/__manifest__.py
+++ b/account_payment_pro_receiptbook/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Account Payment receiptbook",
-    "version": "19.0.1.0.0",
+    "version": "19.0.2.0.0",
     "category": "Payment",
     "website": "www.adhoc.com.ar",
     "author": "ADHOC SA",

--- a/account_payment_pro_receiptbook/i18n/account_payment_pro_receiptbook.pot
+++ b/account_payment_pro_receiptbook/i18n/account_payment_pro_receiptbook.pot
@@ -159,11 +159,6 @@ msgid ""
 msgstr ""
 
 #. module: account_payment_pro_receiptbook
-#: model:ir.model.fields,field_description:account_payment_pro_receiptbook.field_account_payment_receiptbook__initial_sequence
-msgid "Initial Sequence"
-msgstr ""
-
-#. module: account_payment_pro_receiptbook
 #: model:ir.model.fields,field_description:account_payment_pro_receiptbook.field_l10n_latam_document_type__internal_type
 msgid "Internal Type"
 msgstr ""
@@ -176,11 +171,6 @@ msgstr ""
 #. module: account_payment_pro_receiptbook
 #: model:ir.model,name:account_payment_pro_receiptbook.model_account_move
 msgid "Journal Entry"
-msgstr ""
-
-#. module: account_payment_pro_receiptbook
-#: model:ir.model.fields,field_description:account_payment_pro_receiptbook.field_account_payment_receiptbook__last_sequence
-msgid "Last Sequence"
 msgstr ""
 
 #. module: account_payment_pro_receiptbook

--- a/account_payment_pro_receiptbook/i18n/es.po
+++ b/account_payment_pro_receiptbook/i18n/es.po
@@ -177,11 +177,6 @@ msgstr ""
 "publicado la cuenta, pago o  grupo relacionado."
 
 #. module: account_payment_pro_receiptbook
-#: model:ir.model.fields,field_description:account_payment_pro_receiptbook.field_account_payment_receiptbook__initial_sequence
-msgid "Initial Sequence"
-msgstr "Secuencia inicial"
-
-#. module: account_payment_pro_receiptbook
 #: model:ir.model.fields,field_description:account_payment_pro_receiptbook.field_l10n_latam_document_type__internal_type
 msgid "Internal Type"
 msgstr "Tipo interno"
@@ -195,11 +190,6 @@ msgstr "Diario"
 #: model:ir.model,name:account_payment_pro_receiptbook.model_account_move
 msgid "Journal Entry"
 msgstr "Asiento Contable"
-
-#. module: account_payment_pro_receiptbook
-#: model:ir.model.fields,field_description:account_payment_pro_receiptbook.field_account_payment_receiptbook__last_sequence
-msgid "Last Sequence"
-msgstr "Última secuencia"
 
 #. module: account_payment_pro_receiptbook
 #: model:ir.model.fields,field_description:account_payment_pro_receiptbook.field_account_payment_receiptbook__write_uid

--- a/account_payment_pro_receiptbook/migrations/19.0.2.0.0/post-migration.py
+++ b/account_payment_pro_receiptbook/migrations/19.0.2.0.0/post-migration.py
@@ -1,0 +1,28 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+"""
+Migración 19.0.2.0.0 — Revertir numeración de receiptbooks al modelo basado en
+``ir.sequence`` (como estaba en 18.0).
+
+Delega en ``account.payment.receiptbook.action_resync_sequence()``, que crea el
+``ir.sequence`` si falta y setea ``number_next`` parseando con regex el sufijo
+numérico de los ``account.payment`` existentes. Idempotente: re-correr no
+duplica sequences ni reordena la numeración.
+"""
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    from odoo import SUPERUSER_ID, api
+
+    env = api.Environment(cr, SUPERUSER_ID, {})
+
+    receiptbooks = env["account.payment.receiptbook"].with_context(active_test=False).search([])
+    _logger.info("Procesando %d receiptbooks para migrar a ir.sequence", len(receiptbooks))
+
+    receiptbooks.action_resync_sequence()

--- a/account_payment_pro_receiptbook/models/account_move.py
+++ b/account_payment_pro_receiptbook/models/account_move.py
@@ -10,72 +10,83 @@ class AccountMove(models.Model):
     )
 
     def _get_last_sequence_domain(self, relaxed=False):
-        self.ensure_one()
-        is_payment = self.origin_payment_id or self.env.context.get("is_payment")
-
-        if self.receiptbook_id and is_payment:
-            where_string = "WHERE receiptbook_id = %(receiptbook_id)s AND name != '/'"
-            param = {"receiptbook_id": self.receiptbook_id.id}
-            return where_string, param
+        """para transferencias no queremos que se enumere con el ultimo numero de asiento porque podria ser un
+        pago generado por un grupo de pagos y en ese caso el numero viene dado por el talonario de recibo/pago.
+        Para esto creamos campo related stored a receiptbook_id de manera de que un asiento sepa si fue creado
+        o no desde un payment group
+        """
+        if self.journal_id.type in ("cash", "bank", "credit") and not self.receiptbook_id:
+            where_string, param = super(
+                AccountMove, self.with_context(without_receiptbook_id=True)
+            )._get_last_sequence_domain(relaxed)
+            where_string += " AND receiptbook_id is Null"
         else:
-            where_string, param = super()._get_last_sequence_domain(relaxed)
-            where_string += " AND receiptbook_id is Null "
-
+            where_string, param = super(AccountMove, self)._get_last_sequence_domain(relaxed)
         return where_string, param
 
-    def _get_starting_sequence(self):
-        if self.receiptbook_id:
-            if self.receiptbook_id.document_type_id:
-                return "%s %s%08d" % (
-                    self.receiptbook_id.document_type_id.doc_code_prefix,
-                    self.receiptbook_id.prefix,
-                    self.receiptbook_id.initial_sequence - 1,
-                )
-            return "%s%08d" % (self.receiptbook_id.prefix, self.receiptbook_id.initial_sequence - 1)
-        return super()._get_starting_sequence()
-
-    def _get_next_sequence_format(self):
-        if self.receiptbook_id:
-            last_sequence = self._get_last_sequence()
-            new = not last_sequence
-            if new:
-                last_sequence = self._get_last_sequence(relaxed=True) or self._get_starting_sequence()
-
-            format_string, format_values = self._get_sequence_format_param(last_sequence)
-            return format_string, format_values
-        return super()._get_next_sequence_format()
-
     @api.model
-    def _deduce_sequence_number_reset(self, name):
-        if self.receiptbook_id:
-            return "never"
-        return super()._deduce_sequence_number_reset(name)
+    def _search(self, domain, *args, **kwargs):
+        if self.env.context.get("without_receiptbook_id"):
+            domain += [("receiptbook_id", "=", False)]
+        return super()._search(domain, *args, **kwargs)
 
     def _compute_made_sequence_hole(self):
-        with_receiptbook = self.filtered(lambda x: x.receiptbook_id and x.journal_id.type in ("bank", "cash", "credit"))
-        with_receiptbook.made_sequence_hole = False
-        super(AccountMove, self - with_receiptbook)._compute_made_sequence_hole()
+        receiptbook_recs = self.filtered(lambda x: x.receiptbook_id and x.journal_id.type in ("bank", "cash", "credit"))
+        receiptbook_recs.made_sequence_hole = False
+        super(AccountMove, self - receiptbook_recs)._compute_made_sequence_hole()
 
     @api.depends()
     def _compute_name(self):
         super()._compute_name()
         for move in self.filtered(
             lambda x: x.origin_payment_id.receiptbook_id
-            and (x.state == "draft" or x.origin_payment_id.payment_transaction_id)
+            and (
+                x.state == "draft" or x.origin_payment_id.state == "draft" or x.origin_payment_id.payment_transaction_id
+            )
         ):
             move.name = move.origin_payment_id.name
 
     @api.depends("origin_payment_id.receiptbook_id")
     def _compute_l10n_latam_document_type(self):
-        with_receiptbook = self.filtered(lambda x: x.origin_payment_id.receiptbook_id)
-        super(AccountMove, self - with_receiptbook)._compute_l10n_latam_document_type()
+        receiptbook_payments = self.filtered(lambda x: x.origin_payment_id.receiptbook_id)
+        super(AccountMove, self - receiptbook_payments)._compute_l10n_latam_document_type()
 
     @api.depends()
     def _compute_made_sequence_gap(self):
-        use_receiptbook_moves = self.filtered(lambda m: m.receiptbook_id)
-        use_receiptbook_moves.made_sequence_gap = False
-        if other_moves := self - use_receiptbook_moves:
-            super(AccountMove, other_moves)._compute_made_sequence_gap()
+        with_receiptbook = self.filtered(lambda move: move.receiptbook_id)
+        unposted_recceiptbook = with_receiptbook.filtered(
+            lambda move: move.sequence_number != 0 and move.state != "posted"
+        )
+        unposted_recceiptbook.made_sequence_gap = True
+
+        for (receiptbook, prefix), moves in (
+            (with_receiptbook - unposted_recceiptbook).grouped(lambda m: (m.receiptbook_id, m.sequence_prefix)).items()
+        ):
+            previous_numbers = set(
+                self.env["account.move"]
+                .sudo()
+                .search(
+                    [
+                        ("receiptbook_id", "=", receiptbook.id),
+                        ("sequence_prefix", "=", prefix),
+                        (
+                            "sequence_number",
+                            ">=",
+                            min(moves.mapped("sequence_number")) - 1,
+                        ),
+                        (
+                            "sequence_number",
+                            "<=",
+                            max(moves.mapped("sequence_number")) - 1,
+                        ),
+                    ]
+                )
+                .mapped("sequence_number")
+            )
+            for move in moves:
+                move.made_sequence_gap = move.sequence_number > 1 and (move.sequence_number - 1) not in previous_numbers
+
+        super(AccountMove, self - with_receiptbook)._compute_made_sequence_gap()
 
     def _must_check_constrains_date_sequence(self):
         # OVERRIDES sequence.mixin to skip date sequence check for receiptbook moves
@@ -83,7 +94,3 @@ class AccountMove(models.Model):
         if self.receiptbook_id:
             return False
         return super()._must_check_constrains_date_sequence()
-
-    def _set_next_made_sequence_gap(self, made_gap: bool):
-        if other_moves := self.filtered(lambda m: not m.receiptbook_id):
-            super(AccountMove, other_moves)._set_next_made_sequence_gap(made_gap)

--- a/account_payment_pro_receiptbook/models/account_payment.py
+++ b/account_payment_pro_receiptbook/models/account_payment.py
@@ -33,6 +33,14 @@ class AccountPayment(models.Model):
                     _('Error! The receiptbook "%s" is archived. Please use a differente receipbook.')
                     % rec.receiptbook_id.name
                 )
+            if not rec.receiptbook_id.sequence_id:
+                raise ValidationError(
+                    _("Error!. Please define sequence on the receiptbook related documents to this payment.")
+                )
+
+            if not rec.name or rec.name == "/":
+                name = rec.receiptbook_id.with_context(ir_sequence_date=rec.date).sequence_id.next_by_id()
+                rec.name = "%s %s" % (rec.receiptbook_id.document_type_id.doc_code_prefix, name)
 
         res = super().action_post()
         # Reincorporamos el seteo del l10n_latam_document_type_id para el caso de usar talonario de recibo

--- a/account_payment_pro_receiptbook/models/account_payment_receiptbook.py
+++ b/account_payment_pro_receiptbook/models/account_payment_receiptbook.py
@@ -95,7 +95,15 @@ class AccountPaymentReceiptbook(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         recs = super().create(vals_list)
-        for rec in recs.filtered(lambda x: not x.sequence_id):
+        recs.ensure_sequence()
+        return recs
+
+    def ensure_sequence(self):
+        """Crea el ``ir.sequence`` (padding=8, increment=1) para los
+        receiptbooks de ``self`` que no lo tengan asignado. Usa el ``prefix``
+        y ``company_id`` del propio receiptbook. Idempotente.
+        """
+        for rec in self.filtered(lambda x: not x.sequence_id):
             rec.sequence_id = (
                 self.env["ir.sequence"]
                 .sudo()
@@ -109,13 +117,11 @@ class AccountPaymentReceiptbook(models.Model):
                     }
                 )
             )
-        return recs
 
     def action_resync_sequence(self):
         """Recompone ``sequence_id`` para los receiptbooks en ``self``:
 
-        - Si no tienen ``sequence_id``, crea un ``ir.sequence`` con el ``prefix``
-          y ``company_id`` del receiptbook (padding=8, increment=1).
+        - Asegura el ``ir.sequence`` vía :meth:`ensure_sequence` (crea si falta).
         - Resuelve el último número usado vía un único ``SELECT`` que stripea
           ``"<doc_code_prefix> "`` y ``<prefix>`` del ``name`` de
           ``account.payment`` con dos ``REPLACE`` y castea el residuo a
@@ -126,43 +132,12 @@ class AccountPaymentReceiptbook(models.Model):
         Sirve como ejecutor de la migración 19.0.2.0.0 y como acción manual de
         reparación si la numeración se desfasa (deletes, importaciones, etc.).
         """
+        self.ensure_sequence()
+        self.env.flush_all()
         for rec in self:
-            if not rec.sequence_id:
-                rec.sequence_id = (
-                    self.env["ir.sequence"]
-                    .sudo()
-                    .create(
-                        {
-                            "name": rec.name,
-                            "prefix": rec.prefix,
-                            "padding": 8,
-                            "number_increment": 1,
-                            "company_id": rec.company_id.id,
-                        }
-                    )
-                )
-
             doc_code_prefix = rec.document_type_id.doc_code_prefix or ""
             prefix = rec.prefix or ""
-            self.env.cr.execute(
-                """
-                SELECT MAX(CAST(REPLACE(REPLACE(name, %s, ''), %s, '') AS INTEGER))
-                  FROM account_payment
-                 WHERE receiptbook_id = %s
-                   AND name IS NOT NULL
-                   AND name LIKE %s
-                   AND state != 'draft'
-                """,
-                (
-                    doc_code_prefix + " ",
-                    prefix,
-                    rec.id,
-                    # solo cuentan pagos con el formato canónico del receiptbook;
-                    # excluye linked payments de bundles (e.g. "Main (1)").
-                    f"{doc_code_prefix} {prefix}%",
-                ),
-            )
-            last_number = self.env.cr.fetchone()[0] or 0
+            last_number = self._resync_get_last_number(rec, doc_code_prefix, prefix)
             next_number = last_number + 1
             rec.sequence_id.sudo().number_next = next_number
 
@@ -174,6 +149,31 @@ class AccountPaymentReceiptbook(models.Model):
                 rec.sequence_id.id,
                 next_number,
             )
+
+    def _resync_get_last_number(self, rec, doc_code_prefix, prefix):
+        has_main_payment = "main_payment_id" in self.env["account.payment"]._fields
+        child_filter = "AND main_payment_id IS NULL" if has_main_payment else ""
+        self.env.cr.execute(
+            f"""
+            SELECT MAX(CAST(
+                SPLIT_PART(REPLACE(REPLACE(name, %s, ''), %s, ''), ' ', 1)
+                AS INTEGER
+            ))
+              FROM account_payment
+             WHERE receiptbook_id = %s
+               AND name IS NOT NULL
+               AND name LIKE %s
+               {child_filter}
+               AND state != 'draft'
+            """,
+            (
+                doc_code_prefix + " ",
+                prefix,
+                rec.id,
+                f"{doc_code_prefix} {prefix}%",
+            ),
+        )
+        return self.env.cr.fetchone()[0] or 0
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_used(self):

--- a/account_payment_pro_receiptbook/models/account_payment_receiptbook.py
+++ b/account_payment_pro_receiptbook/models/account_payment_receiptbook.py
@@ -41,6 +41,10 @@ class AccountPaymentReceiptbook(models.Model):
         required=True,
         index=True,
     )
+    next_number = fields.Integer(
+        related="sequence_id.number_next_actual",
+        readonly=False,
+    )
     sequence_id = fields.Many2one(
         "ir.sequence",
         "Entry Sequence",
@@ -59,10 +63,6 @@ class AccountPaymentReceiptbook(models.Model):
         "Document Type",
         required=True,
     )
-    last_sequence = fields.Integer(
-        compute="_compute_last_sequence",
-    )
-    initial_sequence = fields.Integer(default=1)
 
     @api.constrains("company_id", "prefix", "document_type_id", "partner_type")
     def _check_unique_receipt(self):
@@ -82,12 +82,98 @@ class AccountPaymentReceiptbook(models.Model):
                     )
                 )
 
-    def _compute_last_sequence(self):
+    def write(self, vals):
+        """
+        If user change prefix we change prefix of sequence.
+        """
+        prefix = vals.get("prefix")
         for rec in self:
-            move_id = self.env["account.move"].search(
-                [("receiptbook_id", "=", rec.id), ("name", "!=", "/")], order="sequence_number DESC", limit=1
+            if prefix and rec.sequence_id:
+                rec.sequence_id.prefix = prefix
+        return super().write(vals)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        recs = super().create(vals_list)
+        for rec in recs.filtered(lambda x: not x.sequence_id):
+            rec.sequence_id = (
+                self.env["ir.sequence"]
+                .sudo()
+                .create(
+                    {
+                        "name": rec.name,
+                        "prefix": rec.prefix,
+                        "padding": 8,
+                        "number_increment": 1,
+                        "company_id": rec.company_id.id,
+                    }
+                )
             )
-            rec.last_sequence = move_id.sequence_number
+        return recs
+
+    def action_resync_sequence(self):
+        """Recompone ``sequence_id`` para los receiptbooks en ``self``:
+
+        - Si no tienen ``sequence_id``, crea un ``ir.sequence`` con el ``prefix``
+          y ``company_id`` del receiptbook (padding=8, increment=1).
+        - Resuelve el último número usado vía un único ``SELECT`` que stripea
+          ``"<doc_code_prefix> "`` y ``<prefix>`` del ``name`` de
+          ``account.payment`` con dos ``REPLACE`` y castea el residuo a
+          ``INTEGER``, devolviendo el ``MAX``.
+        - Setea ``sequence_id.number_next = max(numero) + 1`` para que el
+          próximo payment posteado retome la numeración sin colisiones.
+
+        Sirve como ejecutor de la migración 19.0.2.0.0 y como acción manual de
+        reparación si la numeración se desfasa (deletes, importaciones, etc.).
+        """
+        for rec in self:
+            if not rec.sequence_id:
+                rec.sequence_id = (
+                    self.env["ir.sequence"]
+                    .sudo()
+                    .create(
+                        {
+                            "name": rec.name,
+                            "prefix": rec.prefix,
+                            "padding": 8,
+                            "number_increment": 1,
+                            "company_id": rec.company_id.id,
+                        }
+                    )
+                )
+
+            doc_code_prefix = rec.document_type_id.doc_code_prefix or ""
+            prefix = rec.prefix or ""
+            self.env.cr.execute(
+                """
+                SELECT MAX(CAST(REPLACE(REPLACE(name, %s, ''), %s, '') AS INTEGER))
+                  FROM account_payment
+                 WHERE receiptbook_id = %s
+                   AND name IS NOT NULL
+                   AND name LIKE %s
+                   AND state != 'draft'
+                """,
+                (
+                    doc_code_prefix + " ",
+                    prefix,
+                    rec.id,
+                    # solo cuentan pagos con el formato canónico del receiptbook;
+                    # excluye linked payments de bundles (e.g. "Main (1)").
+                    f"{doc_code_prefix} {prefix}%",
+                ),
+            )
+            last_number = self.env.cr.fetchone()[0] or 0
+            next_number = last_number + 1
+            rec.sequence_id.sudo().number_next = next_number
+
+            _logger.info(
+                "Receiptbook id=%s prefix=%r: último número=%d, ir.sequence id=%s number_next=%d",
+                rec.id,
+                rec.prefix,
+                last_number,
+                rec.sequence_id.id,
+                next_number,
+            )
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_used(self):

--- a/account_payment_pro_receiptbook/views/account_payment_receipt_group.xml
+++ b/account_payment_pro_receiptbook/views/account_payment_receipt_group.xml
@@ -52,8 +52,8 @@
                         <group>
                             <field name="document_type_id"/>
                             <field name="prefix"/>
-                            <field name="last_sequence" invisible="not last_sequence"/>
-                            <field name="initial_sequence" invisible="last_sequence"/>
+                            <field name="sequence_id"/>
+                            <field name="next_number"/>
                             <field name="company_id" widget="selection" groups="base.group_multi_company"/>
                         </group>
                     </group>

--- a/account_payment_pro_receiptbook/wizard/account_resequence.py
+++ b/account_payment_pro_receiptbook/wizard/account_resequence.py
@@ -43,3 +43,7 @@ class AccountResequenceWizard(models.TransientModel):
             self[0].write({"new_values": json.dumps(filtered_moves)})
 
             super().resequence()
+
+        # Después de renumerar moves, los nombres de los account.payment quedan desfasados
+        # respecto a la ir.sequence del receiptbook: resyncronizamos el number_next.
+        original_move_ids.mapped("receiptbook_id").action_resync_sequence()

--- a/l10n_ar_payment_bundle/wizard/payment_rename.py
+++ b/l10n_ar_payment_bundle/wizard/payment_rename.py
@@ -65,6 +65,9 @@ class PaymentRenameWizard(models.TransientModel):
             message_type="notification",
         )
 
+        # Resyncronizamos el ir.sequence del receiptbook para reflejar el rename.
+        self.payment_id.receiptbook_id.action_resync_sequence()
+
         return {
             "type": "ir.actions.client",
             "tag": "reload",


### PR DESCRIPTION
Revierte la numeración de receiptbooks al modelo de 18.0 (basado en ir.sequence por receiptbook) en lugar del sequence.mixin de account.move que se había adoptado en 19.0.1.

Cambios:

- account.payment.receiptbook: el create() autocrea un ir.sequence (padding=8) y el write() sincroniza el prefix con la sequence. Se expone next_number como related a sequence_id.number_next_actual. Se eliminan los campos initial_sequence y last_sequence.
- account.payment.action_post: numera el payment llamando a receiptbook.sequence_id.next_by_id() y valida que la sequence exista.
- account.move: se eliminan los overrides de sequence.mixin (_get_starting_sequence, _get_next_sequence_format, _deduce_sequence_number_reset, _set_next_made_sequence_gap) y se vuelve al esquema de _get_last_sequence_domain con without_receiptbook_id en contexto. Se mantienen los computes de hueco/gap para evitar reportar gaps en huecos legítimos del receiptbook.
- Vista: se reemplazan last_sequence/initial_sequence por sequence_id y next_number en el formulario del receiptbook.
- Migración post 19.0.2.0.0: para cada receiptbook sin sequence_id, crea el ir.sequence con prefix correspondiente, parsea con regex el sufijo numérico de los account.payment existentes y setea number_next = max(numero) + 1 para retomar la numeración sin colisiones. Idempotente.

Change note: la numeración de talonarios de recibo vuelve a manejarse con ir.sequence (como en 18.0), pudiendo editarse desde el formulario del receiptbook. La migración preserva la numeración existente al configurar ir.sequence con el siguiente número disponible. Ticket 117468.