### PR TITLE
[FIX] account_payment_pro: fix double write-off with withholdings

### DIFF
--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -473,8 +473,17 @@ class AccountPayment(models.Model):
             w_balance = sum(line["balance"] for line in write_off_line_vals)
             w_amount_currency = sum(line["amount_currency"] for line in write_off_line_vals)
             if res.get("counterpart_lines"):
-                res["counterpart_lines"][0]["balance"] -= w_balance
-                res["counterpart_lines"][0]["amount_currency"] -= w_amount_currency
+                # Cuando hay retenciones, el core descarta el write-off y l10n_ar_tax vuelve a
+                # armar la contrapartida en bruto (neto + retenciones). En ese flujo la línea de
+                # ajuste (write-off) termina del mismo lado que la contrapartida en vez de
+                # compensarla, así que el asiento descuadra en 2x el ajuste: el balanceo automático
+                # manda ese importe a la cuenta puente y lo deja sin conciliar en la cuenta
+                # corriente del partner (bug ticket 121602, visible en pagos con retención).
+                # Por eso, con retenciones compensamos en sentido inverso para que la línea de
+                # ajuste quede como contrapartida y el asiento cierre sin residual.
+                sign = 1 if res.get("withholding_lines") else -1
+                res["counterpart_lines"][0]["balance"] += sign * w_balance
+                res["counterpart_lines"][0]["amount_currency"] += sign * w_amount_currency
 
         if not self.company_id.use_payment_pro and not self.is_internal_transfer:
             return res


### PR DESCRIPTION
## Problem

On a payment that carries **both withholdings and a write-off** (e.g. a rounding adjustment), the write-off is accounted **twice**, leaving an unreconciled residual equal to `2 x write_off` on the partner ledger and the same amount stuck in the bridge (multiple-payments) account.

Chain of events:

1. Core `account.payment._prepare_move_lines_per_type` drops the `write_off_lines` when `withholding_lines` are present and rebalances the counterpart without them.
2. `account_payment_pro` re-adds the write-off line and compensates the counterpart.
3. `l10n_ar_tax` then rebuilds the counterpart as **gross** (net + withholdings).

In that combined flow the write-off line ends up on the **same side** as the counterpart instead of offsetting it, so the entry is unbalanced by `2 x write_off`. The automatic balancing line sends that amount to the bridge account and it stays unreconciled on the partner receivable/payable.

It only shows up with **multi-line payments (bundles) that combine withholdings + a rounding adjustment**; plain payments are unaffected (core does not drop the write-off there, so this branch does not run).

## Fix

Compensate the counterpart in the **opposite direction when withholding lines are present**, so the write-off nets exactly once and the entry balances. The no-withholding path keeps the original behaviour (`sign = -1`, identical to before).

## Test plan

Company using Payment Pro, on a customer receipt / payment bundle:

1. Register a payment combining withholdings **and** a rounding write-off.
2. Before the fix: the bridge account keeps a balance of `2 x write_off` and the same amount is unreconciled on the partner ledger; the write-off line sits on the counterpart side.
3. After the fix: the bridge account nets to zero, the partner ledger reconciles with no dangling residual, and the write-off line offsets the counterpart.
4. Regression: a plain payment (no withholdings) with a write-off still books the adjustment correctly (unchanged path).

Internal ref: helpdesk ticket #121602.