### PR TITLE
[FIX] account_payment_loan: registrar préstamo solo sobre cuenta por cobrar

### DIFF
--- a/account_payment_loan/wizards/account_loan_register.py
+++ b/account_payment_loan/wizards/account_loan_register.py
@@ -114,7 +114,11 @@ class AccountLoanRegister(models.TransientModel):
             res["amount"] = loan_move_ids._get_total_debit() + sum(amls.mapped("amount_residual"))
 
         elif self.env.context.get("active_ids"):
-            amls = self.env["account.move.line"].browse(self.env.context.get("active_ids", [])).filtered("debit")
+            amls = (
+                self.env["account.move.line"]
+                .browse(self.env.context.get("active_ids", []))
+                .filtered(lambda x: x.debit and x.account_id.account_type == "asset_receivable")
+            )
             res["move_line_ids"] = [Command.set(amls.ids)]
             res["amount"] = sum(amls.mapped("amount_residual"))
         if not res.get("move_line_ids") or res.get("amount", 0) <= 0:


### PR DESCRIPTION

Al registrar un préstamo desde una factura con descuento, el wizard tomaba todos los apuntes con débito (incluyendo la línea de descuento), inflando el monto del préstamo. Ahora filtra únicamente los apuntes de cuenta por cobrar (asset_receivable), alineado con la lógica de conciliación existente.

Tiquet 119436