### PR TITLE
[FIX] account_payment_pro: filter empty currency_id in _onchange_amount_update_exact

### DIFF
--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -395,7 +395,7 @@ class AccountPayment(models.Model):
 
     @api.onchange("amount")
     def _onchange_amount_update_exact(self):
-        for rec in self:
+        for rec in self.filtered("currency_id"):
             if not rec.currency_id.is_zero(rec.amount - rec.amount_exact):
                 rec.amount_exact = rec.amount
 


### PR DESCRIPTION
## Summary

When a user without full permissions opens the payment wizard from an invoice, the `currency_id` field arrives as an empty recordset in the onchange context. Calling `.is_zero()` on it triggers `ensure_one()` → `ValueError: Expected singleton: res.currency()`.

Fix: use `self.filtered("currency_id")` to skip records with no currency before entering the loop, consistent with how `_compute_amount` already handles this case.

## Changes

- `account_payment_pro/models/account_payment.py`: `_onchange_amount_update_exact` — iterate over `self.filtered("currency_id")` instead of `self`.

## Test plan

- Open an invoice and click "Register Payment" with a user that has restricted permissions.
- Verify the payment wizard opens without RPC error.
- Change the amount and confirm the `amount_exact` field updates correctly.