### PR TITLE
[IMP] account_payment_pro: add base payment receipt report template

### DIFF
--- a/account_payment_pro/__manifest__.py
+++ b/account_payment_pro/__manifest__.py
@@ -28,6 +28,7 @@
         "views/account_move.xml",
         "views/account_write_off_type_views.xml",
         "views/res_company_setting.xml",
+        "views/report_payment_receipt_template.xml",
     ],
     "demo": [],
     "post_init_hook": "_post_init_hooks",

--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 from odoo import Command, _, api, fields, models
 from odoo.exceptions import ValidationError
 
@@ -1233,3 +1235,28 @@ class AccountPayment(models.Model):
         for rec in self.filtered(lambda x: x.move_id and x.move_id.state not in ["draft", "cancel"]):
             if rec.journal_id != rec.move_id.journal_id:
                 raise ValidationError(_("The payment journal must match the journal of its journal entry."))
+
+    # ── Report helpers ────────────────────────────────────────────────────────
+
+    def _get_receipt_header_address(self):
+        """Return the partner address shown in the receipt header.
+        Override in country/receiptbook modules to customize."""
+        self.ensure_one()
+        return self.company_id.partner_id
+
+    def _get_payment_bundle_key(self):
+        """Key used to group payments into bundles for printing.
+        Base: each payment is its own bundle (key = id)."""
+        return self.id
+
+    def _get_payment_bundles(self):
+        """Return a dict {key: account.payment recordset} grouping self into print bundles."""
+        bundles = defaultdict(lambda: self.env["account.payment"])
+        for rec in self:
+            bundles[rec._get_payment_bundle_key()] += rec
+        return bundles
+
+    def _select_bundle(self, bundles):
+        """Return the bundle recordset for this payment from the bundles dict."""
+        self.ensure_one()
+        return bundles.get(self._get_payment_bundle_key())

--- a/account_payment_pro/views/report_payment_receipt_template.xml
+++ b/account_payment_pro/views/report_payment_receipt_template.xml
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Inject payment_bundles + payment_bundle into the base receipt loop and route
+         the document template via _get_name_receipt_report so localizations can swap it. -->
+    <template id="report_payment_receipt_inject_bundles" inherit_id="account.report_payment_receipt">
+        <t t-foreach="docs" position="before">
+            <t t-set="payment_bundles" t-value="docs._get_payment_bundles()"/>
+        </t>
+        <t t-call="account.report_payment_receipt_document" position="attributes">
+            <attribute name="t-call">#{o._get_name_receipt_report('account.report_payment_receipt_document')}</attribute>
+        </t>
+        <t t-set="lang" position="after">
+            <t t-set="payment_bundle" t-value="o._select_bundle(payment_bundles)"/>
+        </t>
+    </template>
+
+    <!-- Primary payment receipt document template.
+         Provides the full page structure: partner info, payments table,
+         matching table, and named injection points for localizations.
+         priority=16 beats the default Odoo template. -->
+    <template id="report_payment_receipt_document_pro"
+              inherit_id="account.report_payment_receipt_document"
+              primary="True"
+              priority="16">
+        <t t-set="o" position="after">
+            <!-- Fallback: if payment_bundle was not injected by the outer loop use o alone -->
+            <t t-if="not payment_bundle" t-set="payment_bundle" t-value="o"/>
+            <t t-set="report_date" t-value="o.date"/>
+            <t t-set="report_number" t-value="o.name"/>
+            <t t-set="report_name" t-value="o.payment_type == 'outbound' and _('Payment Order') or _('Receipt')"/>
+        </t>
+        <div class="page" position="replace">
+            <div class="page">
+
+                <!-- ── Partner info ─────────────────────────────────────────────── -->
+                <div id="informations" class="row mt8 mb8">
+                    <div class="col-6" name="partner_info">
+                        <strong>
+                            <span t-if="o.partner_type == 'supplier'">Supplier: </span>
+                            <span t-if="o.partner_type == 'customer'">Customer: </span>
+                        </strong><span t-field="o.partner_id.commercial_partner_id.name"/>
+                        <br/>
+                        <span t-out="o.partner_id" t-options='{"widget": "contact", "fields": ["address"], "no_marker": True, "no_tag_br": True}'/>
+                        <!-- Injection point: country-specific partner attributes (VAT, tax ID, etc.) -->
+                        <span name="partner_info_extra"/>
+                    </div>
+                </div>
+
+                <br/>
+
+                <!-- ── Payments table ───────────────────────────────────────────── -->
+                <table class="table table-sm o_main_table" name="payments_table">
+                    <!--
+                        show_amount_col: show a secondary "native currency" column when any
+                        payment in the bundle uses a currency different from destination_currency_id.
+                        Localizations can override this via xpath targeting show_amount_col_def.
+                    -->
+                    <t name="show_amount_col_def" t-set="show_amount_col" t-value="any(doc.currency_id != o.destination_currency_id for doc in payment_bundle)"/>
+                    <thead>
+                        <tr>
+                            <th><span>Payments</span></th>
+                            <th class="text-right" t-if="show_amount_col"><span>Amount</span></th>
+                            <th class="text-right">
+                                <span>Amount</span><span t-if="show_amount_col"> (<span t-field="o.destination_currency_id.name"/>)</span>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <!-- Check rows -->
+                        <t t-foreach="payment_bundle" t-as="doc">
+                            <t t-foreach="doc._get_latam_checks()" t-as="check">
+                                <tr>
+                                    <td>
+                                        <span t-out="'Cheque nro %s' % (check.name)">Check nro 123456</span>
+                                        <span t-if="check.bank_id" t-out="' - %s' % (check.bank_id.name)"> - Santander Rio</span>
+                                        <span t-out="' (%s)' % (check.payment_method_line_id.name)"> (Electronic checkbook)</span>
+                                        <span t-if="check.payment_date"> - Exp. <span t-field="check.payment_date"/></span>
+                                    </td>
+                                    <td class="text-right" t-if="show_amount_col">
+                                        <!-- Amount in journal currency (A) -->
+                                        <span class="text-nowrap" t-out="check.amount" t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/>
+                                    </td>
+                                    <td class="text-right o_price_total">
+                                        <!-- Amount in destination currency (B2) -->
+                                        <span class="text-nowrap" t-out="doc.destination_currency_id.round(check.amount * (doc.counterpart_rate or 1.0) if doc.counterpart_currency_id == doc.destination_currency_id else (check.amount / doc.accounting_rate if doc.accounting_rate else check.amount))" t-options='{"widget": "monetary", "display_currency": doc.destination_currency_id}'/>
+                                    </td>
+                                </tr>
+                            </t>
+                        </t>
+                        <!-- Injection point: country-specific payment rows (e.g. withholdings) -->
+                        <t name="withholding_rows"/>
+                        <!-- Write-off rows -->
+                        <t t-foreach="payment_bundle.filtered('write_off_amount')" t-as="doc">
+                            <tr>
+                                <td>
+                                    <span t-out="doc.write_off_type_id.label or doc.write_off_type_id.name"/>
+                                </td>
+                                <td class="text-right" t-if="show_amount_col">
+                                    <span class="text-nowrap" t-field="doc.write_off_amount"/>
+                                </td>
+                                <td class="text-right o_price_total">
+                                    <span class="text-nowrap" t-field="doc.write_off_amount"/>
+                                </td>
+                            </tr>
+                        </t>
+                        <!-- Regular (non-check) payment rows -->
+                        <t t-set="all_same_type" t-value="len(set(payment_bundle.mapped('payment_type'))) == 1"/>
+                        <t t-foreach="payment_bundle.filtered(lambda x: not x._is_latam_check_payment() and x.amount != 0.0)" t-as="doc" id="payment_bundle_doc">
+                            <t t-set="display_amount_a" t-value="abs(doc.amount_signed) if all_same_type else doc.amount_signed"/>
+                            <t t-set="display_amount_b_raw" t-value="doc.counterpart_currency_amount if doc.counterpart_currency_id == doc.destination_currency_id else (doc.amount / doc.accounting_rate if doc.accounting_rate else doc.amount)"/>
+                            <t t-set="display_amount_b" t-value="abs(display_amount_b_raw) if all_same_type else (display_amount_b_raw if doc.payment_type == 'inbound' else -display_amount_b_raw)"/>
+                            <tr>
+                                <td>
+                                    <span t-field="doc.journal_id.name"/>
+                                    <span t-field="doc.payment_method_line_id.name"/>
+                                </td>
+                                <td class="text-right" t-if="show_amount_col">
+                                    <!-- Amount in journal currency (A) -->
+                                    <span class="text-nowrap"
+                                        t-out="display_amount_a"
+                                        t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/>
+                                </td>
+                                <td class="text-right o_price_total">
+                                    <!-- Amount in destination currency (B2) -->
+                                    <span class="text-nowrap"
+                                        t-out="display_amount_b"
+                                        t-options='{"widget": "monetary", "display_currency": doc.destination_currency_id}'/>
+                                </td>
+                            </tr>
+                        </t>
+                    </tbody>
+                    <tfoot>
+                        <tr>
+                            <td><strong><span>Total Paid</span></strong></td>
+                            <td t-if="show_amount_col"/>
+                            <td class="text-right">
+                                <strong><span class="text-nowrap" t-field="o.payment_total"/></strong>
+                            </td>
+                        </tr>
+                    </tfoot>
+                </table>
+
+                <br/>
+
+                <!-- ── Matching (imputed vouchers) table ────────────────────────── -->
+                <t t-set="matched_lines" t-value="payment_bundle.with_context(matched_payment_ids=payment_bundle.ids).mapped('matched_move_line_ids')"/>
+                <table class="table table-sm o_main_table" name="matching_table">
+                    <thead>
+                        <tr>
+                            <th><span>Imputed Vouchers</span></th>
+                            <th class="text-center"><span>Exp. Date</span></th>
+                            <th class="text-right"><span>Original Amount</span></th>
+                            <th class="text-right"><span>Imputed Amount</span></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <t t-foreach="matched_lines" t-as="line">
+                            <tr>
+                                <td><span t-field='line.move_id.display_name'/></td>
+                                <td class="text-center">
+                                    <span class="text-nowrap" t-field="line.date_maturity"/>
+                                </td>
+                                <td class="text-right o_price_total">
+                                    <!-- Original amount in line's currency -->
+                                    <span class="text-nowrap" t-out="(o.payment_type == 'outbound' and -1.0 or 1.0) * line.amount_currency" t-options='{"widget": "monetary", "display_currency": line.currency_id}'/>
+                                </td>
+                                <td class="text-right o_price_total">
+                                    <!-- Matched amount in destination currency (B2) -->
+                                    <span class="text-nowrap" t-out="(o.payment_type == 'outbound' and -1.0 or 1.0) * line.payment_matched_amount" t-options='{"widget": "monetary", "display_currency": line.payment_matched_currency_id}'/>
+                                </td>
+                            </tr>
+                            <t class="reversal_move_lines"/>
+                        </t>
+                        <tr t-if="sum(payment_bundle.mapped('unmatched_amount'))">
+                            <td>On account</td>
+                            <td class="text-center"/>
+                            <td class="text-right o_price_total"/>
+                            <td class="text-right o_price_total">
+                                <span class="text-nowrap" t-out="sum(payment_bundle.mapped('unmatched_amount'))" t-options="{'widget': 'monetary', 'display_currency': o.destination_currency_id}"/>
+                            </td>
+                        </tr>
+                    </tbody>
+                    <tfoot>
+                        <tr>
+                            <td colspan="3"><strong><span>Total Imputed</span></strong></td>
+                            <td class="text-right">
+                                <strong><span class="text-nowrap" t-out="o.matched_amount + o.unmatched_amount" t-options='{"widget": "monetary", "display_currency": o.destination_currency_id}'/></strong>
+                            </td>
+                        </tr>
+                    </tfoot>
+                </table>
+
+                <br/>
+
+                <!-- Injection point: country-specific extra tables (e.g. pending receivables) -->
+                <span name="pending_table"/>
+
+                <!-- Injection point: receipt footer (signature, memo, etc.) -->
+                <span name="payment_footer"/>
+
+            </div>
+        </div>
+    </template>
+
+</odoo>

--- a/account_payment_pro_receiptbook/models/account_payment.py
+++ b/account_payment_pro_receiptbook/models/account_payment.py
@@ -81,3 +81,7 @@ class AccountPayment(models.Model):
                 and not (x.receiptbook_id and x.payment_transaction_id)
             ),
         )._compute_name()
+
+    def _get_receipt_header_address(self):
+        self.ensure_one()
+        return self.receiptbook_id.report_partner_id or super()._get_receipt_header_address()

--- a/l10n_ar_payment_bundle/__manifest__.py
+++ b/l10n_ar_payment_bundle/__manifest__.py
@@ -23,6 +23,7 @@
         "views/payment_rename_wizard_view.xml",
         "data/account_payment_method_data.xml",
         "views/account_payment_view.xml",
+        "views/report_payment_receipt_template.xml",
     ],
     "installable": True,
     "auto_install": False,

--- a/l10n_ar_payment_bundle/models/account_payment.py
+++ b/l10n_ar_payment_bundle/models/account_payment.py
@@ -264,7 +264,8 @@ class AccountPayment(models.Model):
         return res
 
     def action_draft(self):
-        res = super(AccountPayment, self + self.link_payment_ids).action_draft()
+        active_links = self.link_payment_ids.filtered(lambda p: p.state != "cancel")
+        res = super(AccountPayment, self + active_links).action_draft()
         if self.main_payment_id:
             return {
                 "type": "ir.actions.act_window",

--- a/l10n_ar_payment_bundle/views/report_payment_receipt_template.xml
+++ b/l10n_ar_payment_bundle/views/report_payment_receipt_template.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Bundle report: renders one receipt per bundle when printing multiple payments at once.
+         Each bundle is identified by _get_payment_bundles() grouping (company/partner/type/currency). -->
+    <template id="report_payment_receipt_bundle">
+        <t t-call="web.html_container">
+            <t t-foreach="docs.with_context(print_in_bundles=True)._get_payment_bundles().values()" t-as="payment_bundle">
+                <t t-set="o" t-value="payment_bundle[0]"/>
+                <t t-set="lang" t-value="o.partner_id.lang or o.company_id.partner_id.lang"/>
+                <t t-call="#{o._get_name_receipt_report('account.report_payment_receipt_document')}" t-lang="lang"/>
+            </t>
+        </t>
+    </template>
+
+    <record id="action_report_receipt_bundle" model="ir.actions.report">
+        <field name="name">Payment Receipt bundled</field>
+        <field name="model">account.payment</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">l10n_ar_payment_bundle.report_payment_receipt_bundle</field>
+        <field name="report_file">l10n_ar_payment_bundle.report_payment_receipt_bundle</field>
+        <field name="binding_model_id" ref="model_account_payment"/>
+        <field name="binding_type">report</field>
+        <field name="binding_view_types">list</field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
## Summary

- **`account_payment_pro`**: agrega template primario `report_payment_receipt_document_pro` con la estructura completa del recibo (tabla de pagos, cheques, write-offs, tabla de imputados) y puntos de extensión nombrados para localizaciones. Agrega métodos base `_get_payment_bundle_key`, `_get_payment_bundles`, `_select_bundle`, `_get_receipt_header_address`. Registra el template en el manifest (el archivo existía pero nunca se cargaba)
- **`account_payment_pro_receiptbook`**: override de `_get_receipt_header_address()` para usar `receiptbook_id.report_partner_id`, reemplazando el check `_fields.get('receiptbook_id')` que vivía en `l10n_ar_tax`
- **`l10n_ar_payment_bundle`**: mueve `report_payment_receipt_bundle` y `action_report_receipt_bundle` desde `l10n_ar_tax` (actualiza el prefijo del `report_name` a `l10n_ar_payment_bundle`)

## Depends on
PR complementario en `odoo-argentina` que adelgaza `l10n_ar_tax`.

## Test plan
- [ ] Instalar `account_payment_pro` sin `l10n_ar_tax` — verificar que el template pro renderiza correctamente
- [ ] Instalar `account_payment_pro_receiptbook` — verificar que `header_address` usa `receiptbook_id.report_partner_id`
- [ ] Imprimir desde lista con "Payment Receipt bundled" — verificar que el template ahora tiene ID `l10n_ar_payment_bundle.report_payment_receipt_bundle`
- [ ] Pago en moneda extranjera — verificar columna extra en tabla de pagos
- [ ] Pago con write-off — verificar fila de write-off en tabla de pagos