### PR TITLE
[REF] account_payment_pro_receiptbook: scope made_sequence_gap to receiptbook

### DIFF
--- a/account_payment_pro_receiptbook/__manifest__.py
+++ b/account_payment_pro_receiptbook/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Account Payment receiptbook",
-    "version": "19.0.2.3.0",
+    "version": "19.0.2.4.0",
     "category": "Payment",
     "website": "www.adhoc.com.ar",
     "author": "ADHOC SA",

--- a/account_payment_pro_receiptbook/migrations/19.0.2.4.0/post-migration.py
+++ b/account_payment_pro_receiptbook/migrations/19.0.2.4.0/post-migration.py
@@ -1,0 +1,36 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+"""
+Migración 19.0.2.4.0 — Recomputar ``made_sequence_gap`` de los asientos de
+talonario de recibo según la nueva lógica de ``_update_sequence_made_gap``.
+
+Hasta la versión previa el flag de los asientos de receiptbook quedaba en
+``False`` de forma incondicional (o lo fijaba la lógica journal-based del core,
+que daba falsos positivos). Ahora la detección de huecos se hace acotada al
+receiptbook + prefijo, así que los valores guardados pueden estar desactualizados.
+
+Barremos *todos* los asientos con ``receiptbook_id`` (sin filtro de fecha: la
+condición es exacta y una ventana temporal solo dejaría asientos viejos mal
+marcados) y reaplicamos la detección. Idempotente.
+"""
+
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    _logger.info("Running post-migration %s: recompute made_sequence_gap on receiptbook moves", version)
+
+    env = api.Environment(cr, SUPERUSER_ID, {})
+
+    moves = env["account.move"].with_context(active_test=False).search([("receiptbook_id", "!=", False)])
+    _logger.info("Recomputando made_sequence_gap en %d asientos de receiptbook", len(moves))
+
+    if moves:
+        moves._update_receiptbook_made_sequence_gap()
+        env.flush_all()

--- a/account_payment_pro_receiptbook/models/account_move.py
+++ b/account_payment_pro_receiptbook/models/account_move.py
@@ -30,11 +30,6 @@ class AccountMove(models.Model):
             domain += [("receiptbook_id", "=", False)]
         return super()._search(domain, *args, **kwargs)
 
-    def _compute_made_sequence_hole(self):
-        receiptbook_recs = self.filtered(lambda x: x.receiptbook_id and x.journal_id.type in ("bank", "cash", "credit"))
-        receiptbook_recs.made_sequence_hole = False
-        super(AccountMove, self - receiptbook_recs)._compute_made_sequence_hole()
-
     @api.depends()
     def _compute_name(self):
         super()._compute_name()
@@ -55,43 +50,6 @@ class AccountMove(models.Model):
         receiptbook_payments = self.filtered(lambda x: x.origin_payment_id.receiptbook_id)
         super(AccountMove, self - receiptbook_payments)._compute_l10n_latam_document_type()
 
-    @api.depends()
-    def _compute_made_sequence_gap(self):
-        with_receiptbook = self.filtered(lambda move: move.receiptbook_id)
-        unposted_recceiptbook = with_receiptbook.filtered(
-            lambda move: move.sequence_number != 0 and move.state != "posted"
-        )
-        unposted_recceiptbook.made_sequence_gap = True
-
-        for (receiptbook, prefix), moves in (
-            (with_receiptbook - unposted_recceiptbook).grouped(lambda m: (m.receiptbook_id, m.sequence_prefix)).items()
-        ):
-            previous_numbers = set(
-                self.env["account.move"]
-                .sudo()
-                .search(
-                    [
-                        ("receiptbook_id", "=", receiptbook.id),
-                        ("sequence_prefix", "=", prefix),
-                        (
-                            "sequence_number",
-                            ">=",
-                            min(moves.mapped("sequence_number")) - 1,
-                        ),
-                        (
-                            "sequence_number",
-                            "<=",
-                            max(moves.mapped("sequence_number")) - 1,
-                        ),
-                    ]
-                )
-                .mapped("sequence_number")
-            )
-            for move in moves:
-                move.made_sequence_gap = move.sequence_number > 1 and (move.sequence_number - 1) not in previous_numbers
-
-        super(AccountMove, self - with_receiptbook)._compute_made_sequence_gap()
-
     def _must_check_constrains_date_sequence(self):
         # OVERRIDES sequence.mixin to skip date sequence check for receiptbook moves
         self.ensure_one()
@@ -100,7 +58,55 @@ class AccountMove(models.Model):
         return super()._must_check_constrains_date_sequence()
 
     def _update_sequence_made_gap(self, invalidate_current=False):
+        # OVERRIDE: en el core ``made_sequence_gap`` ya no es computado; se fija
+        # imperativamente acá agrupando por journal + prefijo. Los asientos de
+        # talonario se numeran por receiptbook (cada uno con su ``ir.sequence``),
+        # así que esa lógica journal-based da falsos positivos. Acotamos la
+        # detección de huecos al receiptbook + prefijo.
         receiptbook_moves = self.filtered(lambda m: m.receiptbook_id)
-        receiptbook_moves.made_sequence_gap = False
+        if receiptbook_moves:
+            receiptbook_moves._update_receiptbook_made_sequence_gap()
         if other_moves := self - receiptbook_moves:
             super(AccountMove, other_moves)._update_sequence_made_gap(invalidate_current=invalidate_current)
+
+    def _update_receiptbook_made_sequence_gap(self):
+        """Fija ``made_sequence_gap`` según la continuidad dentro del propio
+        receiptbook + prefijo (no del journal).
+
+        Un asiento posteado hace hueco cuando falta el número inmediatamente
+        anterior en el mismo receiptbook. Los no posteados que ya tomaron número
+        se marcan siempre. Además de ``self`` se re-evalúa el asiento siguiente
+        de cada uno, porque agregar/quitar un asiento cambia si el que sigue es
+        o no un hueco.
+        """
+        records = self.sudo()
+        AccountMove = records.env["account.move"]
+
+        moves_to_check = records
+        for (receiptbook, prefix), moves in records.grouped(lambda m: (m.receiptbook_id, m.sequence_prefix)).items():
+            moves_to_check |= AccountMove.search(
+                [
+                    ("receiptbook_id", "=", receiptbook.id),
+                    ("sequence_prefix", "=", prefix),
+                    ("sequence_number", "in", [n + 1 for n in moves.mapped("sequence_number")]),
+                ]
+            )
+
+        unposted = moves_to_check.filtered(lambda m: m.sequence_number != 0 and m.state != "posted")
+        unposted.made_sequence_gap = True
+
+        for (receiptbook, prefix), moves in (
+            (moves_to_check - unposted).grouped(lambda m: (m.receiptbook_id, m.sequence_prefix)).items()
+        ):
+            existing_numbers = set(
+                AccountMove.search(
+                    [
+                        ("receiptbook_id", "=", receiptbook.id),
+                        ("sequence_prefix", "=", prefix),
+                        ("sequence_number", ">=", min(moves.mapped("sequence_number")) - 1),
+                        ("sequence_number", "<=", max(moves.mapped("sequence_number")) - 1),
+                    ]
+                ).mapped("sequence_number")
+            )
+            for move in moves:
+                move.made_sequence_gap = move.sequence_number > 1 and (move.sequence_number - 1) not in existing_numbers


### PR DESCRIPTION
## Summary

Receiptbook moves are numbered per receiptbook (each receiptbook has its own `ir.sequence`), so the standard journal-based `made_sequence_gap` detection produces false positives for them. This PR scopes the gap detection to each `receiptbook_id` + `sequence_prefix` instead of the journal.

## Context

In current core, `made_sequence_gap` is no longer a computed field — it is set imperatively by `_update_sequence_made_gap` (called on post/cancel/resequence/unlink). The module still carried two dead overrides:

- `_compute_made_sequence_gap` — core's method is `@api.deprecated` and is never invoked anymore.
- `_compute_made_sequence_hole` — references `made_sequence_hole`, a field that no longer exists in core.

\#1105 added a `_update_sequence_made_gap` override that unconditionally set `made_sequence_gap = False` for receiptbook moves. That removed the false positives but also suppressed *real* gaps within a receiptbook's own numbering. This PR moves the actual per-receiptbook detection into the live hook.

## Changes

- `models/account_move.py`:
  - `_update_sequence_made_gap`: delegate receiptbook moves to a new `_update_receiptbook_made_sequence_gap`, which detects gaps within `receiptbook_id` + `sequence_prefix` (not the journal) and re-evaluates the next sibling of each affected move. Non-receiptbook moves keep the standard core behavior.
  - Remove the dead `_compute_made_sequence_gap` and `_compute_made_sequence_hole`.
- `migrations/19.0.2.4.0/post-migration.py`: recompute `made_sequence_gap` on all existing receiptbook moves with the new logic.
- Manifest bump `19.0.2.3.0` → `19.0.2.4.0`.

## Test plan

- [ ] Create payments with a receiptbook and post them in order → no red flag.
- [ ] Post entries so a number is missing within the same receiptbook → the move after the missing number shows red.
- [ ] Non-receiptbook journal entries still show red on a real sequence gap.
- [ ] Resequence journal entries → receiptbook moves are not flagged unless there is a real gap in their own numbering.
- [ ] Upgrade an existing DB → stale flags on receiptbook moves are corrected by the migration.

Replaces the approach in #1105.
