### PR TITLE
[FIX] l10n_ar_payment_bundle: skip cancelled link payments on action_…

### DIFF
--- a/l10n_ar_payment_bundle/models/account_payment.py
+++ b/l10n_ar_payment_bundle/models/account_payment.py
@@ -177,7 +177,8 @@ class AccountPayment(models.Model):
         return res
 
     def action_draft(self):
-        res = super(AccountPayment, self + self.link_payment_ids).action_draft()
+        active_links = self.link_payment_ids.filtered(lambda p: p.state != "canceled")
+        res = super(AccountPayment, self + active_links).action_draft()
         if self.main_payment_id:
             return {
                 "type": "ir.actions.act_window",


### PR DESCRIPTION
…draft

- Filter out cancelled payments from link_payment_ids before calling action_draft
- Prevents error when resetting to draft when some linked payments are cancelled

Change note: Se corrige un error que impedía volver al borrador un pago que tenía pagos vinculados en estado cancelado. Ahora los pagos vinculados cancelados son ignorados al restablecer el estado a borrador.