### PR TITLE
[IMP] account_cashbox: propagate cashbox_session_id in payment regist…

### DIFF
--- a/account_cashbox/wizards/account_payment_register.py
+++ b/account_cashbox/wizards/account_payment_register.py
@@ -52,3 +52,9 @@ class AccountPaymentRegister(models.TransientModel):
             pay.available_journal_ids = pay.available_journal_ids._origin.filtered(
                 lambda x: x in pay.cashbox_session_id.line_ids.mapped("journal_id")
             )
+
+    def _create_payment_vals_from_wizard(self, batch_result):
+        payment_vals = super()._create_payment_vals_from_wizard(batch_result)
+        if self.cashbox_session_id:
+            payment_vals["cashbox_session_id"] = self.cashbox_session_id.id
+        return payment_vals


### PR DESCRIPTION
…er wizard

- Override _create_payment_vals_from_wizard in AccountPaymentRegister
- Add cashbox_session_id to payment vals when session is set

Change note: Al registrar un pago desde el wizard de pagos (por ejemplo, desde gastos de empleados), la sesión de caja activa ahora se asigna correctamente al pago generado, asegurando que quede vinculado al punto de operación correspondiente.