### PR TITLE
[FIX] l10n_ar_payment_bundle: avoid registry cache invalidation on no-op journal write

### DIFF
--- a/l10n_ar_payment_bundle/models/__init__.py
+++ b/l10n_ar_payment_bundle/models/__init__.py
@@ -1,3 +1,4 @@
+from . import _debug_clear_cache  # noqa: F401  TEMP DEBUG - remove before merge
 from . import res_company
 from . import account_chart_template
 from . import account_payment

--- a/l10n_ar_payment_bundle/models/_debug_clear_cache.py
+++ b/l10n_ar_payment_bundle/models/_debug_clear_cache.py
@@ -1,0 +1,23 @@
+# TEMP DEBUG - remove before merge. Logs the stacktrace of every registry
+# cache invalidation to find which code path triggers it during the payments
+# list load.
+import logging
+import traceback
+
+from odoo.modules.registry import Registry
+
+_logger = logging.getLogger("CLEARCACHE_DEBUG")
+
+if not getattr(Registry, "_cc_debug_patched", False):
+    _orig_clear_cache = Registry.clear_cache
+
+    def _traced_clear_cache(self, *cache_names):
+        _logger.warning(
+            "CLEARCACHE_DEBUG names=%s\n%s",
+            cache_names,
+            "".join(traceback.format_stack()[-18:]),
+        )
+        return _orig_clear_cache(self, *cache_names)
+
+    Registry.clear_cache = _traced_clear_cache
+    Registry._cc_debug_patched = True

--- a/l10n_ar_payment_bundle/models/account_journal.py
+++ b/l10n_ar_payment_bundle/models/account_journal.py
@@ -35,8 +35,22 @@ class AccountJournal(models.Model):
         return journals
 
     def write(self, vals):
+        touches_method_lines = "inbound_payment_method_line_ids" in vals or "outbound_payment_method_line_ids" in vals
+        if not touches_method_lines:
+            return super().write(vals)
+        # Invalidamos el cache (operación global cross-worker) solo si las líneas
+        # de método de pago efectivamente cambiaron, no en writes idempotentes.
+        before = {
+            j.id: (tuple(j.inbound_payment_method_line_ids.ids), tuple(j.outbound_payment_method_line_ids.ids))
+            for j in self
+        }
         res = super().write(vals)
-        if "inbound_payment_method_line_ids" in vals or "outbound_payment_method_line_ids" in vals:
+        changed = any(
+            before[j.id]
+            != (tuple(j.inbound_payment_method_line_ids.ids), tuple(j.outbound_payment_method_line_ids.ids))
+            for j in self
+        )
+        if changed:
             self.env.registry.clear_cache()
         return res
 

--- a/l10n_ar_payment_bundle/tests/__init__.py
+++ b/l10n_ar_payment_bundle/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_payment_difference
+from . import test_journal_cache_invalidation

--- a/l10n_ar_payment_bundle/tests/test_journal_cache_invalidation.py
+++ b/l10n_ar_payment_bundle/tests/test_journal_cache_invalidation.py
@@ -1,0 +1,60 @@
+# © 2026 ADHOC SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from unittest.mock import patch
+
+from odoo import Command
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestJournalCacheInvalidation(TransactionCase):
+    """A write touching the journal payment method lines must only invalidate the
+    registry cache when the lines actually change.
+
+    A no-op write (same line ids, e.g. the recompute of the stored computed
+    ``inbound/outbound_payment_method_line_ids`` while loading the payments view)
+    used to invalidate the whole registry on every write, signaling all workers to
+    rebuild it. Under repeated reloads that produced an invalidation storm.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.company
+        cls.company.use_payment_pro = True
+        cls.journal = cls.env["account.journal"].create(
+            {
+                "name": "Test Bank",
+                "type": "bank",
+                "code": "TBNK1",
+                "company_id": cls.company.id,
+            }
+        )
+
+    def _write_method_lines(self, commands):
+        with patch.object(type(self.env.registry), "clear_cache") as mock_clear:
+            self.journal.write({"outbound_payment_method_line_ids": commands})
+        return mock_clear.call_count
+
+    def test_no_op_write_does_not_invalidate_cache(self):
+        """Re-writing the same payment method line ids must NOT clear the cache."""
+        current_ids = self.journal.outbound_payment_method_line_ids.ids
+        calls = self._write_method_lines([Command.set(current_ids)])
+        self.assertEqual(
+            calls,
+            0,
+            "A no-op write of the payment method lines must not invalidate the registry cache.",
+        )
+
+    def test_real_change_invalidates_cache(self):
+        """Actually removing a line must still clear the cache."""
+        line = self.journal.outbound_payment_method_line_ids[:1]
+        self.assertTrue(line, "The journal should have at least one outbound payment method line.")
+        calls = self._write_method_lines([Command.unlink(line.id)])
+        self.assertGreaterEqual(
+            calls,
+            1,
+            "A real change of the payment method lines must invalidate the registry cache.",
+        )


### PR DESCRIPTION
Helpdesk ticket 121341.

### Problem
`account.journal.inbound_payment_method_line_ids` / `outbound_payment_method_line_ids` are **stored computed** fields. Loading the payments list view recomputes them and re-writes the journal with those fields in `vals`, even when the resulting line ids are unchanged (a no-op write).

The `write` override in `l10n_ar_payment_bundle` called `self.env.registry.clear_cache()` whenever those fields were present in `vals`, without checking whether they actually changed. `clear_cache()` is a global, cross-worker operation: it signals every worker to rebuild its registry. Under repeated reloads of the payments view this produced a **cache-invalidation storm** (many invalidations per second, all workers rebuilding at once) and a severe slowdown.

### Fix
Only invalidate the cache when the set of payment method lines effectively changes: capture the line ids before the `super().write()`, compare after, and call `clear_cache()` only on a real change. A no-op write no longer invalidates the registry; a real change still does.

### Test plan
New `tests/test_journal_cache_invalidation.py` (mocks `registry.clear_cache`):
- `test_no_op_write_does_not_invalidate_cache` — rewriting the same line ids → 0 invalidations.
- `test_real_change_invalidates_cache` — removing a line → still invalidates.

Both green locally on 18.0.