### PR TITLE
[FIX] account_payment_pro_receiptbook: unique receiptbook prefix across branches

### DIFF
--- a/account_payment_pro_receiptbook/__manifest__.py
+++ b/account_payment_pro_receiptbook/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Account Payment receiptbook",
-    "version": "19.0.2.4.0",
+    "version": "19.0.2.5.0",
     "category": "Payment",
     "website": "www.adhoc.com.ar",
     "author": "ADHOC SA",

--- a/account_payment_pro_receiptbook/migrations/19.0.2.5.0/post-migration.py
+++ b/account_payment_pro_receiptbook/migrations/19.0.2.5.0/post-migration.py
@@ -1,0 +1,27 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+"""
+Migración 19.0.2.5.0 — Resolver colisiones de prefix entre receiptbooks de una
+compañía y sus branches.
+
+En 19 una branch comparte los diarios de la padre, así que dos receiptbooks con
+el mismo ``(prefix, document_type_id, partner_type)`` dentro del mismo árbol de
+compañías generan el mismo nombre de asiento en un mismo diario. Delega en
+``account.payment.receiptbook._resolve_branch_prefix_collisions()``, que reasigna
+un prefix libre al receiptbook de la branch (conservando el de la raíz) y
+resincroniza la numeración. Idempotente.
+"""
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    from odoo import SUPERUSER_ID, api
+
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    reassigned = env["account.payment.receiptbook"]._resolve_branch_prefix_collisions()
+    _logger.info("Migración 19.0.2.5.0: %d receiptbooks reasignados por colisión de prefix", len(reassigned))

--- a/account_payment_pro_receiptbook/models/account_chart_template.py
+++ b/account_payment_pro_receiptbook/models/account_chart_template.py
@@ -37,12 +37,15 @@ class AccountChartTemplate(models.AbstractModel):
             )
             if not document_type:
                 continue
+            # Pick the first free prefix in the branch tree so a branch does not
+            # reuse the parent prefix (root company keeps "0001-").
+            prefix = self.env["account.payment.receiptbook"]._get_free_prefix(company, document_type, partner_type)
             vals = {
                 "name": partner_type_name_map[partner_type],
                 "partner_type": partner_type,
                 "company_id": company.id,
                 "document_type_id": document_type.id,
-                "prefix": "0001-",
+                "prefix": prefix,
             }
             # sudo() is used to bypass access restrictions during the initial creation
             # of receiptbooks when creating an argentine company,

--- a/account_payment_pro_receiptbook/models/account_payment_receiptbook.py
+++ b/account_payment_pro_receiptbook/models/account_payment_receiptbook.py
@@ -80,20 +80,84 @@ class AccountPaymentReceiptbook(models.Model):
     @api.constrains("company_id", "prefix", "document_type_id", "partner_type")
     def _check_unique_receipt(self):
         for rec in self:
+            # Uniqueness spans the whole branch tree: a branch shares the parent
+            # journals, so a duplicated prefix collides on the payment move name.
+            # For a company without branches root_id is itself, so child_of
+            # resolves to that single company (same as the previous check).
+            # sudo() to see parent/sibling receiptbooks regardless of the active
+            # companies of the current user.
             domain = [
                 ("id", "!=", rec.id),
-                ("company_id", "=", rec.company_id.id),
+                ("company_id", "child_of", rec.company_id.root_id.id),
                 ("prefix", "=", rec.prefix),
                 ("document_type_id", "=", rec.document_type_id.id),
                 ("partner_type", "=", rec.partner_type),
             ]
-            if self.search(domain):
+            if self.sudo().search(domain):
                 raise UserError(
                     _(
-                        "The combination of Company, Prefix, Document Type and Partner Type must be unique. "
-                        "There is already a receiptbook with these values."
+                        "The combination of Prefix, Document Type and Partner Type must be unique "
+                        "across a company and its branches. There is already a receiptbook with these values."
                     )
                 )
+
+    @api.model
+    def _get_free_prefix(self, company, document_type, partner_type):
+        """Return the first free '000N-' prefix within the company branch tree
+        for the given document type and partner type. Keeps '0001-' for the
+        first receiptbook and bumps branches to '0002-', '0003-', ..."""
+        used = set(
+            self.sudo()
+            .with_context(active_test=False)
+            .search(
+                [
+                    ("company_id", "child_of", company.root_id.id),
+                    ("document_type_id", "=", document_type.id),
+                    ("partner_type", "=", partner_type),
+                ]
+            )
+            .mapped("prefix")
+        )
+        number = 1
+        while "%04d-" % number in used:
+            number += 1
+        return "%04d-" % number
+
+    @api.model
+    def _resolve_branch_prefix_collisions(self):
+        """Reassign a free prefix to branch receiptbooks that collide with
+        another receiptbook of the same tree (same prefix/document_type/
+        partner_type), keeping the one highest in the tree, then resync the
+        numbering. Executor of migration 19.0.2.5.0 and manual repair action.
+        """
+        Company = self.env["res.company"].with_context(active_test=False)
+        roots = Company.search([("parent_id", "!=", False)]).mapped("root_id")
+        reassigned = self.browse()
+        for root in roots:
+            tree = Company.search([("id", "child_of", root.id)])
+            receiptbooks = self.with_context(active_test=False).search([("company_id", "in", tree.ids)])
+            # Shallow companies first so the root keeps its prefix as keeper.
+            receiptbooks = receiptbooks.sorted(key=lambda r: (len((r.company_id.parent_path or "").split("/")), r.id))
+            seen = set()
+            for rec in receiptbooks:
+                key = (rec.prefix, rec.document_type_id.id, rec.partner_type)
+                if key not in seen:
+                    seen.add(key)
+                    continue
+                new_prefix = self._get_free_prefix(rec.company_id, rec.document_type_id, rec.partner_type)
+                _logger.info(
+                    "Receiptbook id=%s company=%s: prefix %r -> %r (branch collision)",
+                    rec.id,
+                    rec.company_id.name,
+                    rec.prefix,
+                    new_prefix,
+                )
+                rec.prefix = new_prefix
+                seen.add((new_prefix, rec.document_type_id.id, rec.partner_type))
+                reassigned |= rec
+        if reassigned:
+            reassigned.action_resync_sequence()
+        return reassigned
 
     def write(self, vals):
         """

--- a/account_payment_pro_receiptbook/tests/test_account_paymet_pro_receiptbook_unit_test.py
+++ b/account_payment_pro_receiptbook/tests/test_account_paymet_pro_receiptbook_unit_test.py
@@ -2,9 +2,11 @@ import json
 
 from odoo import Command, fields
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
+from odoo.tests import tagged
 
 
+@tagged("post_install", "-at_install")
 class TestAccountPaymentProReceiptbookUnitTest(AccountTestInvoicingCommon):
     @classmethod
     def setUpClass(cls):
@@ -219,3 +221,74 @@ class TestAccountPaymentProReceiptbookUnitTest(AccountTestInvoicingCommon):
         with self.assertRaises(ValidationError) as cm:
             resequence_wizard.resequence()
         self.assertIn("already exist", str(cm.exception))
+
+    def _create_branch(self):
+        """Minimal branch under the test AR company (reuses its chart)."""
+        return self.env["res.company"].create({"name": "Test Branch", "parent_id": self.company.id})
+
+    def test_branch_prefix_constraint(self):
+        """A branch cannot reuse a receiptbook prefix of its parent tree."""
+        RB = self.env["account.payment.receiptbook"]
+        branch = self._create_branch()
+        doc_type = self.receiptbook.document_type_id
+        # Same prefix/document_type/partner_type as the parent 0001- receiptbook -> blocked.
+        with self.assertRaises(UserError):
+            RB.create(
+                {
+                    "name": "Branch dup",
+                    "partner_type": "customer",
+                    "company_id": branch.id,
+                    "document_type_id": doc_type.id,
+                    "prefix": self.receiptbook.prefix,
+                }
+            )
+        # A free prefix is accepted.
+        rb = RB.create(
+            {
+                "name": "Branch ok",
+                "partner_type": "customer",
+                "company_id": branch.id,
+                "document_type_id": doc_type.id,
+                "prefix": "0099-",
+            }
+        )
+        self.assertTrue(rb.id)
+
+    def test_branch_default_prefix(self):
+        """Auto-created branch receiptbooks pick the first free prefix in the tree."""
+        branch = self._create_branch()
+        self.env["account.chart.template"]._create_receiptbooks(branch)
+        branch_rb = self.env["account.payment.receiptbook"].search(
+            [("company_id", "=", branch.id), ("partner_type", "=", "customer")], limit=1
+        )
+        # Parent keeps 0001-, so the branch bumps to 0002-.
+        self.assertEqual(branch_rb.prefix, "0002-")
+
+    def test_branch_prefix_collision_migration(self):
+        """_resolve_branch_prefix_collisions reassigns the branch and keeps the root."""
+        RB = self.env["account.payment.receiptbook"]
+        branch = self._create_branch()
+        branch_rb = RB.create(
+            {
+                "name": "Branch cust",
+                "partner_type": "customer",
+                "company_id": branch.id,
+                "document_type_id": self.receiptbook.document_type_id.id,
+                "prefix": "0050-",
+            }
+        )
+        # Force a legacy collision with the parent prefix, bypassing the constraint.
+        self.env.cr.execute(
+            "UPDATE account_payment_receiptbook SET prefix=%s WHERE id=%s",
+            (self.receiptbook.prefix, branch_rb.id),
+        )
+        self.env.invalidate_all()
+        self.assertEqual(branch_rb.prefix, self.receiptbook.prefix)
+
+        reassigned = RB._resolve_branch_prefix_collisions()
+        self.assertIn(branch_rb, reassigned)
+        self.assertNotEqual(branch_rb.prefix, self.receiptbook.prefix)
+        self.assertEqual(self.receiptbook.prefix, "0001-")
+        self.assertEqual(branch_rb.sequence_id.prefix, branch_rb.prefix)
+        # Idempotent: a second run reassigns nothing.
+        self.assertFalse(RB._resolve_branch_prefix_collisions())


### PR DESCRIPTION
## Problem

In v19 a company branch shares the parent company's journals. Two receiptbooks with the same prefix within the same company tree (parent + branch) end up producing the same payment move name and collide on the `account.move` name uniqueness for that journal.

## Changes

- **Constraint** — `account.payment.receiptbook._check_unique_receipt`: uniqueness of `(prefix, document_type_id, partner_type)` now spans the whole branch tree (`company_id child_of root_id`) instead of a single company. A company without branches is unaffected (its `root_id` is itself, so the domain resolves to that single company, same as before); separate non-branch companies each have their own root and do not cross-validate.
- **Default creation** — `_create_receiptbooks` picks the first free `000N-` prefix within the tree via the new `_get_free_prefix` helper, so a branch no longer reuses the parent prefix (root keeps `0001-`, branches get `0002-`, `0003-`, ...). This covers branches created at runtime, since `res.company.create` schedules the chart template `_load` which calls `_create_receiptbooks`.
- **Migration** — `migrations/19.0.2.2.0/post-migration.py` reassigns colliding branch prefixes on existing databases (where separate companies become branches), via the reusable model method `_resolve_branch_prefix_collisions` (keeps the receiptbook highest in the tree and resyncs its numbering). The method also works as a manual repair action.

## Test plan

- On a DB with a company + branch, creating a branch receiptbook with the same prefix / document type / partner type as the parent raises a `UserError`; a different prefix is accepted.
- Creating a new branch yields a receiptbook with prefix `0002-` instead of `0001-`.
- Single-company DBs keep prefix `0001-` and behave as before.
- Simulating a legacy collision (parent + branch both `0001-`) and running the migration reassigns the branch to `0002-`, keeps the parent at `0001-`, resyncs the sequence, and is idempotent.

Internal task 70738.