### PR TITLE
[IMP] account_payment_pro: add setting to show full reference on imputed vouchers

### DIFF
--- a/account_payment_pro/i18n/es.po
+++ b/account_payment_pro/i18n/es.po
@@ -946,6 +946,25 @@ msgstr ""
 msgid "account.write_off.type"
 msgstr "Tipo de Write Off"
 
+#. module: account_payment_pro
+#: model:ir.model.fields,help:account_payment_pro.field_res_company__payment_receipt_full_ref
+#: model:ir.model.fields,help:account_payment_pro.field_res_config_settings__payment_receipt_full_ref
+#: model_terms:ir.ui.view,arch_db:account_payment_pro.res_config_settings_view_form
+msgid ""
+"On the payment receipt / payment order report, show the full reference of "
+"the imputed vouchers instead of the shortened version that cuts long "
+"references with '[...]'."
+msgstr ""
+"En el informe de recibo de pago / orden de pago, muestra la referencia "
+"completa de los comprobantes imputados en lugar de la versión acortada que "
+"recorta las referencias largas con '[...]'."
+
+#. module: account_payment_pro
+#: model:ir.model.fields,field_description:account_payment_pro.field_res_company__payment_receipt_full_ref
+#: model:ir.model.fields,field_description:account_payment_pro.field_res_config_settings__payment_receipt_full_ref
+msgid "Show full reference on imputed vouchers"
+msgstr "Mostrar la referencia completa en los comprobantes imputados"
+
 #~ msgid "Customer Bank Account"
 #~ msgstr "Cuenta Bancaria"
 

--- a/account_payment_pro/models/account_move.py
+++ b/account_payment_pro/models/account_move.py
@@ -24,10 +24,25 @@ class AccountMove(models.Model):
     def _compute_open_move_lines(self):
         for rec in self:
             rec.open_move_line_ids = rec.line_ids.filtered(
-                lambda r: not r.reconciled
-                and r.parent_state == "posted"
-                and r.account_id.account_type in self.env["account.payment"]._get_valid_payment_account_types()
+                lambda r: (
+                    not r.reconciled
+                    and r.parent_state == "posted"
+                    and r.account_id.account_type in self.env["account.payment"]._get_valid_payment_account_types()
+                )
             )
+
+    def _get_payment_receipt_voucher_name(self):
+        """Name for the 'imputed vouchers' column of our payment receipt format.
+
+        Our format prints ``move_id.display_name``, which embeds the reference shortened to
+        ~50 chars and cut with ``[...]``. When the company enables ``payment_receipt_full_ref`` we
+        print the full reference instead.
+        """
+        self.ensure_one()
+        if not self.company_id.payment_receipt_full_ref:
+            return self.display_name
+        name = self._get_move_display_name(show_ref=False)
+        return name + (f" ({self.ref})" if self.ref else "")
 
     # Map explícito move_type → (payment_type, partner_type).
     # Se usa en pay_now() para setear el payment_type correcto desde el create,
@@ -43,10 +58,12 @@ class AccountMove(models.Model):
 
     def pay_now(self):
         for rec in self.filtered(
-            lambda x: x.pay_now_journal_id
-            and x.state == "posted"
-            and x.payment_state in ("not_paid", "partial")
-            and x.move_type in self._PAY_NOW_TYPE_MAP
+            lambda x: (
+                x.pay_now_journal_id
+                and x.state == "posted"
+                and x.payment_state in ("not_paid", "partial")
+                and x.move_type in self._PAY_NOW_TYPE_MAP
+            )
         ):
             pay_journal = rec.pay_now_journal_id
             payment_type, partner_type = self._PAY_NOW_TYPE_MAP[rec.move_type]

--- a/account_payment_pro/models/res_company.py
+++ b/account_payment_pro/models/res_company.py
@@ -6,6 +6,12 @@ class ResCompany(models.Model):
 
     use_payment_pro = fields.Boolean(compute="_compute_use_payment_pro", store=True, readonly=False)
 
+    payment_receipt_full_ref = fields.Boolean(
+        "Show full reference on imputed vouchers",
+        help="On the payment receipt / payment order report, show the full reference of the imputed "
+        "vouchers instead of the shortened version that cuts long references with '[...]'.",
+    )
+
     @api.depends("partner_id.country_id")
     def _compute_use_payment_pro(self):
         ar_companies = self.filtered(lambda x: x.partner_id.country_id.code == "AR")

--- a/account_payment_pro/models/res_config_setting.py
+++ b/account_payment_pro/models/res_config_setting.py
@@ -9,6 +9,11 @@ class ResConfigSettings(models.TransientModel):
         readonly=False,
     )
 
+    payment_receipt_full_ref = fields.Boolean(
+        related="company_id.payment_receipt_full_ref",
+        readonly=False,
+    )
+
     group_pay_now_customer_invoices = fields.Boolean(
         "Allow pay now on customer invoices?",
         implied_group="account_payment_pro.group_pay_now_customer_invoices",

--- a/account_payment_pro/views/report_payment_receipt_template.xml
+++ b/account_payment_pro/views/report_payment_receipt_template.xml
@@ -148,7 +148,7 @@
                 <table class="table table-sm o_main_table" name="matching_table">
                     <thead>
                         <tr>
-                            <th><span>Imputed Vouchers</span></th>
+                            <th style="width: 50%;"><span>Imputed Vouchers</span></th>
                             <th class="text-center"><span>Exp. Date</span></th>
                             <th class="text-right"><span>Original Amount</span></th>
                             <th class="text-right"><span>Imputed Amount</span></th>
@@ -157,7 +157,7 @@
                     <tbody>
                         <t t-foreach="matched_lines" t-as="line">
                             <tr>
-                                <td><span t-field='line.move_id.display_name'/></td>
+                                <td style="word-break: break-all;"><span t-out='line.move_id._get_payment_receipt_voucher_name()'/></td>
                                 <td class="text-center">
                                     <span class="text-nowrap" t-field="line.date_maturity"/>
                                 </td>

--- a/account_payment_pro/views/res_company_setting.xml
+++ b/account_payment_pro/views/res_company_setting.xml
@@ -14,6 +14,11 @@
                         y sugerencias de diferencia de cambio">
                         <field name="use_payment_pro"/>
                     </setting>
+                    <setting id="payment_receipt_full_ref" string="Show full reference on imputed vouchers"
+                        company_dependent="1"
+                        help="On the payment receipt / payment order report, show the full reference of the imputed vouchers instead of the shortened version that cuts long references with '[...]'.">
+                        <field name="payment_receipt_full_ref"/>
+                    </setting>
                 </setting>
                   <!-- supplier payments section -->
                 <xpath expr="//block[@id='print_vendor_checks_setting_container']" position="inside">


### PR DESCRIPTION
The payment receipt / payment order report printed the imputed vouchers using move_id.display_name, which shortens the reference to ~50 chars with '[...]'. Add a company setting (payment_receipt_full_ref) to print the full reference instead, and wrap long references in the report cell.

Task 54883