### PR TITLE
[IMP] bundle, receiptbook: bp of rename and sync sequence

### DIFF
--- a/account_payment_pro_receiptbook/models/account_payment_receiptbook.py
+++ b/account_payment_pro_receiptbook/models/account_payment_receiptbook.py
@@ -87,7 +87,15 @@ class AccountPaymentReceiptbook(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         recs = super().create(vals_list)
-        for rec in recs.filtered(lambda x: not x.sequence_id):
+        recs.ensure_sequence()
+        return recs
+
+    def ensure_sequence(self):
+        """Crea el ``ir.sequence`` (padding=8, increment=1) para los
+        receiptbooks de ``self`` que no lo tengan asignado. Usa el ``prefix``
+        y ``company_id`` del propio receiptbook. Idempotente.
+        """
+        for rec in self.filtered(lambda x: not x.sequence_id):
             rec.sequence_id = (
                 self.env["ir.sequence"]
                 .sudo()
@@ -101,7 +109,65 @@ class AccountPaymentReceiptbook(models.Model):
                     }
                 )
             )
-        return recs
+
+    def action_resync_sequence(self):
+        """Recompone ``sequence_id`` para los receiptbooks en ``self``:
+
+        - Asegura el ``ir.sequence`` vía :meth:`ensure_sequence` (crea si falta).
+        - Resuelve el último número usado vía un único ``SELECT`` que extrae
+          con regex los dígitos finales del ``name`` de ``account.payment``
+          (``SUBSTRING(name FROM '[0-9]+$')``) y castea ese residuo a
+          ``INTEGER``, devolviendo el ``MAX``.
+        - Setea ``sequence_id.number_next = max(numero) + 1`` para que el
+          próximo payment posteado retome la numeración sin colisiones.
+
+        Se usa como acción manual de reparación si la numeración se desfasa
+        (deletes, importaciones, resecuenciación de recibos, etc.).
+        """
+        self.ensure_sequence()
+        self.env.flush_all()
+        for rec in self:
+            doc_code_prefix = rec.document_type_id.doc_code_prefix or ""
+            prefix = rec.prefix or ""
+            last_number = self._resync_get_last_number(rec, doc_code_prefix, prefix)
+            next_number = last_number + 1
+            rec.sequence_id.sudo().number_next = next_number
+
+            _logger.info(
+                "Receiptbook id=%s prefix=%r: último número=%d, ir.sequence id=%s number_next=%d",
+                rec.id,
+                rec.prefix,
+                last_number,
+                rec.sequence_id.id,
+                next_number,
+            )
+
+    def _resync_get_last_number(self, rec, doc_code_prefix, prefix):
+        has_main_payment = "main_payment_id" in self.env["account.payment"]._fields
+        child_filter = "AND main_payment_id IS NULL" if has_main_payment else ""
+        self.env.cr.execute(
+            f"""
+            SELECT MAX(CAST(
+                SUBSTRING(
+                    SPLIT_PART(REPLACE(REPLACE(name, %s, ''), %s, ''), ' ', 1)
+                    FROM '[0-9]+$')
+                AS INTEGER
+            ))
+              FROM account_payment
+             WHERE receiptbook_id = %s
+               AND name IS NOT NULL
+               AND name LIKE %s
+               {child_filter}
+               AND state != 'draft'
+            """,
+            (
+                doc_code_prefix + " ",
+                prefix,
+                rec.id,
+                f"{doc_code_prefix} {prefix}%",
+            ),
+        )
+        return self.env.cr.fetchone()[0] or 0
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_used(self):

--- a/account_payment_pro_receiptbook/wizard/account_resequence.py
+++ b/account_payment_pro_receiptbook/wizard/account_resequence.py
@@ -43,3 +43,7 @@ class ReSequenceWizard(models.TransientModel):
             self[0].write({"new_values": json.dumps(filtered_moves)})
 
             super().resequence()
+
+        # Después de renumerar moves, los nombres de los account.payment quedan desfasados
+        # respecto a la ir.sequence del receiptbook: resyncronizamos el number_next.
+        original_move_ids.mapped("receiptbook_id").action_resync_sequence()

--- a/l10n_ar_payment_bundle/__init__.py
+++ b/l10n_ar_payment_bundle/__init__.py
@@ -1,4 +1,5 @@
 from . import models  # noqa: F401
+from . import wizard  # noqa: F401
 
 
 def post_init_hook(env):

--- a/l10n_ar_payment_bundle/__manifest__.py
+++ b/l10n_ar_payment_bundle/__manifest__.py
@@ -19,6 +19,8 @@
         "account_payment_pro_receiptbook",
     ],
     "data": [
+        "security/ir.model.access.csv",
+        "views/payment_rename_wizard_view.xml",
         "data/account_payment_method_data.xml",
         "views/account_payment_view.xml",
         "views/report_payment_receipt_templates.xml",

--- a/l10n_ar_payment_bundle/i18n/es.po
+++ b/l10n_ar_payment_bundle/i18n/es.po
@@ -1,10 +1,10 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # 	* l10n_ar_payment_bundle
-# 
+#
 # Translators:
 # Juan José Scarafía <scarafia.juanjose@gmail.com>, 2025
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 18.0+e\n"
@@ -50,6 +50,11 @@ msgid "Bundle Counterpart Currency Amount"
 msgstr ""
 
 #. module: l10n_ar_payment_bundle
+#: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_payment_rename_wizard_form
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: l10n_ar_payment_bundle
 #: model:ir.model,name:l10n_ar_payment_bundle.model_res_company
 msgid "Companies"
 msgstr "Compañías"
@@ -60,9 +65,19 @@ msgid "Counterpart Exchange Rate"
 msgstr "Tasa de Imputación"
 
 #. module: l10n_ar_payment_bundle
+#: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_payment_rename_wizard__current_name
+msgid "Current Name"
+msgstr "Nombre Actual"
+
+#. module: l10n_ar_payment_bundle
 #: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_account_payment__partner_id
 msgid "Customer/Vendor"
 msgstr "Cliente/Proveedor"
+
+#. module: l10n_ar_payment_bundle
+#: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_payment_rename_wizard_form
+msgid "Enter new payment name..."
+msgstr "Ingresar nuevo nombre del pago..."
 
 #. module: l10n_ar_payment_bundle
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_from_bundle_form
@@ -123,6 +138,11 @@ msgid "Multiple payments"
 msgstr ""
 
 #. module: l10n_ar_payment_bundle
+#: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_payment_rename_wizard__new_name
+msgid "New Name"
+msgstr "Nuevo Nombre"
+
+#. module: l10n_ar_payment_bundle
 #. odoo-python
 #: code:addons/l10n_ar_payment_bundle/models/account_payment.py:0
 msgid "Paid Bills"
@@ -135,9 +155,19 @@ msgid "Paid Invoices"
 msgstr ""
 
 #. module: l10n_ar_payment_bundle
+#: model:ir.model.fields,field_description:l10n_ar_payment_bundle.field_payment_rename_wizard__payment_id
+msgid "Payment"
+msgstr "Pago"
+
+#. module: l10n_ar_payment_bundle
 #: model:ir.model,name:l10n_ar_payment_bundle.model_account_payment_method
 msgid "Payment Methods"
 msgstr "Métodos de pago"
+
+#. module: l10n_ar_payment_bundle
+#: model:ir.model,name:l10n_ar_payment_bundle.model_payment_rename_wizard
+msgid "Payment Rename Wizard"
+msgstr "Asistente para Renombrar Pago"
 
 #. module: l10n_ar_payment_bundle
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_form
@@ -151,6 +181,12 @@ msgid "Payment multiple"
 msgstr ""
 
 #. module: l10n_ar_payment_bundle
+#. odoo-python
+#: code:addons/l10n_ar_payment_bundle/wizard/payment_rename.py:0
+msgid "Payment name changed from '%s' to '%s'"
+msgstr "El nombre del pago cambió de '%s' a '%s'"
+
+#. module: l10n_ar_payment_bundle
 #: model:ir.model,name:l10n_ar_payment_bundle.model_account_payment
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_custom_list
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_form
@@ -158,9 +194,32 @@ msgid "Payments"
 msgstr "Pagos"
 
 #. module: l10n_ar_payment_bundle
+#. odoo-python
+#: code:addons/l10n_ar_payment_bundle/wizard/payment_rename.py:0
+msgid "Please enter a new name for the payment."
+msgstr "Por favor ingrese un nuevo nombre para el pago."
+
+#. module: l10n_ar_payment_bundle
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_custom_list
 msgid "Rate"
 msgstr ""
+
+#. module: l10n_ar_payment_bundle
+#: model:ir.model,name:l10n_ar_payment_bundle.model_account_resequence_wizard
+msgid "Remake the sequence of Journal Entries."
+msgstr "Rehaga la secuencia de los asientos contables."
+
+#. module: l10n_ar_payment_bundle
+#: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_form
+#: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_payment_rename_wizard_form
+msgid "Rename"
+msgstr "Renombrar"
+
+#. module: l10n_ar_payment_bundle
+#: model:ir.actions.act_window,name:l10n_ar_payment_bundle.action_payment_rename_wizard
+#: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_payment_rename_wizard_form
+msgid "Rename Payment"
+msgstr "Renombrar Pago"
 
 #. module: l10n_ar_payment_bundle
 #: model_terms:ir.ui.view,arch_db:l10n_ar_payment_bundle.view_account_payment_form
@@ -207,3 +266,13 @@ msgid ""
 "You cannot assign a currency to journals that use the payment bundle payment"
 " method."
 msgstr ""
+
+#. module: l10n_ar_payment_bundle
+#. odoo-python
+#: code:addons/l10n_ar_payment_bundle/wizard/account_resequence.py:0
+msgid ""
+"You cannot resequence moves linked to a bundle payment. Please resequence "
+"the payment instead."
+msgstr ""
+"No puede resecuenciar asientos vinculados a un pago agrupado. En su lugar, "
+"resecuencie el pago."

--- a/l10n_ar_payment_bundle/security/ir.model.access.csv
+++ b/l10n_ar_payment_bundle/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_payment_rename_wizard_user,payment.rename.wizard.user,model_payment_rename_wizard,account.group_account_user,1,1,1,1
+access_payment_rename_wizard_manager,payment.rename.wizard.manager,model_payment_rename_wizard,account.group_account_manager,1,1,1,1

--- a/l10n_ar_payment_bundle/views/account_payment_view.xml
+++ b/l10n_ar_payment_bundle/views/account_payment_view.xml
@@ -112,6 +112,14 @@
             <button name="action_post_and_new" position="attributes">
                 <attribute name="invisible">1</attribute>
             </button>
+            <button name="action_draft" position="after">
+                <button name="%(l10n_ar_payment_bundle.action_payment_rename_wizard)d"
+                        type="action"
+                        string="Rename"
+                        class="btn-secondary"
+                        invisible="not is_main_payment or state not in ['in_process', 'paid']"
+                        groups="base.group_no_one"/>
+            </button>
             <field name="counterpart_currency_id" position="attributes">
                 <attribute name="readonly" separator=" or " add="main_payment_id"/>
             </field>

--- a/l10n_ar_payment_bundle/views/payment_rename_wizard_view.xml
+++ b/l10n_ar_payment_bundle/views/payment_rename_wizard_view.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Wizard form view -->
+    <record id="view_payment_rename_wizard_form" model="ir.ui.view">
+        <field name="name">payment.rename.wizard.form</field>
+        <field name="model">payment.rename.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Rename Payment">
+                <group>
+                    <field name="payment_id" readonly="1"/>
+                    <field name="current_name"/>
+                    <field name="new_name" placeholder="Enter new payment name..."/>
+                </group>
+                <footer>
+                    <button name="action_rename_payment" type="object" string="Rename" class="btn-primary" data-hotkey="q"/>
+                    <button special="cancel" string="Cancel" class="btn-secondary" data-hotkey="x"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <!-- Window action to open the wizard -->
+    <record id="action_payment_rename_wizard" model="ir.actions.act_window">
+        <field name="name">Rename Payment</field>
+        <field name="res_model">payment.rename.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+</odoo>

--- a/l10n_ar_payment_bundle/wizard/__init__.py
+++ b/l10n_ar_payment_bundle/wizard/__init__.py
@@ -1,0 +1,2 @@
+from . import account_resequence
+from . import payment_rename

--- a/l10n_ar_payment_bundle/wizard/account_resequence.py
+++ b/l10n_ar_payment_bundle/wizard/account_resequence.py
@@ -1,0 +1,15 @@
+from odoo import _, api, models
+from odoo.exceptions import UserError
+
+
+class AccountResequenceWizard(models.TransientModel):
+    _inherit = "account.resequence.wizard"
+
+    @api.model
+    def default_get(self, fields):
+        move_ids = self.env["account.move"].browse(self.env.context.get("active_ids", []))
+        if any(move_ids.payment_ids.main_payment_id):
+            raise UserError(
+                _("You cannot resequence moves linked to a bundle payment. Please resequence the payment instead.")
+            )
+        return super().default_get(fields)

--- a/l10n_ar_payment_bundle/wizard/payment_rename.py
+++ b/l10n_ar_payment_bundle/wizard/payment_rename.py
@@ -1,0 +1,74 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class PaymentRenameWizard(models.TransientModel):
+    _name = "payment.rename.wizard"
+    _description = "Payment Rename Wizard"
+
+    payment_id = fields.Many2one(
+        "account.payment",
+        string="Payment",
+        required=True,
+    )
+    new_name = fields.Char(
+        required=True,
+    )
+    current_name = fields.Char(
+        string="Current Name",
+        related="payment_id.name",
+        readonly=True,
+    )
+
+    @api.model
+    def open_rename_wizard(self, payment_ids):
+        """Server action method to open rename wizard"""
+        payment = self.env["account.payment"].browse(payment_ids)
+
+        return {
+            "type": "ir.actions.act_window",
+            "res_model": "payment.rename.wizard",
+            "view_mode": "form",
+            "target": "new",
+            "context": {"default_payment_id": payment.id},
+        }
+
+    @api.model
+    def default_get(self, fields_list):
+        result = super().default_get(fields_list)
+        payment_id = None
+
+        payment_id = self.env.context.get("active_id")
+
+        if payment_id:
+            payment = self.env["account.payment"].browse(payment_id)
+            result["payment_id"] = payment_id
+            result["new_name"] = payment.name
+        return result
+
+    def action_rename_payment(self):
+        """Rename the payment"""
+        if not self.new_name:
+            raise UserError(_("Please enter a new name for the payment."))
+
+        # Update the payment name for main and linked payments
+        old_name = self.payment_id.name
+        self.payment_id.write({"name": self.new_name})
+        for i, payment in enumerate(self.payment_id.link_payment_ids):
+            new_linked_name = f"{self.new_name} ({i + 1})"
+            payment.name = new_linked_name
+            payment.move_id.name = new_linked_name  # Update the move name to keep it in sync with the payment name
+
+        # Log the change in chatter
+        self.payment_id.message_post(
+            body=_("Payment name changed from '%s' to '%s'") % (old_name, self.new_name),
+            message_type="notification",
+        )
+
+        # Resyncronizamos el ir.sequence del receiptbook para reflejar el rename.
+        self.payment_id.receiptbook_id.action_resync_sequence()
+
+        return {
+            "type": "ir.actions.client",
+            "tag": "reload",
+        }


### PR DESCRIPTION
Backport to 18.0 of two improvements already present in 19.0.

## account_payment_pro_receiptbook
- New `action_resync_sequence()` on `account.payment.receiptbook`: recomputes the `number_next` of the receiptbook's `ir.sequence` from the highest numeric suffix of posted payments (single SQL `MAX`, excluding bundle child payments). Backed by `ensure_sequence()` (extracted from `create`).
- The resequence wizard (`account.resequence.wizard`) now calls `action_resync_sequence()` after renumbering the moves, so the receiptbook `number_next` stays in sync with the renumbered names (fixes the numbering gap that appears after a manual resequence).

## l10n_ar_payment_bundle
- New `payment.rename.wizard` + "Rename" button on the payment form (only on main payments in `in_process`/`paid`, group `base.group_no_one`). It renames the main payment, its linked payments and their journal entries, logs the change in the chatter and resyncs the receiptbook sequence.
- Block resequencing journal entries linked to a bundle payment (the payment must be renamed instead).
- Spanish translation.

## Notes
- Faithful port of the 19.0 behavior. Only what this case needs was backported, not the full 19.0 numbering/validation rework.
- Manifest version bump still pending.

Task: 69717