### PR TITLE
[FIX] account_payment_pro: sync amount_exact in payment computations

### DIFF
--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -385,6 +385,12 @@ class AccountPayment(models.Model):
             if not rec.currency_id.is_zero(rec.amount - rec.amount_exact):
                 rec.amount_exact = rec.amount
 
+    def _compute_amount(self):
+        super()._compute_amount()
+        for rec in self:
+            if not rec.currency_id.is_zero(rec.amount - rec.amount_exact):
+                rec.amount_exact = rec.amount
+
     @api.onchange("currency_id")
     def _onchange_currency_recompute_amount(self):
         """Al cambiar la moneda del diario, reconvertir amount a la nueva moneda A."""
@@ -521,7 +527,7 @@ class AccountPayment(models.Model):
             self = self.with_company(self.company_id.id)
         super(AccountPayment, self)._compute_available_journal_ids()
 
-    @api.depends("amount", "counterpart_rate", "counterpart_currency_id", "currency_id")
+    @api.depends("amount", "amount_exact", "counterpart_rate", "counterpart_currency_id", "currency_id")
     def _compute_counterpart_currency_amount(self):
         for rec in self:
             amount = rec.amount_exact or rec.amount
@@ -908,6 +914,7 @@ class AccountPayment(models.Model):
         "counterpart_currency_amount",
         "write_off_amount",
         "amount",
+        "amount_exact",
         "accounting_rate",
         "counterpart_currency_id",
         "destination_currency_id",
@@ -925,7 +932,6 @@ class AccountPayment(models.Model):
                 # Convertir A → C = amount_exact / accounting_rate (usar amount_exact para evitar redondeos)
                 amount_for_calc = rec.amount_exact if rec.amount_exact else rec.amount
                 base_amount = amount_for_calc / rec.accounting_rate if rec.accounting_rate else amount_for_calc
-                base_amount = rec.amount / rec.accounting_rate if rec.accounting_rate else rec.amount
             rec.payment_total = base_amount + rec.write_off_amount
 
     # TODO revisar depends
@@ -1013,6 +1019,7 @@ class AccountPayment(models.Model):
             diff_in_a = rec._get_payment_difference_in_currency_a()
             amount = rec.amount + diff_in_a
             rec.amount = amount if amount > 0 else 0
+            rec.amount_exact = amount if amount > 0 else 0
 
     @api.onchange("l10n_latam_new_check_ids")
     def _onchange_new_check_default_amount(self):


### PR DESCRIPTION
- Add _compute_amount override to sync amount_exact after payment method changes
- Add amount_exact to depends of _compute_counterpart_currency_amount
- Use amount_exact or amount in counterpart amount calculation
- Add amount_exact to depends of _compute_payment_total
- Remove duplicate base_amount calculation in reconcile case
- Sync amount_exact in _onchange_to_pay_lines_adjust_amount

Change note: Solucionamos un error en los pagos con cheques múltiples donde el monto total mostrado en pantalla no coincidía con la suma de los cheques ingresados. Ahora cuando agregas o modificas cheques, el sistema calcula correctamente el total del pago.