### PR TITLE
[FIX] l10n_latam_check_ux: own check liquidity lines per check

### DIFF
--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -468,6 +468,24 @@ class AccountPayment(models.Model):
 
         res = super()._prepare_move_lines_per_type(write_off_line_vals=write_off_line_vals, force_balance=force_balance)
 
+        # FX sign-symmetry (odoo PR 248296): on a plain conversion, convert the
+        # absolute amount and re-apply the sign so rounding is symmetric. No-op
+        # on a patched core; skips forced/withholding cases (liquidity would not
+        # hold the full payment amount).
+        if (
+            not force_balance
+            and not self.force_amount_company_currency
+            and self.currency_id != self.company_id.currency_id
+        ):
+            for line in res.get("liquidity_lines", []):
+                amount_currency = line.get("amount_currency") or 0.0
+                if self.currency_id.compare_amounts(abs(amount_currency), self.amount) != 0:
+                    continue
+                sign = 1 if amount_currency > 0 else -1
+                line["balance"] = sign * self.currency_id._convert(
+                    abs(amount_currency), self.company_id.currency_id, self.company_id, self.date
+                )
+
         if self.company_id.use_payment_pro and write_off_line_vals and not res.get("write_off_lines"):
             res["write_off_lines"] = write_off_line_vals
             w_balance = sum(line["balance"] for line in write_off_line_vals)

--- a/l10n_latam_check_ux/models/account_payment.py
+++ b/l10n_latam_check_ux/models/account_payment.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from odoo import api, fields, models
+from odoo import Command, _, api, fields, models
 from odoo.exceptions import ValidationError
 
 
@@ -152,3 +152,77 @@ class AccountPayment(models.Model):
                     "All selected checks must belong to the source journal (%s)."
                     % rec.destination_journal_id.display_name
                 )
+
+    # One liquidity line per own check (replaces core's post-hoc split move).
+    def _prepare_move_liquidity_lines(self, default_values):
+        self.ensure_one()
+        check_ids = self.l10n_latam_new_check_ids | self.l10n_latam_move_check_ids
+        if (
+            self.payment_method_code == "own_checks"
+            and self.payment_type == "outbound"
+            and len(self.l10n_latam_new_check_ids) >= 1
+            and check_ids
+        ):
+            company_currency = self.company_id.currency_id
+            amount_currency_total = 0.0
+            balance_total = 0.0
+            line_vals = []
+            for check in check_ids:
+                if check == self.l10n_latam_new_check_ids[-1]:
+                    # last check absorbs rounding
+                    liquidity_amount_currency = self.currency_id.round(
+                        abs(default_values["amount_currency"]) - amount_currency_total
+                    )
+                    liquidity_balance = company_currency.round(abs(default_values["balance"]) - balance_total)
+                else:
+                    # check.amount is in the payment currency
+                    liquidity_amount_currency = self.currency_id.round(check.amount)
+                    liquidity_balance = self.currency_id._convert(
+                        liquidity_amount_currency, company_currency, self.company_id, self.date
+                    )
+                    amount_currency_total += liquidity_amount_currency
+                    balance_total += liquidity_balance
+
+                line_vals.append(
+                    {
+                        "name": _(
+                            "Check %(check_number)s - %(suffix)s",
+                            check_number=check.name,
+                            suffix="".join([item[1] for item in self._get_aml_default_display_name_list()]),
+                        ),
+                        "date_maturity": check.payment_date,
+                        "partner_id": self.partner_id.id,
+                        "account_id": self.outstanding_account_id.id,
+                        "currency_id": check.currency_id.id,
+                        "balance": -liquidity_balance,
+                        "amount_currency": -liquidity_amount_currency,
+                        "l10n_latam_check_ids": [Command.link(check.id)],
+                    }
+                )
+            return line_vals
+
+        return super()._prepare_move_liquidity_lines(default_values)
+
+    # Split move no longer used: liquidity lines are built per check above.
+    def _l10n_latam_check_split_move(self):
+        return
+
+    # No split move to unlink on draft: own-check liquidity lines live in the
+    # payment move itself, so keep the checks linked (matches patched core).
+    def _l10n_latam_check_unlink_split_move(self):
+        return
+
+    def _synchronize_to_moves(self, changed_fields):
+        # Own checks legitimately post several liquidity lines (one per check).
+        # Base only blocks them through the "amount + multiple liquidity lines"
+        # guard; its line mapping already handles N liquidity lines. So we just
+        # drop 'amount' from the trigger set for those payments and let base do
+        # the actual sync (no copied mapping -> upstream changes are inherited).
+        own_multi = self.filtered(
+            lambda p: p.payment_method_code == "own_checks"
+            and p.payment_type == "outbound"
+            and len(p.l10n_latam_new_check_ids) > 1
+        )
+        super(AccountPayment, self - own_multi)._synchronize_to_moves(changed_fields)
+        if own_multi:
+            super(AccountPayment, own_multi)._synchronize_to_moves(tuple(f for f in changed_fields if f != "amount"))

--- a/l10n_latam_check_ux/tests/__init__.py
+++ b/l10n_latam_check_ux/tests/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import test_own_checks_ux

--- a/l10n_latam_check_ux/tests/test_own_checks_ux.py
+++ b/l10n_latam_check_ux/tests/test_own_checks_ux.py
@@ -1,0 +1,111 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import Command, fields
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestOwnChecksUx(TransactionCase):
+    """Own checks build one liquidity line per check (no post-hoc split move),
+    reproduced from l10n_latam_check_ux instead of a core patch."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        own_checks = cls.env.ref("l10n_latam_check.account_payment_method_own_checks")
+        # reuse a company/journal that already has own checks configured
+        cls.payment_method_line = cls.env["account.payment.method.line"].search(
+            [
+                ("payment_method_id", "=", own_checks.id),
+                ("payment_account_id", "!=", False),
+            ],
+            limit=1,
+        )
+        if not cls.payment_method_line:
+            raise cls.skipTest(cls, "No own_checks journal configured in this database")
+        cls.bank_journal = cls.payment_method_line.journal_id
+        cls.company = cls.bank_journal.company_id
+        cls.env = cls.env(context=dict(cls.env.context, allowed_company_ids=cls.company.ids))
+        cls.partner = cls.env["res.partner"].create({"name": "Own Check Vendor"})
+
+    def _create_own_check_payment(self, amounts, currency=None):
+        return (
+            self.env["account.payment"]
+            .with_company(self.company)
+            .create(
+                {
+                    "payment_type": "outbound",
+                    "partner_type": "supplier",
+                    "partner_id": self.partner.id,
+                    "journal_id": self.bank_journal.id,
+                    "company_id": self.company.id,
+                    "date": fields.Date.today(),
+                    "currency_id": (currency or self.company.currency_id).id,
+                    "payment_method_line_id": self.payment_method_line.id,
+                    "l10n_latam_new_check_ids": [
+                        Command.create({"payment_date": fields.Date.today(), "amount": amount}) for amount in amounts
+                    ],
+                }
+            )
+        )
+
+    def test_one_liquidity_line_per_check(self):
+        payment = self._create_own_check_payment([25, 25])
+        payment.action_post()
+        self.assertEqual(payment.amount, 50)
+        outstanding_lines = payment.l10n_latam_new_check_ids.mapped("outstanding_line_id")
+        self.assertEqual(len(outstanding_lines), 2, "There should be a liquidity line per check.")
+
+    def test_no_separate_split_move(self):
+        payment = self._create_own_check_payment([20, 30, 70])
+        payment.action_post()
+        self.assertEqual(payment.amount, 120)
+        # every check points to a line inside the payment move, not a separate one
+        for check in payment.l10n_latam_new_check_ids:
+            self.assertEqual(check.outstanding_line_id.move_id, payment.move_id)
+
+    def test_reset_to_draft_keeps_checks_linked(self):
+        payment = self._create_own_check_payment([20, 30, 70])
+        payment.action_post()
+        payment.action_draft()
+        # no separate split move to unlink, so checks stay linked to the payment move
+        for check in payment.l10n_latam_new_check_ids:
+            self.assertEqual(check.outstanding_line_id.move_id, payment.move_id)
+
+    def test_own_check_multicurrency_liquidity_amounts(self):
+        """Own checks in a currency different from the company one: each check
+        line keeps the nominal in amount_currency and its conversion in balance.
+        The issue only shows up when the rate is not 1:1."""
+        company_currency = self.company.currency_id
+        foreign_currency = self.env.ref("base.EUR")
+        if foreign_currency == company_currency:
+            foreign_currency = self.env.ref("base.USD")
+        foreign_currency.active = True
+        self.env["res.currency.rate"].create(
+            {
+                "name": fields.Date.today(),
+                "currency_id": foreign_currency.id,
+                "company_id": self.company.id,
+                "rate": 4.0,
+            }
+        )
+        payment = self._create_own_check_payment([20, 30, 70], currency=foreign_currency)
+        payment.action_post()
+        self.assertEqual(payment.amount, 120)
+
+        for check in payment.l10n_latam_new_check_ids:
+            line = check.outstanding_line_id
+            self.assertEqual(
+                abs(line.amount_currency),
+                check.amount,
+                "Check liquidity line must hold the nominal in the payment currency",
+            )
+            expected_balance = foreign_currency._convert(check.amount, company_currency, self.company, payment.date)
+            self.assertEqual(
+                abs(line.balance),
+                expected_balance,
+                "Check liquidity line balance must be the nominal converted to company currency",
+            )


### PR DESCRIPTION
Reproduces, from our own modules, the parts of odoo/odoo PR
https://github.com/odoo/odoo/pull/248296 we were carrying as a patch on core,
so the image can run a vanilla Odoo core.

## `l10n_latam_check_ux` — own checks

Own check payments build **one liquidity line per check** (each with its own
currency conversion) directly in the payment move, instead of a post-hoc split
move.

- `_prepare_move_liquidity_lines`: one liquidity line per check; nominal kept in
  `amount_currency`, conversion in `balance` (fixes the multicurrency case).
- `_l10n_latam_check_split_move` / `_l10n_latam_check_unlink_split_move`:
  neutralized — no separate entry, and reset-to-draft keeps the checks linked.
- `_synchronize_to_moves`: for multi-check own payments it only drops the
  `amount` trigger so base skips its "multiple liquidity lines" guard; the line
  mapping stays in `super()` (no copied core logic, upstream changes inherited).

## `account_payment_pro` — FX sign symmetry

`_prepare_move_lines_per_type` reproduces the core FX fix: on a plain conversion,
convert the absolute amount and re-apply the sign so rounding is symmetric.
No-op on a patched core; gated to the plain FX case (skips forced-balance and
withholding).

## Notes

The upstream PR also drops the `Journal Entry` button on the check form. That
view cleanup is cosmetic and can only be added once core is de-patched (on the
patched image the button no longer exists, so an xpath would fail to load) — to
be handled together with the core de-patch.

## Tests

Own-check tests (line per check, no split move, reset to draft, multicurrency)
and the existing `account_payment_pro` FX suite. Green on both the currently
patched core and a vanilla 18.0 core.

Task 70884
