### PR TITLE
[FIX] account_payment_pro: make 19.0.2.0.0 pre-migrate column backup idempotent

### DIFF
--- a/account_payment_pro/migrations/19.0.2.0.0/pre-migrate.py
+++ b/account_payment_pro/migrations/19.0.2.0.0/pre-migrate.py
@@ -44,7 +44,11 @@ def migrate(cr, version):
         "write_off_amount",
         "unreconciled_amount",
     ):
-        if openupgrade.column_exists(cr, "account_payment", col):
+        # Saltear si el backup ya existe: los x_bkp_ son write-once, así un
+        # reintento nunca pisa el valor original que lee el post-migrate.
+        if openupgrade.column_exists(cr, "account_payment", col) and not openupgrade.column_exists(
+            cr, "account_payment", f"x_bkp_{col}"
+        ):
             columns_to_backup.append((col, f"x_bkp_{col}", None))
 
     if columns_to_backup:


### PR DESCRIPTION
### Problema

El pre-migrate de `account_payment_pro` `19.0.2.0.0` respalda columnas
originales en columnas `x_bkp_*` vía `openupgrade.copy_columns`, que hace un
`ALTER TABLE ... ADD COLUMN` crudo (sin `IF NOT EXISTS`). El filtro solo
chequeaba la existencia de la columna **origen**, no la de destino. En un
reintento de upgrade la columna `x_bkp_*` ya existe y la migración rompe:

```
psycopg2.errors.DuplicateColumn: column "x_bkp_force_amount_company_currency"
of relation "account_payment" already exists
```

### Solución

Saltear el backup cuando la columna `x_bkp_*` ya existe. Los backups son
write-once por diseño: el post-migrate transforma las columnas vivas en el
lugar leyendo siempre del backup pristino, así que refrescarlo en un reintento
causaría doble conversión de importes. Con este cambio el paso queda idempotente
igual que el resto del script y el pase se puede reintentar sin tocar la DB a
mano.
