### PR TITLE
[FIX] account_payment_pro: exclude check payments from onchange amoun…

### DIFF
--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -676,7 +676,7 @@ class AccountPayment(models.Model):
 
     @api.onchange("to_pay_move_line_ids")
     def _onchange_amount(self):
-        for rec in self.filtered(lambda r: r.company_id.use_payment_pro):
+        for rec in self.filtered(lambda r: r.company_id.use_payment_pro and not r._is_latam_check_payment()):
             if rec.amount != abs(rec.to_pay_amount):
                 rec.amount = abs(rec.to_pay_amount)
 

--- a/account_payment_pro/tests/test_account_paymet_pro_unit_test.py
+++ b/account_payment_pro/tests/test_account_paymet_pro_unit_test.py
@@ -199,6 +199,78 @@ class TestAccountPaymentProUnitTest(common.TransactionCase):
         self.assertAlmostEqual(payment.amount_company_currency, accounting_amount, places=2)
         self.assertAlmostEqual(payment.exchange_rate, 1000.0, places=2)
 
+    def test_check_method_does_not_update_amount_from_to_pay_lines(self):
+        """Check payments get their amount from the checks tab, not from selected debts."""
+        check_method_line = self.env["account.payment.method.line"].search(
+            [
+                ("journal_id", "=", self.company_bank_journal.id),
+                ("code", "=", "new_third_party_checks"),
+            ],
+            limit=1,
+        )
+        if not check_method_line:
+            check_method = self.env["account.payment.method"].search([("code", "=", "new_third_party_checks")])
+            self.assertTrue(check_method, "new_third_party_checks payment method is required")
+            check_method_line = self.env["account.payment.method.line"].create(
+                {
+                    "name": "Third Party Checks",
+                    "payment_method_id": check_method.id,
+                    "journal_id": self.company_bank_journal.id,
+                }
+            )
+
+        invoice = self.env["account.move"].create(
+            {
+                "partner_id": self.partner_ri.id,
+                "invoice_date": self.today,
+                "move_type": "out_invoice",
+                "journal_id": self.company_journal.id,
+                "company_id": self.company.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.env.ref("product.product_product_16").id,
+                            "quantity": 1,
+                            "price_unit": 457012.45,
+                        }
+                    ),
+                ],
+            }
+        )
+        invoice.action_post()
+
+        payment = self.env["account.payment"].new(
+            {
+                "payment_type": "inbound",
+                "partner_type": "customer",
+                "partner_id": self.partner_ri.id,
+                "journal_id": self.company_bank_journal.id,
+                "payment_method_line_id": check_method_line.id,
+                "amount": 435599.40,
+                "l10n_latam_new_check_ids": [
+                    Command.create(
+                        {
+                            "name": "CHK-001",
+                            "payment_date": self.today,
+                            "amount": 435599.40,
+                        }
+                    )
+                ],
+                "to_pay_move_line_ids": [
+                    Command.set(
+                        invoice.line_ids.filtered(
+                            lambda l: l.account_id.account_type in ("asset_receivable", "liability_payable")
+                        ).ids
+                    )
+                ],
+            }
+        )
+        payment._compute_amount()
+
+        payment._onchange_amount()
+
+        self.assertAlmostEqual(payment.amount, 435599.40, places=2)
+
     def test_write_off_line_amounts_company_vs_payment_currency(self):
         """Minimal test: company currency vs payment currency, force company amount and check write-off line balance"""
         # Use existing company and ensure we have a different currency for the payment


### PR DESCRIPTION
…t update

Prevent check payments from automatically updating their amount based on selected debt lines. Check amounts should be determined by the checks tab, not by to_pay_move_line_ids.

The _onchange_amount method now filters out payments using check payment methods (_is_latam_check_payment) to preserve their manually set amounts.

---
**Nota de Cambio:**

Se corrige el comportamiento del onchange que actualizaba automáticamente el monto de los pagos con cheques basándose en las deudas seleccionadas. Ahora los pagos con cheques mantienen su monto según lo configurado en la pestaña de cheques.