### PR TITLE
[IMP] l10n_latam_check_ux: remove check menu reassignment to bank_and_cash

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,20 @@ Odoo Invoicing Extension Addons
 <img alt="ADHOC" src="http://fotos.subefotos.com/83fed853c1e15a8023b86b2b22d6145bo.png" />
 **Adhoc SA** - www.adhoc.com.ar
 .
+
+| Descripción | Nombre Técnico | Última Versión |
+|-------------|----------------|----------------|
+| Introduces concept cashbox and accounting journal sessions | account_cashbox | 18.0.1.3.0 |
+| Technical bridge module for account_cashbox and l10n_ar_payment_bundle | account_cashbox_bundle | 18.0.1.1.0 |
+| Add cashbox for check operations | account_cashbox_l10n_latam_check | 18.0.1.0.0 |
+|  | account_payment_financial_surcharge | 18.0.1.1.0 |
+|  | account_payment_loan | 18.0.1.2.0 |
+| Manage multiple payments in Odoo | account_payment_multi | 18.0.1.1.0 |
+|  | account_payment_pro | 18.0.1.15.0 |
+|  | account_payment_pro_receiptbook | 18.0.1.4.0 |
+| Force exchange rate when registering payment on foreign currency invoices | account_payment_register_force_rate | 18.0.1.0.0 |
+|  | account_payment_ux | 18.0.1.0.0 |
+|  | card_installment | 18.0.1.1.0 |
+|  | l10n_ar_payment_bundle | 18.0.1.7.0 |
+|  | l10n_latam_check_ux | 18.0.2.10.0 |
+|  | payment_retry | 18.0.1.2.0 |

--- a/account_payment_register_force_rate/__init__.py
+++ b/account_payment_register_force_rate/__init__.py
@@ -1,0 +1,1 @@
+from . import wizards

--- a/account_payment_register_force_rate/__manifest__.py
+++ b/account_payment_register_force_rate/__manifest__.py
@@ -1,0 +1,22 @@
+{
+    "name": "Account Payment Register - Force Rate",
+    "version": "18.0.1.0.0",
+    "category": "Accounting",
+    "summary": "Force exchange rate when registering payment on foreign currency invoices",
+    "description": """
+When registering a payment from a foreign currency invoice using the standard
+payment register wizard, this module adds an editable exchange rate field
+(amount in company currency) so the user can override the system rate.
+
+Without this module, the wizard uses the automatic rate from res.currency.rate
+and there is no way to change it.
+    """,
+    "author": "BMYA",
+    "license": "AGPL-3",
+    "depends": ["account"],
+    "data": [
+        "views/account_payment_register_views.xml",
+    ],
+    "installable": True,
+    "auto_install": False,
+}

--- a/account_payment_register_force_rate/views/account_payment_register_views.xml
+++ b/account_payment_register_force_rate/views/account_payment_register_views.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_account_payment_register_form" model="ir.ui.view">
+        <field name="name">account.payment.register.form.currency</field>
+        <field name="model">account.payment.register</field>
+        <field name="inherit_id" ref="account.view_account_payment_register_form"/>
+        <field name="arch" type="xml">
+
+            <field name="company_currency_id" position="after">
+                <field name="other_currency" invisible="1"/>
+                <field name="force_amount_company_currency" invisible="1"/>
+            </field>
+
+            <div name="amount_div" position="after">
+                <div class="o_row" name="exchange_rate_div" invisible="not other_currency">
+                    <span><strong>Rate = </strong></span><strong><field name="exchange_rate" nolabel="1"/></strong>
+                </div>
+                <field name="amount_company_currency" nolabel="1" invisible="not other_currency"/>
+            </div>
+
+        </field>
+    </record>
+
+</odoo>

--- a/account_payment_register_force_rate/wizards/__init__.py
+++ b/account_payment_register_force_rate/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import account_payment_register

--- a/account_payment_register_force_rate/wizards/account_payment_register.py
+++ b/account_payment_register_force_rate/wizards/account_payment_register.py
@@ -1,0 +1,84 @@
+from odoo import api, fields, models
+
+
+class AccountPaymentRegister(models.TransientModel):
+    _inherit = "account.payment.register"
+
+    other_currency = fields.Boolean(compute="_compute_other_currency")
+    force_amount_company_currency = fields.Monetary(
+        string="Forced Amount on Company Currency",
+        currency_field="company_currency_id",
+    )
+    amount_company_currency = fields.Monetary(
+        string="Amount on Company Currency",
+        compute="_compute_amount_company_currency",
+        inverse="_inverse_amount_company_currency",
+        currency_field="company_currency_id",
+    )
+    exchange_rate = fields.Float(
+        string="Exchange Rate",
+        compute="_compute_exchange_rate",
+        digits=(16, 6),
+    )
+
+    @api.depends("currency_id", "company_currency_id")
+    def _compute_other_currency(self):
+        for wizard in self:
+            wizard.other_currency = bool(
+                wizard.currency_id
+                and wizard.company_currency_id
+                and wizard.currency_id != wizard.company_currency_id
+            )
+
+    @api.depends("amount", "currency_id", "company_id", "payment_date", "other_currency", "force_amount_company_currency")
+    def _compute_amount_company_currency(self):
+        for wizard in self:
+            if not wizard.other_currency:
+                wizard.amount_company_currency = wizard.amount
+            elif wizard.force_amount_company_currency:
+                wizard.amount_company_currency = wizard.force_amount_company_currency
+            else:
+                wizard.amount_company_currency = wizard.currency_id._convert(
+                    wizard.amount,
+                    wizard.company_currency_id,
+                    wizard.company_id,
+                    wizard.payment_date or fields.Date.context_today(wizard),
+                )
+
+    def _inverse_amount_company_currency(self):
+        for wizard in self:
+            if wizard.other_currency:
+                auto_amount = wizard.currency_id._convert(
+                    wizard.amount,
+                    wizard.company_currency_id,
+                    wizard.company_id,
+                    wizard.payment_date or fields.Date.context_today(wizard),
+                )
+                if wizard.company_currency_id.compare_amounts(
+                    wizard.amount_company_currency, auto_amount
+                ) != 0:
+                    wizard.force_amount_company_currency = wizard.amount_company_currency
+                else:
+                    wizard.force_amount_company_currency = False
+            else:
+                wizard.force_amount_company_currency = False
+
+    @api.depends("amount", "amount_company_currency", "other_currency")
+    def _compute_exchange_rate(self):
+        for wizard in self:
+            if wizard.other_currency and wizard.amount:
+                wizard.exchange_rate = wizard.amount_company_currency / wizard.amount
+            else:
+                wizard.exchange_rate = False
+
+    def _create_payment_vals_from_wizard(self, batch_result):
+        payment_vals = super()._create_payment_vals_from_wizard(batch_result)
+        if self.other_currency and self.force_amount_company_currency:
+            payment_vals["force_balance"] = self.force_amount_company_currency
+        return payment_vals
+
+    def _create_payment_vals_from_batch(self, batch_result):
+        payment_vals = super()._create_payment_vals_from_batch(batch_result)
+        if self.other_currency and self.force_amount_company_currency:
+            payment_vals["force_balance"] = self.force_amount_company_currency
+        return payment_vals

--- a/l10n_latam_check_ux/views/account_payment_view.xml
+++ b/l10n_latam_check_ux/views/account_payment_view.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <record model="ir.ui.menu" id="l10n_latam_check.menu_own_check">
+<!--    <record model="ir.ui.menu" id="l10n_latam_check.menu_own_check">
         <field name="parent_id" ref="account_internal_transfer.menu_finance_bank_and_cash"/>
     </record>
     <record model="ir.ui.menu" id="l10n_latam_check.menu_third_party_check">
         <field name="parent_id" ref="account_internal_transfer.menu_finance_bank_and_cash"/>
-    </record>
+    </record>-->
     <record id="view_account_payment_form_inherited" model="ir.ui.view">
         <field name="name">account.payment.form.inherited.add.context</field>
         <field name="model">account.payment</field>


### PR DESCRIPTION
Comment out check menu reassignment to bank_and_cash parent, consistent with transfer menu relocation.