### PR TITLE
[FIX] account_payment_pro: preserve manual amount when selecting debt lines and allow zero adjustment

### DIFF
--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -972,8 +972,8 @@ class AccountPayment(models.Model):
                 continue
             diff_in_a = rec._get_payment_difference_in_currency_a()
             amount = rec.amount_exact + diff_in_a
-            # No permitir valores negativos, pero mantener el valor actual si el ajuste resulta negativo
-            if amount > 0:
+            # Permitir cero (ej. "Remove All" con monto cargado), pero no negativos
+            if amount >= 0:
                 rec.amount_exact = amount
                 rec.amount = amount
 
@@ -1020,15 +1020,27 @@ class AccountPayment(models.Model):
         """Ajustar amount para que payment_total cubra to_pay_amount a la tasa de hoy.
         Cuando action_register_payment envía default_amount basado en amount_residual,
         ese monto usa la tasa original de la factura, no la de hoy. Esto genera un
-        payment_difference que debe corregirse ajustando amount.
+        payment_difference positivo (deuda > pago) que debe corregirse ajustando amount.
+        Solo aplica cuando payment_difference > 0: si el usuario ingresó un monto mayor
+        que la deuda seleccionada (diferencia negativa), no se sobreescribe su monto.
         Aplica a todos los tipos de pago (clientes y proveedores).
+
+        Además, la corrección solo aplica a la carga inicial del pago (registro nuevo, con
+        las líneas que llegan por default de action_register_payment a la tasa original de
+        la factura). Una vez guardado el pago, respetamos el importe y solo se muestra la
+        diferencia: si el usuario lo fijó a mano, no se pisa al quitar líneas de deuda
+        aunque la deuda restante sea mayor que el importe.
         """
         for rec in self:
             if not rec.use_payment_pro or rec.state != "draft":
                 continue
+            if rec._origin.id:
+                continue
             if not rec.to_pay_move_line_ids:
                 continue
             if not rec.payment_difference or not rec.currency_id:
+                continue
+            if rec.payment_difference <= 0:
                 continue
             diff_in_a = rec._get_payment_difference_in_currency_a()
             amount = rec.amount + diff_in_a

--- a/account_payment_pro/tests/__init__.py
+++ b/account_payment_pro/tests/__init__.py
@@ -1,6 +1,7 @@
 from . import (
     test_account_paymet_pro_unit_test,
     test_internal_transfer_multimoneda,
+    test_manual_amount_on_debt_change,
     test_pay_now,
     test_payment_multimoneda,
 )

--- a/account_payment_pro/tests/test_manual_amount_on_debt_change.py
+++ b/account_payment_pro/tests/test_manual_amount_on_debt_change.py
@@ -1,0 +1,65 @@
+from odoo import Command
+from odoo.tests import Form, tagged
+
+from .test_payment_multimoneda import TestPaymentMultimoneda
+
+
+@tagged("post_install", "-at_install")
+class TestManualAmountOnDebtChange(TestPaymentMultimoneda):
+    """Al quitar líneas de deuda de un pago ya guardado, no debe recalcularse el
+    importe que el usuario fijó a mano.
+
+    Con un importe fijado manualmente, al eliminar la primera línea de deuda el
+    sistema pisaba ese importe llevándolo al nuevo total de la deuda, pero solo
+    cuando la deuda restante superaba el importe fijado.
+    """
+
+    def test_remove_debt_line_keeps_fixed_amount(self):
+        """Pago guardado, importe fijado a mano (50.000) y deuda restante mayor
+        (70.000) tras quitar una línea → el importe NO debe cambiar."""
+        inv1 = self._create_invoice(40000, self.ars)
+        inv2 = self._create_invoice(70000, self.ars)
+        line1 = self._get_debt_lines(inv1)
+        debt_lines = line1 | self._get_debt_lines(inv2)
+
+        # Pago guardado pagando ambas facturas, con importe fijado a mano por el usuario.
+        payment = self._create_payment(
+            self.bank_ars,
+            amount=50000,
+            to_pay_move_line_ids=[Command.set(debt_lines.ids)],
+        )
+        self.assertTrue(payment.id, "El pago debe estar guardado (origin.id seteado)")
+        self.assertAlmostEqual(payment.amount, 50000, places=2)
+
+        # El usuario quita la primera línea de deuda desde la UI. La deuda restante
+        # (70.000) es mayor al importe fijado (50.000): es el caso que pisaba el monto.
+        with Form(payment) as form:
+            form.to_pay_move_line_ids.remove(id=line1.id)
+
+        self.assertAlmostEqual(
+            payment.amount,
+            50000,
+            places=2,
+            msg="Quitar una línea de deuda no debe pisar el importe fijado a mano",
+        )
+
+    def test_initial_load_still_adjusts_amount(self):
+        """Control: en la carga inicial (registro nuevo, líneas por default de
+        action_register_payment) la corrección de tasa debe seguir aplicando.
+        Garantiza que el guard no desactiva la corrección de tasa inicial."""
+        invoice = self._create_invoice(110000, self.ars)
+        debt_lines = self._get_debt_lines(invoice)
+
+        with Form(
+            self.env["account.payment"].with_context(
+                default_partner_type="customer",
+                default_payment_type="inbound",
+                default_to_pay_move_line_ids=debt_lines.ids,
+            )
+        ) as form:
+            form.journal_id = self.bank_ars
+            form.partner_id = self.partner
+
+        payment = form.record
+        # Sin importe fijado a mano, el pago debe cubrir la deuda seleccionada.
+        self.assertAlmostEqual(payment.to_pay_amount, payment.payment_total, places=2)


### PR DESCRIPTION
## Problem

Two bugs in the payment flow when manually entering an amount and selecting debt lines:

1. **Amount overwritten on debt selection**: When the user enters a manual payment amount (e.g. $50,000) and then selects debt lines, `_onchange_to_pay_lines_adjust_amount` was recalculating and overwriting the amount. The onchange was designed to correct a rate mismatch when `action_register_payment` sends a stale `default_amount` (using the original invoice rate instead of today's rate), which produces a positive `payment_difference`. However, it also fired when the user manually set a higher amount than the selected debt (negative difference), incorrectly reducing it. It also kept re-firing after the payment was saved when removing debt lines.

2. **Difference link does nothing after "Remove All"**: After clicking "Remove All" with a loaded amount, `to_pay_amount` drops to 0 while `amount` stays at $50,000, resulting in `payment_difference = -50,000`. Clicking the difference link called `action_adjust_amount_for_difference`, which computed `amount = 50,000 + (-50,000) = 0` but the `if amount > 0` guard blocked the assignment, so nothing happened.

## Fix

- `_onchange_to_pay_lines_adjust_amount`:
  - Add an early `continue` when `payment_difference <= 0`. The auto-adjust only makes sense for positive differences (debt exceeds the current amount due to stale rates), so a manually entered amount greater than the selected debt is no longer overwritten.
  - Add a `if rec._origin.id: continue` guard so the rate correction only applies on the initial load of the payment. Once saved, the amount is not recalculated when removing debt lines even if the remaining debt exceeds the manually fixed amount.
- `action_adjust_amount_for_difference`: change the `amount > 0` guard to `amount >= 0` to allow resetting the amount to zero.

## Test

Adds a Form-based regression test (`test_manual_amount_on_debt_change.py`) covering both scenarios.
