### PR TITLE
[FIX] l10n_latam_check_ux, account_payment_pro: skip debt autofill on third-party check rejection

### DIFF
--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -140,6 +140,13 @@ class AccountPayment(models.Model):
         readonly=False,
         check_company=True,
     )
+    skip_to_pay_autofill = fields.Boolean(
+        default=False,
+        copy=False,
+        help="Payments created only to register a movement (e.g. third-party check rejection) that "
+        "must not reconcile existing debt. When set, to_pay_move_line_ids is left empty instead of "
+        "auto-filled with the partner's open lines.",
+    )
     matched_move_line_ids = fields.Many2many(
         "account.move.line",
         compute="_compute_matched_move_line_ids",
@@ -1053,7 +1060,7 @@ class AccountPayment(models.Model):
             self.remove_all()
 
     # We dont set 'is_internal_transfer' as a dependencies as it could leed to recompute to_pay_move_line_ids
-    @api.depends("partner_id", "partner_type", "company_id")
+    @api.depends("partner_id", "partner_type", "company_id", "skip_to_pay_autofill")
     def _compute_to_pay_move_lines(self):
         # TODO ?
         # # if payment group is being created from a payment we dont want to compute to_pay_move_lines
@@ -1062,6 +1069,14 @@ class AccountPayment(models.Model):
         # Se recomputan las lienas solo si la deuda que esta seleccionada solo si
         # cambio el partner, compania o partner_type
         records = self.filtered(lambda x: x.state == "draft")
+        # Hay pagos que solo registran un movimiento (ej. rechazo de cheques de terceros) y no
+        # concilian deuda existente. En esos casos el autollenado de la deuda del partner no
+        # corresponde y ademas, con conciliacion en moneda original y deuda multimoneda,
+        # romperia _check_to_pay_lines_currency. La intencion se persiste en skip_to_pay_autofill
+        # (esta en @api.depends) para que el valor almacenado no dependa del contexto.
+        skip = records.filtered("skip_to_pay_autofill")
+        skip.remove_all()
+        records -= skip
         internal_transfers = records.filtered(lambda x: x.is_internal_transfer)
 
         with_payment_pro = self._get_filter_payments(records, ["direct_debit_mandate_id", "pos_session_id"])

--- a/l10n_latam_check_ux/wizards/account_check_reject_wizard.py
+++ b/l10n_latam_check_ux/wizards/account_check_reject_wizard.py
@@ -114,6 +114,18 @@ class AccountCheckRejectWizard(models.TransientModel):
         if operation_dates:
             customer_payment.l10n_latam_move_check_ids_operation_date = max(operation_dates) + timedelta(seconds=3)
 
+    def _rejection_payment_vals(self):
+        """Extra vals common to the payments created to register the check movement.
+
+        account_payment_pro (an optional dependency, not in this module's manifest) auto-fills
+        to_pay_move_line_ids on new payments with the partner's open debt. These payments only
+        register the check movement and must not reconcile existing debt, so we opt out via
+        skip_to_pay_autofill. The field only exists when account_payment_pro is installed.
+        """
+        if "skip_to_pay_autofill" in self.env["account.payment"]._fields:
+            return {"skip_to_pay_autofill": True}
+        return {}
+
     def _create_endorsed_recovery_payment(self, check):
         """Case A: Create inbound payment in rejected_journal to recover the check from the endorsee (vendor)."""
         inbound_method = self.rejected_journal_id._get_available_payment_method_lines("inbound").filtered(
@@ -144,6 +156,7 @@ class AccountCheckRejectWizard(models.TransientModel):
                 "payment_method_line_id": inbound_method.id,
                 "memo": memo,
                 "l10n_latam_move_check_ids": [Command.link(check.id)],
+                **self._rejection_payment_vals(),
             }
         )
 
@@ -188,6 +201,7 @@ class AccountCheckRejectWizard(models.TransientModel):
                 "payment_method_line_id": out_method.id,
                 "memo": memo,
                 "l10n_latam_move_check_ids": [Command.link(check.id)],
+                **self._rejection_payment_vals(),
             }
         )
 
@@ -214,13 +228,13 @@ class AccountCheckRejectWizard(models.TransientModel):
                 "amount": check.amount,
                 "currency_id": check.currency_id.id,
                 "partner_id": customer.id,
-                "to_pay_move_line_ids": False,
                 "payment_type": "outbound",
                 "partner_type": "customer",
                 "journal_id": self.rejected_journal_id.id,
                 "payment_method_line_id": return_method.id,
                 "memo": memo,
                 "l10n_latam_move_check_ids": [Command.link(check.id)],
+                **self._rejection_payment_vals(),
             }
         )
 


### PR DESCRIPTION
When rejecting an endorsed third-party check, the reject wizard creates
payments that only register the check movement, not to reconcile existing
debt. But account_payment_pro's stored compute (_compute_to_pay_move_lines)
auto-filled to_pay_move_line_ids with all the partner's open lines,
including multiple currencies. On companies that reconcile in the original
currency (reconcile_on_company_currency=False), this hit the
_check_to_pay_lines_currency constraint and raised "All selected debt lines
must have the same currency. Found: ARS, USD", blocking the rejection.

Add a `skip_to_pay_autofill` context flag honored by the compute (clears the
lines instead of autofilling) and create the rejection payments with it, so
they no longer pull the partner's unrelated multi-currency debt.