### PR TITLE
[FIX] account_payment_pro: avoid N+1 in _compute_matched_move_line_ids

### DIFF
--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -555,10 +555,14 @@ class AccountPayment(models.Model):
         conciliacion de deuda de un asiento normal no lo muestra)
         """
         stored_payments = self.filtered("id")
+        # _get_valid_payment_account_types() does not depend on the filtered
+        # line, so we compute it once instead of on every line. Otherwise it
+        # triggers an N+1: account_balance_import overrides it to call
+        # company.get_unaffected_earnings_account(), which runs an uncached
+        # search on account.account once per evaluated line.
+        valid_payment_account_types = self._get_valid_payment_account_types()
         for rec in stored_payments:
-            payment_lines = rec.move_id.line_ids.filtered(
-                lambda x: x.account_type in self._get_valid_payment_account_types()
-            )
+            payment_lines = rec.move_id.line_ids.filtered(lambda x: x.account_type in valid_payment_account_types)
             debit_moves = payment_lines.mapped("matched_debit_ids.debit_move_id")
             credit_moves = payment_lines.mapped("matched_credit_ids.credit_move_id")
             debit_lines_sorted = debit_moves.filtered(lambda x: x.date_maturity != False).sorted(


### PR DESCRIPTION
## Qué hace (resumen para PO / funcional)

Al armar el **recibo de pago**, el cálculo de los "comprobantes
imputados" repetía una misma consulta a la base **una vez por cada
línea** del pago. En pagos con muchas líneas conciliadas eso disparaba
decenas de consultas innecesarias y hacía lento el armado del recibo.

Este cambio calcula ese dato **una sola vez** en lugar de por línea. El
recibo muestra **exactamente lo mismo que antes** — es una mejora de
performance, no un cambio funcional.

**Qué verificar (PO):** que el recibo / OP siga listando los **mismos
"Comprobantes imputados"** que antes. Caso sensible a mirar: pagos con
**cheque nuevo** (es el único donde el cálculo suma un tipo de cuenta
extra). Equivalente técnico: `payment.matched_move_line_ids` debe dar
igual antes y después.

## Detalle técnico (devs)

`_compute_matched_move_line_ids` filtraba las líneas con
`lambda x: x.account_type in self._get_valid_payment_account_types()`.
`_get_valid_payment_account_types()` no depende de la línea filtrada,
pero se evaluaba una vez por línea. Con `account_balance_import`
instalado, ese método llama a `company.get_unaffected_earnings_account()`,
que hace un `search` sin cache sobre `account.account` → un search por
línea (N+1) que dominaba el costo de renderizar el recibo
(`account.report_payment_receipt`).

Fix: subir la llamada fuera del `.filtered()` para que corra una vez por
recordset. Mismo `self`, mismo resultado, sin la repetición.

## Cómo se validó

Renderizando el recibo (solo HTML, cache ORM caliente) sobre un set de
pagos representativos y contando queries SQL por render:

| recibo | queries antes → después | lecturas a `account.account` |
|---|---|---|
| recibo de cliente (pesado) | 128 → 56 (−56%) | 81 → 9 |
| recibo de cliente | 116 → 60 | 64 → 8 |
| **total muestra** | **467 → 263 (−44%)** | **234 → 30 (−87%)** |

El residual de lecturas a `account.account` viene de
`get_unaffected_earnings_account()` (sin cache en core), que podría ser
un follow-up. Pagos sin cheque nuevo no son afectados por el override.

Emparejado con ingadhoc/odoo-argentina#1485 (cache del recibo de
proveedor); mismo nombre de branch para un único build de runbot.