### PR TITLE
[FIX] account_cashbox: restrict payment sessions available to branches

### DIFF
--- a/account_cashbox/models/account_cashbox_session.py
+++ b/account_cashbox/models/account_cashbox_session.py
@@ -55,6 +55,26 @@ class AccountCashboxSession(models.Model):
         "El nombre de esta sesión de caja debe ser único!",
     )
 
+    @api.model
+    def _get_available_domain(self, company):
+        """Dominio de sesiones abiertas operables por el usuario actual desde `company`.
+
+        Desde una sucursal (company.parent_id) solo son elegibles las sesiones de la
+        propia empresa o las de la empresa padre cuyos diarios estén compartidos a
+        sucursales. Reusa el criterio canónico de account.journal._check_company_domain.
+        """
+        domain = [
+            ("state", "=", "opened"),
+            ("company_id", "parent_of", company.id),
+            "|",
+            ("user_ids", "=", self.env.uid),
+            ("user_ids", "=", False),
+        ]
+        if company.parent_id:
+            journal_domain = self.env["account.journal"]._check_company_domain(company)
+            domain += [("cashbox_id.journal_ids", "any", journal_domain)]
+        return domain
+
     @api.depends("cashbox_id")
     def _compute_user_ids(self):
         for rec in self:

--- a/account_cashbox/models/account_payment.py
+++ b/account_cashbox/models/account_payment.py
@@ -20,6 +20,10 @@ class AccountPayment(models.Model):
         compute="_compute_requiere_account_cashbox_session",
         compute_sudo=False,
     )
+    available_cashbox_session_ids = fields.Many2many(
+        "account.cashbox.session",
+        compute="_compute_available_cashbox_session_ids",
+    )
 
     destination_cashbox_session_id = fields.Many2one(
         "account.cashbox.session",
@@ -64,16 +68,15 @@ class AccountPayment(models.Model):
     def _compute_requiere_account_cashbox_session(self):
         self.requiere_account_cashbox_session = self.env.user.requiere_account_cashbox_session
 
+    @api.depends("company_id")
+    def _compute_available_cashbox_session_ids(self):
+        Session = self.env["account.cashbox.session"]
+        for rec in self:
+            rec.available_cashbox_session_ids = Session.search(Session._get_available_domain(rec.company_id))
+
     def _compute_cashbox_session_id(self):
         for rec in self:
-            session_ids = self.env["account.cashbox.session"].search(
-                [
-                    ("state", "=", "opened"),
-                    "|",
-                    ("user_ids", "=", self.env.uid),
-                    ("user_ids", "=", False),
-                ]
-            )
+            session_ids = rec.available_cashbox_session_ids
             if len(session_ids) == 1:
                 rec.cashbox_session_id = session_ids.id
             elif len(session_ids) > 1:

--- a/account_cashbox/views/account_payment.xml
+++ b/account_cashbox/views/account_payment.xml
@@ -9,10 +9,11 @@
         <field name="arch" type="xml">
             <field name="journal_id" position="before">
                 <field name="requiere_account_cashbox_session" invisible="1"/>
+                <field name="available_cashbox_session_ids" invisible="1"/>
                 <!-- filtramos por usuario para que a los admin solo les aparezcan en donde estan involucrados. Total siendo admin se pueden agregar en la que quieran -->
                 <field
                     name="cashbox_session_id"
-                    domain="[('state', '=', 'opened'), ('company_id', 'parent_of', company_id), '|', ('user_ids', '=', uid), ('user_ids', '=', False)]"
+                    domain="[('id', 'in', available_cashbox_session_ids)]"
                     required="requiere_account_cashbox_session and state == 'draft'"
                     readonly = "state != 'draft'"
                     options="{'no_create': True}"/>
@@ -20,7 +21,7 @@
             <field name="destination_journal_id" position="after">
                 <field
                     name="destination_cashbox_session_id"
-                    domain="[('state', '=', 'opened'), ('company_id', 'parent_of', company_id), ('cashbox_id.journal_ids', '=', destination_journal_id), '|', ('user_ids', '=', uid), ('user_ids', '=', False)]"
+                    domain="[('state', '=', 'opened'), ('company_id', 'parent_of', company_id), '|', ('company_id', '=', company_id), ('cashbox_id.journal_ids.shared_to_branches', '=', True), ('cashbox_id.journal_ids', '=', destination_journal_id), '|', ('user_ids', '=', uid), ('user_ids', '=', False)]"
                     required="requiere_account_cashbox_session and state == 'draft' and payment_type == 'transfer'"
                     readonly = "state != 'draft'"
                     invisible = "not is_internal_transfer or not destination_journal_id or (paired_internal_transfer_payment_id and not destination_cashbox_session_id)"

--- a/account_cashbox/wizards/account_payment_register.py
+++ b/account_cashbox/wizards/account_payment_register.py
@@ -21,6 +21,10 @@ class AccountPaymentRegister(models.TransientModel):
         compute="_compute_requiere_account_cashbox_session",
         compute_sudo=False,
     )
+    available_cashbox_session_ids = fields.Many2many(
+        "account.cashbox.session",
+        compute="_compute_available_cashbox_session_ids",
+    )
 
     @api.depends_context("uid")
     # dummy depends para que se compute(no estamos seguros porque solo con el depends_context no computa)
@@ -28,16 +32,15 @@ class AccountPaymentRegister(models.TransientModel):
     def _compute_requiere_account_cashbox_session(self):
         self.requiere_account_cashbox_session = self.env.user.requiere_account_cashbox_session
 
+    @api.depends("company_id")
+    def _compute_available_cashbox_session_ids(self):
+        Session = self.env["account.cashbox.session"]
+        for rec in self:
+            rec.available_cashbox_session_ids = Session.search(Session._get_available_domain(rec.company_id))
+
     def _compute_cashbox_session_id(self):
         for rec in self:
-            session_ids = self.env["account.cashbox.session"].search(
-                [
-                    ("state", "=", "opened"),
-                    "|",
-                    ("user_ids", "=", self.env.uid),
-                    ("user_ids", "=", False),
-                ]
-            )
+            session_ids = rec.available_cashbox_session_ids
             if len(session_ids) == 1:
                 rec.cashbox_session_id = session_ids.id
             else:

--- a/account_cashbox/wizards/account_payment_register.xml
+++ b/account_cashbox/wizards/account_payment_register.xml
@@ -7,10 +7,11 @@
         <field name="arch" type="xml">
             <field name="journal_id" position="before">
                 <field name="requiere_account_cashbox_session" invisible="1"/>
+                <field name="available_cashbox_session_ids" invisible="1"/>
                 <!-- filtramos por usuario para que a los admin solo les aparezcan en donde estan involucrados. Total siendo admin se pueden agregar en la que quieran -->
                 <field
                     name="cashbox_session_id"
-                    domain="[('state', '=', 'opened'), ('company_id', 'parent_of', company_id), '|', ('user_ids', '=', uid), ('user_ids', '=', False)]"
+                    domain="[('id', 'in', available_cashbox_session_ids)]"
                     required="requiere_account_cashbox_session"
                 />
             </field>


### PR DESCRIPTION
Only show cashbox sessions whose journals are shared to branches (shared_to_branches) when operating from a branch company. Reuses the canonical account.journal._check_company_domain criterion via a shared _get_available_domain helper, and exposes available_cashbox_session_ids so the payment form and register wizard filter the selectable sessions by [('id', 'in', available_cashbox_session_ids)].