### PR TITLE
[FIX] account_payment_pro_receiptbook: prevent stale red flag after resequencing

### DIFF
--- a/account_payment_pro_receiptbook/models/account_move.py
+++ b/account_payment_pro_receiptbook/models/account_move.py
@@ -39,9 +39,13 @@ class AccountMove(models.Model):
     def _compute_name(self):
         super()._compute_name()
         for move in self.filtered(
-            lambda x: x.origin_payment_id.receiptbook_id
-            and (
-                x.state == "draft" or x.origin_payment_id.state == "draft" or x.origin_payment_id.payment_transaction_id
+            lambda x: (
+                x.origin_payment_id.receiptbook_id
+                and (
+                    x.state == "draft"
+                    or x.origin_payment_id.state == "draft"
+                    or x.origin_payment_id.payment_transaction_id
+                )
             )
         ):
             move.name = move.origin_payment_id.name
@@ -94,3 +98,9 @@ class AccountMove(models.Model):
         if self.receiptbook_id:
             return False
         return super()._must_check_constrains_date_sequence()
+
+    def _update_sequence_made_gap(self, invalidate_current=False):
+        receiptbook_moves = self.filtered(lambda m: m.receiptbook_id)
+        receiptbook_moves.made_sequence_gap = False
+        if other_moves := self - receiptbook_moves:
+            super(AccountMove, other_moves)._update_sequence_made_gap(invalidate_current=invalidate_current)


### PR DESCRIPTION
## Summary

Receiptbook moves (`account.move` with `receiptbook_id` set) were incorrectly showing `made_sequence_gap = True` (red highlight in journal entries list) after resequencing, even when the sequence was actually continuous.

**Root cause:** Odoo calls `_update_sequence_made_gap` directly on post/cancel/resequence/unlink. This module already overrides `_compute_made_sequence_gap` and `_compute_made_sequence_hole` to always return `False` for receiptbook moves (opting them out of Odoo's journal sequence gap detection), but `_update_sequence_made_gap` was not overridden — so the standard journal-based logic could set the flag back to `True`, leaving stale values in the DB.

## Changes

- `account_payment_pro_receiptbook/models/account_move.py`: add `_update_sequence_made_gap` override that sets `made_sequence_gap = False` for receiptbook moves and delegates to `super()` only for non-receiptbook moves. Consistent with the existing `_compute_made_sequence_gap` and `_compute_made_sequence_hole` overrides introduced in cd655f3.

## Test plan

- [ ] Create payments with a receiptbook, confirm them
- [ ] Resequence the journal entries (Accounting > Journal Entries > Action > Resequence)
- [ ] Verify the payment names no longer appear in red after resequencing
- [ ] Verify non-receiptbook journal entries still show red correctly when there is a real sequence gap