### PR TITLE
[FIX] l10n_ar_payment_bundle: avoid double-count in bundled receipt totals for main payments

### DIFF
--- a/l10n_ar_payment_bundle/models/account_payment.py
+++ b/l10n_ar_payment_bundle/models/account_payment.py
@@ -213,6 +213,18 @@ class AccountPayment(models.Model):
 
             rec.warnings = warnings
 
+    def _get_bundle_payment_total(self, payment_bundle):
+        # main_payment.payment_total already accumulates all link_payment_ids via
+        # _compute_payment_total; summing the full bundle would double-count the links.
+        if self.is_main_payment:
+            return self.payment_total
+        return super()._get_bundle_payment_total(payment_bundle)
+
+    def _get_bundle_imputed_total(self, payment_bundle):
+        if self.is_main_payment:
+            return self.matched_amount + self.unmatched_amount
+        return super()._get_bundle_imputed_total(payment_bundle)
+
     def _get_payment_bundles(self):
         main_payments = self.filtered("is_main_payment")
         bundles = super(AccountPayment, self - main_payments)._get_payment_bundles()


### PR DESCRIPTION
## Problem

Companion PR to ingadhoc/odoo-argentina#1452.

`l10n_ar_tax` now computes bundled receipt totals via `sum(payment_bundle.mapped('payment_total'))`. For a standard payment bundle (`is_main_payment=True`), `main_payment.payment_total` already accumulates all `link_payment_ids` through `_compute_payment_total`. Summing the full bundle recordset (which includes `main_payment + link_payment_ids`) would double-count the linked payments.

## Solution

Override `_get_bundle_payment_total` and `_get_bundle_imputed_total` in `l10n_ar_payment_bundle`. When `self.is_main_payment`, return `self.payment_total` (and `self.matched_amount + self.unmatched_amount`) directly — the aggregation is already done. Otherwise delegate to `super()`.

## Test plan

- Create a payment bundle (main + 2 linked payments)
- Select the main payment from the list view
- Print → Payment receipt bundled
- Verify **Total Paid** = sum of all linked payment amounts (not double-counted)
- Also verify the base fix from ingadhoc/odoo-argentina#1452 works alongside this module