### PR TITLE
[FIX] account_payment_pro: guard currency_id before is_zero in _compu…

### DIFF
--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -400,7 +400,7 @@ class AccountPayment(models.Model):
     def _compute_amount(self):
         super()._compute_amount()
         for rec in self:
-            if not rec.currency_id.is_zero(rec.amount - rec.amount_exact):
+            if rec.currency_id and not rec.currency_id.is_zero(rec.amount - rec.amount_exact):
                 rec.amount_exact = rec.amount
 
     @api.onchange("currency_id")


### PR DESCRIPTION
…te_amount

- Add `rec.currency_id and` guard in _compute_amount override
- Prevents ValueError when l10n_ar_payment_bundle batch-computes amount for withholding sub-payments that have no currency_id initialized

Change note: Solucionamos un error que impedía cobrar facturas en la empresa operativa cuando se usaban pagos con retenciones (bundle). El sistema ya no falla al calcular el monto del pago en esos contextos.