### PR TITLE
[FIX] account_payment_pro: post draft card moves before reconcile

### DIFF
--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -768,7 +768,15 @@ class AccountPayment(models.Model):
                 )
 
     def _reconcile_after_post(self):
-        for rec in self.filtered(lambda x: x.company_id.use_payment_pro and not x.is_internal_transfer):
+        to_reconcile = self.filtered(lambda x: x.company_id.use_payment_pro and not x.is_internal_transfer)
+        # El pago con tarjeta de crédito llega a 'paid' con el asiento en borrador (el core no lo
+        # postea) y _reconcile_after_post exige posteados. Posteamos ese asiento antes de conciliar.
+        to_reconcile.filtered(
+            lambda p: p.state == "paid" and p.outstanding_account_id.account_type == "liability_credit_card"
+        ).move_id.filtered(
+            lambda m: m.state == "draft" and m.company_currency_id.is_zero(sum(m.line_ids.mapped("balance")))
+        ).action_post()
+        for rec in to_reconcile:
             counterpart_aml = rec.mapped("move_id.line_ids").filtered(
                 lambda r: not r.reconciled and r.account_id.account_type in self._get_valid_payment_account_types()
             )


### PR DESCRIPTION
En pago masivo con tarjeta + retencion, el asiento del pago queda balanceado pero en borrador y _reconcile_after_post exige asientos posteados, fallando con 'Solo puede conciliar los asientos publicados'. Posteamos solo los asientos de tarjeta (outstanding liability_credit_card) en borrador y ya cuadrados.