### PR TITLE
[FIX] account_payment_pro: handle None move_id.name in sort key

### DIFF
--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -847,11 +847,11 @@ class AccountPayment(models.Model):
                 debit_moves = debit_moves.filtered(lambda x: x.move_id not in exchange_move_ids)
                 credit_moves = credit_moves.filtered(lambda x: x.move_id not in exchange_move_ids)
 
-            debit_lines_sorted = debit_moves.filtered(lambda x: x.date_maturity != False).sorted(
-                key=lambda x: (x.date_maturity, x.move_id.name)
+            debit_lines_sorted = debit_moves.filtered(lambda x: x.date_maturity).sorted(
+                key=lambda x: (x.date_maturity, x.move_id.name or "")
             )
-            credit_lines_sorted = credit_moves.filtered(lambda x: x.date_maturity != False).sorted(
-                key=lambda x: (x.date_maturity, x.move_id.name)
+            credit_lines_sorted = credit_moves.filtered(lambda x: x.date_maturity).sorted(
+                key=lambda x: (x.date_maturity, x.move_id.name or "")
             )
             debit_lines_without_date_maturity = debit_moves - debit_lines_sorted
             credit_lines_without_date_maturity = credit_moves - credit_lines_sorted


### PR DESCRIPTION
- Replace `!= False` with truthy check for date_maturity filter
- Add `or ""` fallback for move_id.name in sort key to avoid TypeError when move name is None

Change note: Corrige un error al ordenar líneas de pago cuando el nombre del asiento contable es nulo, evitando un TypeError al conciliar pagos.