### PR TITLE
[I18N] account_payment_pro, l10n_ar_payment_bundle: restore es translations for receipt report

### DIFF
--- a/account_payment_pro/i18n/es.po
+++ b/account_payment_pro/i18n/es.po
@@ -81,42 +81,42 @@ msgstr "<span>=</span>"
 #. module: account_payment_pro
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.report_payment_receipt_document_pro
 msgid "<span>Amount</span>"
-msgstr ""
+msgstr "<span>Importe</span>"
 
 #. module: account_payment_pro
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.report_payment_receipt_document_pro
 msgid "<span>Exp. Date</span>"
-msgstr ""
+msgstr "<span>Fecha Venc.</span>"
 
 #. module: account_payment_pro
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.report_payment_receipt_document_pro
 msgid "<span>Imputed Amount</span>"
-msgstr ""
+msgstr "<span>Importe Imputado</span>"
 
 #. module: account_payment_pro
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.report_payment_receipt_document_pro
 msgid "<span>Imputed Vouchers</span>"
-msgstr ""
+msgstr "<span>Comprobantes Imputados</span>"
 
 #. module: account_payment_pro
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.report_payment_receipt_document_pro
 msgid "<span>Original Amount</span>"
-msgstr ""
+msgstr "<span>Importe Original</span>"
 
 #. module: account_payment_pro
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.report_payment_receipt_document_pro
 msgid "<span>Payments</span>"
-msgstr ""
+msgstr "<span>Pagos</span>"
 
 #. module: account_payment_pro
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.report_payment_receipt_document_pro
 msgid "<strong><span>Total Imputed</span></strong>"
-msgstr ""
+msgstr "<strong><span>Total Imputado</span></strong>"
 
 #. module: account_payment_pro
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.report_payment_receipt_document_pro
 msgid "<strong><span>Total Paid</span></strong>"
-msgstr ""
+msgstr "<strong><span>Total Pagado</span></strong>"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_write_off_type__account_id
@@ -346,7 +346,7 @@ msgstr "Moneda"
 #. module: account_payment_pro
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.report_payment_receipt_document_pro
 msgid "Customer:"
-msgstr ""
+msgstr "Cliente:"
 
 #. module: account_payment_pro
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.latam_check_view_account_payment_form_inherited
@@ -598,7 +598,7 @@ msgstr "Nada por pagar de los asientos seleccionados"
 #. module: account_payment_pro
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.report_payment_receipt_document_pro
 msgid "On account"
-msgstr ""
+msgstr "A cuenta"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_bank_statement_line__open_move_line_ids
@@ -756,7 +756,7 @@ msgstr ""
 #. module: account_payment_pro
 #: model_terms:ir.ui.view,arch_db:account_payment_pro.report_payment_receipt_document_pro
 msgid "Supplier:"
-msgstr ""
+msgstr "Proveedor:"
 
 #. module: account_payment_pro
 #: model:ir.model.fields,field_description:account_payment_pro.field_account_payment_invoice_wizard__tax_ids

--- a/l10n_ar_payment_bundle/i18n/es.po
+++ b/l10n_ar_payment_bundle/i18n/es.po
@@ -265,7 +265,7 @@ msgstr "Métodos de Pago"
 #. module: l10n_ar_payment_bundle
 #: model:ir.actions.report,name:l10n_ar_payment_bundle.action_report_receipt_bundle
 msgid "Payment Receipt bundled"
-msgstr ""
+msgstr "Recibo de Pago agrupado"
 
 #. module: l10n_ar_payment_bundle
 #: model:ir.model,name:l10n_ar_payment_bundle.model_payment_rename_wizard


### PR DESCRIPTION
## Summary

The split-receipt-report refactor (merged via PR #1088) moved the payment receipt template content from `l10n_ar_tax` to `account_payment_pro`. As a result, the Spanish translations for the receipt report strings were lost: they existed in `l10n_ar_tax/i18n/es.po` but ended up with empty `msgstr` in `account_payment_pro/i18n/es.po`.

- `account_payment_pro/i18n/es.po`: fill in 11 empty translations for table headers and labels that moved from `l10n_ar_tax` (Imputed Vouchers, Exp. Date, Original Amount, Imputed Amount, Total Paid, Total Imputed, Payments, Amount, Customer, Supplier, On account)
- `l10n_ar_payment_bundle/i18n/es.po`: fill in `Payment Receipt bundled` → `Recibo de Pago agrupado` (moved from `l10n_ar_tax`)

## Test plan

- [ ] Print customer payment receipt — verify all table headers appear in Spanish
- [ ] Print supplier payment with withholdings — verify "Total Pagado", "Comprobantes Imputados", "Total Imputado" appear correctly
- [ ] Print from list using "Payment Receipt bundled" — verify action name shows "Recibo de Pago agrupado"