### PR TITLE
[FIX] account_cashbox: stamp closing_date when closing session without cash control journals

### DIFF
--- a/account_cashbox/models/account_cashbox_session.py
+++ b/account_cashbox/models/account_cashbox_session.py
@@ -213,7 +213,11 @@ class AccountCashboxSession(models.Model):
                     "target": "new",
                 }
 
-        self.write({"state": "closed"})
+        values = {"state": "closed"}
+        if not self.closing_date:
+            # ensure closing date is always stamped, even without cash-control journals
+            values["closing_date"] = fields.Datetime.now()
+        self.write(values)
 
     def _check_session_balance(self):
         differences = []


### PR DESCRIPTION
### Problema

En `account.cashbox.session`, `closing_date` solo se completaba cuando el cashbox tenía diarios de control (`cash_control_journal_ids`). En ese caso el flujo pasa por `action_closing_control`, que es el único método que estampa la fecha.

Cuando el cashbox **no** tiene diarios de control, el botón "Close" llama directo a `action_account_cashbox_session_close` y saltea `closing_control`, por lo que la sesión se cerraba con `closing_date` vacía.

### Cambio

En `action_account_cashbox_session_close`, estampar `closing_date = now()` si viene vacía, con el mismo guard `if not closing_date` que ya usa `action_closing_control`. Se aplica en el punto único de cierre (`state = 'closed'`), así cubre ambas rutas:

- Ruta directa (sin control): estampa la fecha.
- Ruta con control ("Validate"): el guard la saltea porque ya fue estampada en `closing_control`.

Respeta la edición manual: si el usuario cargó la fecha a mano (`allow_dates_edition`), no se pisa.

### Módulo

`account_cashbox` — `models/account_cashbox_session.py`.

### Test plan

Cashbox sin diarios de control → abrir sesión → botón "Close". Antes: `closing_date` vacía. Ahora: `closing_date` = momento del cierre. Verificado en shell sobre una sesión cerrada por la ruta directa.