### PR TITLE
[FIX] account_payment_pro_receiptbook: defer receipt mail on payment bundles

### DIFF
--- a/account_payment_pro_receiptbook/models/account_payment.py
+++ b/account_payment_pro_receiptbook/models/account_payment.py
@@ -19,8 +19,9 @@ class AccountPayment(models.Model):
     def action_post(self):
         # si no tengo nombre y tengo talonario de recibo, numeramos con el talonario
         for rec in self.filtered(
-            lambda x: x.receiptbook_id
-            and (not x.name or x.name == "/" or (x.move_id and not x.move_id._get_last_sequence()))
+            lambda x: (
+                x.receiptbook_id and (not x.name or x.name == "/" or (x.move_id and not x.move_id._get_last_sequence()))
+            )
         ):
             if not rec.receiptbook_id.active:
                 raise ValidationError(
@@ -45,9 +46,17 @@ class AccountPayment(models.Model):
         for rec in self.filtered(lambda x: x.receiptbook_id):
             rec.move_id.l10n_latam_document_type_id = rec.receiptbook_id.document_type_id.id
 
+        payments_to_send = self
+        # El bundle imputa sus pagos vinculados al final de su action_post, así que acá
+        # el recibo saldría "A cuenta". Diferimos el envío del main: lo dispara el bundle.
+        if "is_main_payment" in self._fields:
+            payments_to_send = payments_to_send.filtered(lambda x: not x.is_main_payment)
+        payments_to_send._send_receiptbook_mail()
+        return res
+
+    def _send_receiptbook_mail(self):
         for rec in self.filtered("receiptbook_id.mail_template_id"):
             rec.message_post_with_source(rec.receiptbook_id.mail_template_id, subtype_xmlid="mail.mt_comment")
-        return res
 
     @api.depends("company_id", "partner_type", "is_internal_transfer")
     def _compute_receiptbook(self):
@@ -72,7 +81,9 @@ class AccountPayment(models.Model):
         super(
             AccountPayment,
             self.filtered(
-                lambda x: (not x.move_id or x.move_id.state != "draft" or not x.receiptbook_id)
-                and not (x.receiptbook_id and x.payment_transaction_id)
+                lambda x: (
+                    (not x.move_id or x.move_id.state != "draft" or not x.receiptbook_id)
+                    and not (x.receiptbook_id and x.payment_transaction_id)
+                )
             ),
         )._compute_name()

--- a/l10n_ar_payment_bundle/models/account_payment.py
+++ b/l10n_ar_payment_bundle/models/account_payment.py
@@ -174,6 +174,10 @@ class AccountPayment(models.Model):
         if draft_linked:
             draft_linked.action_post()
 
+        # Envío diferido del recibo del main: acá los vinculados ya imputaron, así el
+        # PDF sale con los comprobantes y no "A cuenta" (receiptbook lo saltea en el post).
+        self.filtered("is_main_payment")._send_receiptbook_mail()
+
         return res
 
     def action_draft(self):


### PR DESCRIPTION
On "Multiple payments" (bundle) receipts, the main payment posts and
reconciles its linked payments only at the end of its own action_post.
Sending the receipt mail during the main payment's action_post rendered
the PDF with the amount "on account" because the invoices were not yet
reconciled.

Extract the send into _send_receiptbook_mail(), skip it for main bundle
payments in account_payment_pro_receiptbook, and trigger it from
l10n_ar_payment_bundle once the linked payments are posted and reconciled.