### PR TITLE
[IMP] account_payment_pro_receiptbook: add implementation field on receiptbook

### DIFF
--- a/account_payment_pro_receiptbook/__manifest__.py
+++ b/account_payment_pro_receiptbook/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Account Payment receiptbook",
-    "version": "19.0.2.1.0",
+    "version": "19.0.2.2.0",
     "category": "Payment",
     "website": "www.adhoc.com.ar",
     "author": "ADHOC SA",

--- a/account_payment_pro_receiptbook/i18n/account_payment_pro_receiptbook.pot
+++ b/account_payment_pro_receiptbook/i18n/account_payment_pro_receiptbook.pot
@@ -101,6 +101,21 @@ msgid "Customer Receipts"
 msgstr ""
 
 #. module: account_payment_pro_receiptbook
+#: model:ir.model.fields,help:account_payment_pro_receiptbook.field_account_payment_receiptbook__implementation
+msgid ""
+"Defines how the sequence assigns numbers:\n"
+"* Standard: numbers are drawn from a PostgreSQL sequence. It is fast, but the "
+"numbering may have gaps (for example if a draft payment is deleted or two "
+"payments are posted concurrently).\n"
+"* No gap: guarantees a strictly consecutive numbering, because a number is "
+"only assigned once the previous one has been assigned. Use it when the legal/"
+"fiscal numbering must not skip values. It is slower than the standard "
+"implementation: to keep numbers consecutive it locks the sequence on every "
+"assignment, so concurrent payments are serialized and have to wait for each "
+"other, which can cause noticeable delays when posting many payments at once."
+msgstr ""
+
+#. module: account_payment_pro_receiptbook
 #: model:ir.model.fields,field_description:account_payment_pro_receiptbook.field_account_chart_template__display_name
 #: model:ir.model.fields,field_description:account_payment_pro_receiptbook.field_account_journal__display_name
 #: model:ir.model.fields,field_description:account_payment_pro_receiptbook.field_account_move__display_name
@@ -169,6 +184,11 @@ msgstr ""
 msgid ""
 "If set an email will be sent to the customer when the related "
 "account.payment.group has been posted."
+msgstr ""
+
+#. module: account_payment_pro_receiptbook
+#: model:ir.model.fields,field_description:account_payment_pro_receiptbook.field_account_payment_receiptbook__implementation
+msgid "Implementation"
 msgstr ""
 
 #. module: account_payment_pro_receiptbook

--- a/account_payment_pro_receiptbook/i18n/es.po
+++ b/account_payment_pro_receiptbook/i18n/es.po
@@ -112,6 +112,32 @@ msgid "Customer Receipts"
 msgstr "Recibos de Cliente"
 
 #. module: account_payment_pro_receiptbook
+#: model:ir.model.fields,help:account_payment_pro_receiptbook.field_account_payment_receiptbook__implementation
+msgid ""
+"Defines how the sequence assigns numbers:\n"
+"* Standard: numbers are drawn from a PostgreSQL sequence. It is fast, but the "
+"numbering may have gaps (for example if a draft payment is deleted or two "
+"payments are posted concurrently).\n"
+"* No gap: guarantees a strictly consecutive numbering, because a number is "
+"only assigned once the previous one has been assigned. Use it when the legal/"
+"fiscal numbering must not skip values. It is slower than the standard "
+"implementation: to keep numbers consecutive it locks the sequence on every "
+"assignment, so concurrent payments are serialized and have to wait for each "
+"other, which can cause noticeable delays when posting many payments at once."
+msgstr ""
+"Define cómo la secuencia asigna los números:\n"
+"* Estándar: los números se obtienen de una secuencia de PostgreSQL. Es "
+"rápido, pero la numeración puede tener huecos (por ejemplo, si se elimina un "
+"pago en borrador o se confirman dos pagos de forma concurrente).\n"
+"* Sin hueco: garantiza una numeración estrictamente consecutiva, porque un "
+"número solo se asigna una vez que se asignó el anterior. Úsela cuando la "
+"numeración legal/fiscal no deba saltear valores. Es más lenta que la "
+"implementación estándar: para mantener los números consecutivos bloquea la "
+"secuencia en cada asignación, por lo que los pagos concurrentes se serializan "
+"y deben esperarse entre sí, lo que puede provocar demoras notables al "
+"confirmar muchos pagos a la vez."
+
+#. module: account_payment_pro_receiptbook
 #: model:ir.model.fields,field_description:account_payment_pro_receiptbook.field_account_chart_template__display_name
 #: model:ir.model.fields,field_description:account_payment_pro_receiptbook.field_account_journal__display_name
 #: model:ir.model.fields,field_description:account_payment_pro_receiptbook.field_account_move__display_name
@@ -187,6 +213,11 @@ msgid ""
 msgstr ""
 "Si se configura, se enviará un correo electrónico al cliente cuando se haya "
 "publicado la cuenta, pago o  grupo relacionado."
+
+#. module: account_payment_pro_receiptbook
+#: model:ir.model.fields,field_description:account_payment_pro_receiptbook.field_account_payment_receiptbook__implementation
+msgid "Implementation"
+msgstr "Implementación"
 
 #. module: account_payment_pro_receiptbook
 #: model:ir.model.fields,field_description:account_payment_pro_receiptbook.field_l10n_latam_document_type__internal_type

--- a/account_payment_pro_receiptbook/models/account_payment_receiptbook.py
+++ b/account_payment_pro_receiptbook/models/account_payment_receiptbook.py
@@ -45,6 +45,19 @@ class AccountPaymentReceiptbook(models.Model):
         related="sequence_id.number_next_actual",
         readonly=False,
     )
+    implementation = fields.Selection(
+        related="sequence_id.implementation",
+        readonly=False,
+        help="Defines how the sequence assigns numbers:\n"
+        "* Standard: numbers are drawn from a PostgreSQL sequence. It is fast, but the numbering "
+        "may have gaps (for example if a draft payment is deleted or two payments are posted "
+        "concurrently).\n"
+        "* No gap: guarantees a strictly consecutive numbering, because a number is only assigned "
+        "once the previous one has been assigned. Use it when the legal/fiscal numbering must not "
+        "skip values. It is slower than the standard implementation: to keep numbers consecutive it "
+        "locks the sequence on every assignment, so concurrent payments are serialized and have to "
+        "wait for each other, which can cause noticeable delays when posting many payments at once.",
+    )
     sequence_id = fields.Many2one(
         "ir.sequence",
         "Entry Sequence",

--- a/account_payment_pro_receiptbook/views/account_payment_receipt_group.xml
+++ b/account_payment_pro_receiptbook/views/account_payment_receipt_group.xml
@@ -54,6 +54,7 @@
                             <field name="prefix"/>
                             <field name="sequence_id"/>
                             <field name="next_number"/>
+                            <field name="implementation"/>
                             <field name="company_id" widget="selection" groups="base.group_multi_company"/>
                         </group>
                     </group>


### PR DESCRIPTION
### Goal

Add the `implementation` field of `ir.sequence` to `account.payment.receiptbook` as a related field, mirroring the existing `next_number` field.

### Changes

- New related field `implementation` (`related="sequence_id.implementation"`, editable) on `account.payment.receiptbook`.
- Field surfaced on the receiptbook form, next to `next_number`.
- Help text on the field explaining the difference between the **Standard** and **No gap** implementations, and why **No gap** can be noticeably slower (it locks the sequence on every assignment to keep numbering consecutive, serializing concurrent payments).
- Translation terms added for the new field label and help (`en`/`es`).

This lets users choose, per receiptbook, whether the entry numbering allows gaps (Standard) or must stay strictly consecutive (No gap), straight from the receiptbook form.