### PR TITLE
[FIX] l10n_ar_payment_bundle: netear devoluciones en payment_difference

### DIFF
--- a/l10n_ar_payment_bundle/models/account_payment.py
+++ b/l10n_ar_payment_bundle/models/account_payment.py
@@ -16,6 +16,14 @@ class AccountPayment(models.Model):
         currency_field="destination_currency_id",
         compute="_compute_link_payments_total",
     )
+    # payment_total firmado según la dirección del pago principal: las líneas opuestas
+    # (devoluciones/vueltos) se muestran en negativo para que la columna de la solapa
+    # "Pagos" (y su total) netee, igual que el total del bundle (ticket 121656).
+    payment_total_signed = fields.Monetary(
+        currency_field="destination_currency_id",
+        compute="_compute_payment_total_signed",
+        string="Payment Total (signed)",
+    )
     partner_id = fields.Many2one(recursive=True)
 
     show_move_button = fields.Boolean(compute="_compute_show_move_button")
@@ -67,11 +75,29 @@ class AccountPayment(models.Model):
         if self.link_payment_ids:
             self.link_payment_ids = [Command.clear()]
 
-    @api.depends("link_payment_ids.payment_total")
+    @api.depends("payment_total", "payment_type", "main_payment_id.payment_type")
+    def _compute_payment_total_signed(self):
+        """payment_total firmado según la dirección del pago principal.
+
+        payment_total es una magnitud sin signo (en B2/destination_currency_id). Firmamos
+        las líneas linkeadas: las que van en la dirección del principal suman y las opuestas
+        (devoluciones/vueltos) restan. Es la única fuente de signo del bundle — todas las
+        agregaciones netean sumando este campo. En v18 el neteo salía "gratis" porque
+        payment_total era firmado; en v19 pasó a ser magnitud y se perdió, haciendo que una
+        devolución sumara en vez de restar (regresión, ticket 121656). No reusamos
+        amount_company_currency_signed para no romper multimoneda.
+        """
+        for rec in self:
+            if rec.main_payment_id and rec.payment_type != rec.main_payment_id.payment_type:
+                rec.payment_total_signed = -rec.payment_total
+            else:
+                rec.payment_total_signed = rec.payment_total
+
+    @api.depends("link_payment_ids.payment_total_signed")
     def _compute_payment_total(self):
         super()._compute_payment_total()
         for rec in self:
-            rec.payment_total += sum(rec.link_payment_ids.mapped("payment_total"))
+            rec.payment_total += sum(rec.link_payment_ids.mapped("payment_total_signed"))
 
     @api.depends("main_payment_id.payment_difference")
     def _compute_to_pay_amount(self):
@@ -79,7 +105,7 @@ class AccountPayment(models.Model):
             rec.to_pay_amount = rec.main_payment_id.payment_difference
         super(AccountPayment, self - self.filtered("main_payment_id"))._compute_to_pay_amount()
 
-    @api.depends("link_payment_ids.payment_total")
+    @api.depends("link_payment_ids.payment_total_signed")
     def _compute_link_payments_total(self):
         """
         We added this computed field because we cannot modify counterpart_currency_amount,
@@ -88,7 +114,7 @@ class AccountPayment(models.Model):
         main_payment_ids = self.filtered("is_main_payment")
         (self - main_payment_ids).link_payments_total = False
         for rec in main_payment_ids:
-            rec.link_payments_total = sum(rec.link_payment_ids.mapped("payment_total"))
+            rec.link_payments_total = sum(rec.link_payment_ids.mapped("payment_total_signed"))
 
     @api.depends("use_payment_pro", "main_payment_id", "is_internal_transfer")
     def _compute_available_journal_ids(self):
@@ -181,14 +207,10 @@ class AccountPayment(models.Model):
     def _compute_payment_difference(self):
         linked = self.filtered("main_payment_id")
         for rec in linked:
-            # Usamos payment_total de cada linked (en B2/destination_currency_id) para que la
-            # comparación con selected_debt y withholdings_amount —que también están en B2— sea
-            # siempre en la misma moneda.  Cuando B1==B2 (caso normal), payment_total ==
-            # counterpart_currency_amount, por lo que no hay regresión.  Cuando B1≠B2
-            # (reconcile_on_company_currency), counterpart_currency_amount está en B1 y mezclaría
-            # monedas; payment_total ya convierte A→C correctamente en ese branch.
-            payments = rec.main_payment_id.link_payment_ids
-            total_linked_in_b = sum(payments.mapped("payment_total"))
+            # Neteo de los linkeados vía payment_total_signed (una devolución resta, no suma).
+            # payment_total viene en B2/destination_currency_id, misma moneda que selected_debt
+            # y withholdings_amount.
+            total_linked_in_b = sum(rec.main_payment_id.link_payment_ids.mapped("payment_total_signed"))
             rec.payment_difference = (
                 abs(rec.main_payment_id.to_pay_amount)
                 - total_linked_in_b

--- a/l10n_ar_payment_bundle/tests/test_payment_bundle_multimoneda.py
+++ b/l10n_ar_payment_bundle/tests/test_payment_bundle_multimoneda.py
@@ -709,3 +709,111 @@ class TestPaymentBundle(TestPaymentWithholdingMultimoneda):
         )
         wth_ml = self._wth_move_lines(main)
         self.assertAlmostEqual(abs(wth_ml.balance), 36_000, places=0)
+
+    # ==================================================================
+    # B.8 — Bundle con línea de devolución (direcciones mixtas)
+    # ==================================================================
+
+    def test_b8_bundle_con_devolucion_neteada(self):
+        """B.8 · Regresión ticket 121656. Se paga de más y se registra la
+        diferencia como devolución (línea en sentido opuesto).
+
+        Deuda 12 100. Bundle: se paga 13 100 (outbound) y se recibe de vuelta
+        1 000 (inbound, el "vuelto"). El neto pagado es 12 100 → payment_difference = 0.
+
+        Antes del fix, payment_difference sumaba ambas líneas (13 100 + 1 000)
+        y daba -2 000: la devolución se duplicaba en vez de restar.
+        """
+        invoice = self._create_invoice(10_000, self.ars)
+        self.assertAlmostEqual(invoice.amount_total, 12_100, places=2)
+
+        main = self._create_main_payment(
+            invoice,
+            fiscal_position=False,
+            l10n_ar_fiscal_position_id=False,
+        )
+
+        # Línea de pago (misma dirección que el main) por 13 100: paga de más.
+        linked_pay = self._add_linked_payment(main, self.bank_ars, 13_100)
+        # Línea de devolución (dirección opuesta) por 1 000: el vuelto.
+        linked_refund = self._add_linked_payment(main, self.cash_ars, 1_000, payment_type="inbound")
+
+        self.assertEqual(linked_pay.payment_type, "outbound")
+        self.assertEqual(linked_refund.payment_type, "inbound", "La devolución va en sentido opuesto")
+
+        # Los totales del header del pago principal netean la devolución: 13 100 - 1 000.
+        # Antes del fix sumaban (14 100) y payment_difference daba -2 000.
+        self.assertAlmostEqual(main.payment_total, 12_100, places=2, msg="Payment Total neteado")
+        self.assertAlmostEqual(main.link_payments_total, 12_100, places=2, msg="Payments Amount neteado")
+        self.assertAlmostEqual(main.payment_difference, 0, places=2, msg="difference = to_pay(12100) - neto(12100) = 0")
+
+        # payment_difference del linkeado también netea: 12 100 - (13 100 - 1 000) = 0.
+        self.assertAlmostEqual(
+            linked_pay.payment_difference,
+            0,
+            places=2,
+            msg="La devolución debe restar (12100 - (13100 - 1000) = 0), no sumar",
+        )
+
+        # Columna "Amount" de la solapa Pagos (payment_total_signed): la devolución en negativo,
+        # y la suma de la columna netea a link_payments_total.
+        self.assertAlmostEqual(linked_pay.payment_total_signed, 13_100, places=2)
+        self.assertAlmostEqual(linked_refund.payment_total_signed, -1_000, places=2, msg="Devolución en negativo")
+        self.assertAlmostEqual(
+            linked_pay.payment_total_signed + linked_refund.payment_total_signed,
+            main.link_payments_total,
+            places=2,
+            msg="La suma de la columna debe coincidir con el total neteado",
+        )
+
+        # Post: cada linked balancea (el asiento ya era correcto aun con el bug).
+        main.action_post()
+        for linked in (linked_pay, linked_refund):
+            self.assertIn(linked.state, ("paid", "in_process"), "Linked payment debe estar posteado")
+            self.assertAlmostEqual(
+                sum(linked.move_id.line_ids.mapped("balance")),
+                0,
+                places=2,
+                msg="Partida doble en linked",
+            )
+
+    # ==================================================================
+    # B.9 — Neteo preserva el signo (dirección opuesta domina)
+    # ==================================================================
+
+    def test_b9_bundle_devolucion_mayor_al_pago(self):
+        """B.9 · Guarda que el neteo preserva el signo relativo al pago principal.
+
+        Caso degenerado en un bundle outbound (deuda 12 100): se paga solo 1 000
+        (outbound) y se recibe 13 100 (inbound). El neto real es -12 100 (recibiste
+        de más), por lo que payment_difference debe CRECER: 12 100 - (1 000 - 13 100)
+        = 24 200.
+
+        Con abs() el neto quedaría en 12 100 y payment_difference daría 0
+        (deuda saldada), enmascarando el signo. Este test falla si se vuelve a abs().
+        """
+        invoice = self._create_invoice(10_000, self.ars)
+        self.assertAlmostEqual(invoice.amount_total, 12_100, places=2)
+
+        main = self._create_main_payment(
+            invoice,
+            fiscal_position=False,
+            l10n_ar_fiscal_position_id=False,
+        )
+        self.assertEqual(main.payment_type, "outbound")
+
+        # Pago chico (dirección del main) + devolución grande (dirección opuesta).
+        self._add_linked_payment(main, self.bank_ars, 1_000)
+        linked_refund = self._add_linked_payment(main, self.cash_ars, 13_100, payment_type="inbound")
+
+        # net = outbound - inbound = 1000 - 13100 = -12100.
+        # Los totales del header quedan negativos (recibiste neto) y difference crece.
+        self.assertAlmostEqual(main.payment_total, -12_100, places=2, msg="Payment Total negativo (neto)")
+        self.assertAlmostEqual(main.link_payments_total, -12_100, places=2)
+        self.assertAlmostEqual(
+            main.payment_difference,
+            24_200,
+            places=2,
+            msg="difference = 12100 - (-12100) = 24200 (con abs daría 0, enmascarando el signo)",
+        )
+        self.assertAlmostEqual(linked_refund.payment_difference, 24_200, places=2)

--- a/l10n_ar_payment_bundle/views/account_payment_view.xml
+++ b/l10n_ar_payment_bundle/views/account_payment_view.xml
@@ -210,7 +210,7 @@
                 <field name="payment_method_id"/>
                 <field name="payment_type" optional="hide"/>
                 <field name="amount" string="Amount (JC)" help="Amount on journal currency" optional="hide"/>
-                <field name="payment_total" string="Amount" sum="Total"/>
+                <field name="payment_total_signed" string="Amount" sum="Total"/>
                 <field name="counterpart_currency_amount" string="Amount (DC)" sum="Total" help="Amount in Debt Currency" optional="hide" column_invisible="parent.destination_currency_id == parent.counterpart_currency_id"/>
                 <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-warning="state == 'in_process'" decoration-success="state == 'paid'"/>
             </list>


### PR DESCRIPTION
Al pagar de más y registrar la diferencia como devolución (línea de pago en sentido opuesto al principal), payment_difference sumaba las magnitudes de todas las líneas linkeadas en vez de netear recibir (inbound) contra enviar (outbound), duplicando el vuelto (daba -2000 en vez de 0).

Se restaura el neteo por payment_type como en 18.0, pero manteniendo payment_total (en B2/destination_currency_id) en lugar de amount_company_currency_signed, para no reintroducir la mezcla de monedas.

Ticket 121656.