### PR TITLE
[FIX] account_payment_loan: decouple loan_account_id from journal default_account_id

### DIFF
--- a/account_payment_loan/__init__.py
+++ b/account_payment_loan/__init__.py
@@ -14,7 +14,7 @@ def post_init_hook(env):
             ChartTemplate._load_data({"account.journal": journals_to_create})
 
         account_loan_journal_id = env.ref(f"account.{company.id}_account_loan_journal")
-        account_loan_journal_id.default_account_id = env.ref(f"account.{company.id}_account_loan_account").id
         company.loan_journal_id = account_loan_journal_id.id
+        company.loan_account_id = env.ref(f"account.{company.id}_account_loan_account").id
         company.account_late_payment_interest = env.ref(f"account.{company.id}_account_loan_interest_account").id
         company.account_loan_extra_charges = env.ref(f"account.{company.id}_account_loan_extra_charges").id

--- a/account_payment_loan/migrations/19.0.1.0.1/post-migration.py
+++ b/account_payment_loan/migrations/19.0.1.0.1/post-migration.py
@@ -1,0 +1,26 @@
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    _logger.info(
+        "Migrando loan_account_id: lo separamos del default_account_id del loan_journal_id "
+        "(un journal no puede tener una cuenta receivable/payable como default_account_id, "
+        "ver account.account _check_account_is_bank_journal_bank_account)"
+    )
+    cr.execute("""
+        UPDATE res_company company
+        SET loan_account_id = journal.default_account_id
+        FROM account_journal journal
+        WHERE journal.id = company.loan_journal_id
+          AND journal.default_account_id IS NOT NULL
+          AND company.loan_account_id IS NULL
+    """)
+    cr.execute("""
+        UPDATE account_journal journal
+        SET default_account_id = NULL
+        FROM res_company company
+        WHERE company.loan_journal_id = journal.id
+          AND journal.default_account_id IS NOT NULL
+    """)

--- a/account_payment_loan/models/account_chart_template.py
+++ b/account_payment_loan/models/account_chart_template.py
@@ -46,8 +46,8 @@ class AccountChartTemplate(models.AbstractModel):
         company = get_first_parent(company or self.env.company)
 
         account_loan_journal_id = self.env.ref(f"account.{company.id}_account_loan_journal")
-        account_loan_journal_id.default_account_id = self.env.ref(f"account.{company.id}_account_loan_account").id
 
         company.loan_journal_id = account_loan_journal_id.id
+        company.loan_account_id = self.env.ref(f"account.{company.id}_account_loan_account").id
         company.account_late_payment_interest = self.env.ref(f"account.{company.id}_account_loan_interest_account").id
         company.account_loan_extra_charges = self.env.ref(f"account.{company.id}_account_loan_extra_charges").id

--- a/account_payment_loan/models/account_move.py
+++ b/account_payment_loan/models/account_move.py
@@ -24,7 +24,7 @@ class AccountMove(models.Model):
         for rec in self.filtered(lambda x: not x.loan_move_ids):
             late_payment_interest = rec.company_id.late_payment_interest
             daily_interest = late_payment_interest / 30
-            loan_account_id = rec.company_id.loan_journal_id.default_account_id
+            loan_account_id = rec.company_id.loan_account_id
 
             for line_id in rec.line_ids.filtered(
                 lambda x: x.account_id == loan_account_id
@@ -52,7 +52,7 @@ class AccountMove(models.Model):
         for rec in self:
             loan_surcharge = rec._get_total_debit(date)
             # intereses ganado  y perdidos
-            loan_account_id = rec.company_id.loan_journal_id.default_account_id
+            loan_account_id = rec.company_id.loan_account_id
             late_payment_interest_account_id = rec.company_id.account_late_payment_interest
             move_names = ", ".join(rec.filtered(lambda x: not x.loan_move_ids).mapped("name"))
             interest_move_data = {

--- a/account_payment_loan/models/account_payment.py
+++ b/account_payment_loan/models/account_payment.py
@@ -15,7 +15,7 @@ class AccountPayment(models.Model):
     @api.depends("to_pay_move_line_ids")
     def _compute_is_loan_payment(self):
         for rec in self:
-            loan_account_id = rec.company_id.loan_journal_id.default_account_id
+            loan_account_id = rec.company_id.loan_account_id
             rec.is_loan_payment = rec.to_pay_move_line_ids.filtered(
                 lambda x: x.account_id == loan_account_id and not x.move_id.loan_move_ids
             ).exists()
@@ -29,7 +29,7 @@ class AccountPayment(models.Model):
 
             loan_surcharge = 0.0
             daily_interest = rec.company_id.late_payment_interest / 30
-            loan_account_id = rec.company_id.loan_journal_id.default_account_id
+            loan_account_id = rec.company_id.loan_account_id
 
             lines = rec.to_pay_move_line_ids.filtered(
                 lambda l: l.account_id == loan_account_id
@@ -50,7 +50,7 @@ class AccountPayment(models.Model):
         for rec in self.filtered(lambda p: p.is_loan_payment):
             if rec.loan_surcharge:
                 # intereses ganado  y perdidos
-                loan_account_id = rec.company_id.loan_journal_id.default_account_id
+                loan_account_id = rec.company_id.loan_account_id
                 late_payment_interest_account_id = rec.company_id.account_late_payment_interest
                 loan_move_ids = rec.to_pay_move_line_ids.filtered(lambda x: x.account_id == loan_account_id).mapped(
                     "move_id"

--- a/account_payment_loan/models/res_company.py
+++ b/account_payment_loan/models/res_company.py
@@ -5,6 +5,12 @@ class ResCompany(models.Model):
     _inherit = "res.company"
 
     loan_journal_id = fields.Many2one("account.journal")
+    loan_account_id = fields.Many2one(
+        "account.account",
+        help="Account used to identify and record loan receivable lines. Kept independent from "
+        "loan_journal_id.default_account_id: a receivable/payable account can't be a journal's default "
+        "account (see account.account _check_account_is_bank_journal_bank_account).",
+    )
     late_payment_interest = fields.Float(
         help="Monthly interest rate for late payments, expressed as a percentage (e.g., 0.10 for 10%). "
         "This would be prorated to a daily interest rate of 1/30 of the monthly rate."

--- a/account_payment_loan/models/res_config_setting.py
+++ b/account_payment_loan/models/res_config_setting.py
@@ -10,6 +10,12 @@ class ResConfigSettings(models.TransientModel):
         help="Journal to be used for registering loan transactions.",
     )
 
+    loan_account_id = fields.Many2one(
+        related="company_id.loan_account_id",
+        readonly=False,
+        help="Account used to identify and record loan receivable lines.",
+    )
+
     late_payment_interest = fields.Float(
         related="company_id.late_payment_interest",
         readonly=False,

--- a/account_payment_loan/tests/__init__.py
+++ b/account_payment_loan/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_loan_account_setup

--- a/account_payment_loan/tests/test_loan_account_setup.py
+++ b/account_payment_loan/tests/test_loan_account_setup.py
@@ -1,0 +1,22 @@
+from odoo.tests import common, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestLoanAccountSetup(common.TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.company
+
+    def test_loan_account_id_is_set(self):
+        self.assertTrue(self.company.loan_account_id, "loan_account_id should be set by post_init_hook")
+        self.assertEqual(self.company.loan_account_id.account_type, "asset_receivable")
+
+    def test_loan_journal_has_no_default_account(self):
+        # A receivable/payable account can't be a journal's default account
+        # (account.account _check_account_is_bank_journal_bank_account). loan_account_id must
+        # stay decoupled from loan_journal_id.default_account_id or this constraint blocks module install.
+        self.assertFalse(
+            self.company.loan_journal_id.default_account_id,
+            "loan_journal_id.default_account_id must stay empty; use company.loan_account_id instead",
+        )

--- a/account_payment_loan/views/res_company_setting.xml
+++ b/account_payment_loan/views/res_company_setting.xml
@@ -17,6 +17,16 @@
                         </div>
                     </setting>
 
+                    <setting string="Loan Account:" company_dependent="1"
+                            help="Account used to identify and record loan receivable lines.">
+                        <div class="content-group">
+                            <div class="row mt8">
+                                <label for="loan_account_id" class="col-lg-5 o_light_label"/>
+                                <field name="loan_account_id" domain="[('company_ids', '=', company_id)]"/>
+                            </div>
+                        </div>
+                    </setting>
+
                     <setting string="Late Payment Interest" company_dependent="1"
                             help="Monthly interest rate for late payments (e.g. 0.10 = 10%). This is prorated to a daily rate.">
                         <div class="content-group">

--- a/account_payment_loan/wizards/account_loan_debt_report.py
+++ b/account_payment_loan/wizards/account_loan_debt_report.py
@@ -33,7 +33,7 @@ class accountLoanDebtDeport(models.TransientModel):
     @api.depends("partner_id")
     def _compute_available_loan_move_ids(self):
         for rec in self:
-            loan_account_id = self.env.company.loan_journal_id.default_account_id
+            loan_account_id = self.env.company.loan_account_id
             loan_line_ids = self.env["account.move.line"].search(
                 [
                     ("company_id", "=", self.env.company.id),

--- a/account_payment_loan/wizards/account_loan_extra_charges.py
+++ b/account_payment_loan/wizards/account_loan_extra_charges.py
@@ -24,7 +24,7 @@ class accountLoanExtraCharges(models.TransientModel):
     @api.depends("partner_id")
     def _compute_available_loan_move_ids(self):
         for rec in self:
-            loan_account_id = self.env.company.loan_journal_id.default_account_id
+            loan_account_id = self.env.company.loan_account_id
             loan_line_ids = self.env["account.move.line"].search(
                 [
                     ("company_id", "=", self.env.company.id),
@@ -37,7 +37,7 @@ class accountLoanExtraCharges(models.TransientModel):
             rec.available_loan_move_ids = [(6, 0, loan_line_ids.mapped("move_id").ids)]
 
     def action_add_extra_charges(self):
-        loan_account_id = self.company_id.loan_journal_id.default_account_id
+        loan_account_id = self.company_id.loan_account_id
         extra_charges_account_id = self.company_id.account_loan_extra_charges
         if self.loan_move_id:
             base_loan_move_ids = self.loan_move_id.ids

--- a/account_payment_loan/wizards/account_loan_register.py
+++ b/account_payment_loan/wizards/account_loan_register.py
@@ -127,7 +127,7 @@ class AccountLoanRegister(models.TransientModel):
 
     def _prepare_loan_move_data(self):
         amount_total = self.amount * self.installment_id.surcharge_coefficient
-        loan_account = self.company_id.loan_journal_id.default_account_id
+        loan_account = self.company_id.loan_account_id
         move_names = ", ".join(filter(None, self.move_line_ids.mapped("move_id.name")))
         if not self.refinancial_loan_move_ids:
             ref = _("Loan of %s") % move_names if move_names else _("Loan")
@@ -199,7 +199,7 @@ class AccountLoanRegister(models.TransientModel):
             loan_move_data["line_ids"].append(
                 Command.create(
                     {
-                        "account_id": self.env.ref(f"account.{self.company_id.id}_account_loan_account").id,
+                        "account_id": loan_account.id,
                         "balance": credit_total - debit_total,
                         "name": _("Rounding"),
                         "currency_id": self.currency_id.id,


### PR DESCRIPTION
## Summary

A journal's `default_account_id` can't be a receivable/payable account (`account.account._check_account_is_bank_journal_bank_account`). `account_payment_loan` set up its loan journal that way, which is a latent constraint violation — it never triggered because nothing revalidated `account.account` after the journal linked to it, but a recent core change to `account_type` recompute timing surfaces it during multi-company install.

- Add `res.company.loan_account_id` (Many2one to `account.account`) as the explicit identifier for the loan account.
- `post_init_hook` / `account.chart.template._post_load_data` now set `loan_account_id` directly instead of `loan_journal_id.default_account_id`.
- Replace the 9 read sites across `account_payment.py`, `account_move.py`, and the 3 wizards that used `loan_journal_id.default_account_id` to identify the loan account.
- Expose `loan_account_id` in Settings alongside `loan_journal_id`.
- Add a `post-migration` script for databases where the module is already installed: copies the journal's `default_account_id` to `loan_account_id` and clears it on the journal.
- Add `tests/test_loan_account_setup.py` (module had no tests) asserting `loan_account_id` is set and `loan_journal_id.default_account_id` stays empty, as a regression guard.

`loan_journal_id` itself is unchanged — still used correctly as the journal for posting loan-related moves.

## Test plan

- [x] `pre-commit` clean on all changed files.
- [x] New test asserts `company.loan_account_id` is set (`account_type == 'asset_receivable'`) and `company.loan_journal_id.default_account_id` is empty after install.
- [ ] Run full module test suite in CI/runbot.

Internal reference: https://www.adhoc.inc/odoo/helpdesk.ticket/123467