### PR TITLE
[FIX] account_payment_pro: backfill outstanding_account_id on check payments

### DIFF
--- a/account_payment_pro/__manifest__.py
+++ b/account_payment_pro/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Account Payment Super Power",
-    "version": "19.0.2.10.0",
+    "version": "19.0.2.11.0",
     "category": "Payment",
     "website": "www.adhoc.com.ar",
     "author": "ADHOC SA",

--- a/account_payment_pro/migrations/19.0.2.11.0/post-migrate.py
+++ b/account_payment_pro/migrations/19.0.2.11.0/post-migrate.py
@@ -1,0 +1,57 @@
+"""
+Post-migration script for account_payment_pro 19.0.2.11.0
+===========================================================
+
+`outstanding_account_id` es stored + computed con
+`@api.depends('payment_method_line_id')`, que no incluye
+`payment_method_line_id.payment_account_id`. Si la cuenta de liquidez se
+completa/cambia en la linea de metodo de pago despues de que ya existen
+pagos posteados con cheque, esos pagos quedan con
+`outstanding_account_id=False` y la constraint `_check_move_id`
+(l10n_latam_check) bloquea el reset a borrador.
+
+Este script backfillea `outstanding_account_id` en los pagos con metodo
+cheque que quedaron en False pero cuya linea si tiene cuenta configurada,
+forzando el recompute (misma logica que ya usa
+`_compute_outstanding_account_id`, sin reescribirla).
+"""
+
+import logging
+
+from odoo.upgrade import util
+
+_logger = logging.getLogger(__name__)
+
+# account.payment.method.line codes que requieren cuenta de liquidez
+# (l10n_latam_check_ux/models/account_payment.py: check_inbound_codes | check_outbound_codes)
+_CHECK_METHOD_CODES = [
+    "new_third_party_checks",
+    "own_checks",
+    "issued_checks",
+    "in_third_party_checks",
+    "out_third_party_checks",
+    "return_third_party_checks",
+]
+
+
+def migrate(cr, version):
+    if not version:
+        return
+
+    _logger.info("account_payment_pro: running post-migrate for %s", version)
+
+    env = util.env(cr)
+    payments = env["account.payment"].search(
+        [
+            ("outstanding_account_id", "=", False),
+            ("payment_method_line_id.code", "in", _CHECK_METHOD_CODES),
+            ("payment_method_line_id.payment_account_id", "!=", False),
+        ]
+    )
+    _logger.info(
+        "account_payment_pro: backfilling outstanding_account_id on %s check payments",
+        len(payments),
+    )
+    payments.invalidate_recordset(["outstanding_account_id"])
+    payments.modified(["payment_method_line_id"])
+    payments.flush_recordset(["outstanding_account_id"])


### PR DESCRIPTION
## Resumen

`account.payment.outstanding_account_id` es stored + computed con `@api.depends('payment_method_line_id')`, que no incluye `payment_method_line_id.payment_account_id`. Si la cuenta de liquidez se completa/cambia en la `account.payment.method.line` después de que ya existen pagos posteados con esa línea, esos pagos no recomputan y quedan con `outstanding_account_id=False`. Al resetear el pago a borrador, la constraint `_check_move_id` de `l10n_latam_check` bloquea la operación.

Este PR:
- Bumpea la versión del módulo a `19.0.2.11.0`.
- Agrega `migrations/19.0.2.11.0/post-migrate.py`: backfillea `outstanding_account_id` en los pagos con método cheque (`new_third_party_checks`, `own_checks`, `issued_checks`, `in_third_party_checks`, `out_third_party_checks`, `return_third_party_checks`) que quedaron en `False` pero cuya línea sí tiene `payment_account_id`, forzando el recompute vía ORM (`invalidate_recordset` + `modified` + `flush_recordset`).

## Test plan

- [ ] Correr el upgrade sobre una DB con pagos cheque en el estado descripto y verificar que `outstanding_account_id` queda seteado sin tocar el asiento ya posteado.
- [ ] Confirmar que el reset a borrador de un pago cheque ya no falla por `outstanding_account_id` vacío tras el backfill.