### PR TITLE
[FIX] account_payment_pro_receiptbook: skip receiptbook resequence logic for non-payment moves

### DIFF
--- a/account_payment_pro_receiptbook/wizard/account_resequence.py
+++ b/account_payment_pro_receiptbook/wizard/account_resequence.py
@@ -8,6 +8,9 @@ class ReSequenceWizard(models.TransientModel):
     _inherit = "account.resequence.wizard"
 
     def resequence(self):
+        # receiptbook logic only applies to payment moves
+        if not self.move_ids.receiptbook_id:
+            return super().resequence()
         if self.ordering == "keep":
             new_names = [v["new_by_name"] for v in json.loads(self[0]["new_values"]).values()]
         else:


### PR DESCRIPTION
## Problem

The `resequence()` override in `account_payment_pro_receiptbook` runs for every resequence, checking name duplicates scoped by `receiptbook_id`. For invoices (which have no receiptbook), that scope resolves to `False`, so the domain matches every non-receipt move sharing the proposed name and raises a misleading `ValidationError` ("The following receipt names already exist") that does not even apply to invoices.

## Fix

Guard the method: if none of the `move_ids` has a `receiptbook_id`, delegate to the standard `super().resequence()`. The receiptbook-specific logic (duplicate check by receiptbook + sequence resync) only applies to moves originated from a payment.

## Test plan

- Resequence a customer invoice (no receiptbook) to a valid target number → no longer raises the spurious "receipt names already exist" error; standard Odoo resequence applies.
- Resequence receipts within the same receiptbook with a genuine name collision → still blocked as before.

Ref: helpdesk ticket #122383.