### PR TITLE
[FIX] account_payment_loan: settle account_type before linking loan account to journal

### DIFF
--- a/account_payment_loan/__init__.py
+++ b/account_payment_loan/__init__.py
@@ -13,6 +13,11 @@ def post_init_hook(env):
         if journals_to_create := ChartTemplate._get_personal_loan_journal(template_code):
             ChartTemplate._load_data({"account.journal": journals_to_create})
 
+        # Settle the account_type recompute (scheduled when `code` was set) while the account is
+        # not yet a journal default. Otherwise a later flush triggers _check_account_is_bank_journal_bank_account
+        # on the already-linked receivable account and raises during install.
+        env["account.account"].flush_model(["account_type"])
+
         account_loan_journal_id = env.ref(f"account.{company.id}_account_loan_journal")
         account_loan_journal_id.default_account_id = env.ref(f"account.{company.id}_account_loan_account").id
         company.loan_journal_id = account_loan_journal_id.id

--- a/account_payment_loan/models/account_chart_template.py
+++ b/account_payment_loan/models/account_chart_template.py
@@ -45,6 +45,11 @@ class AccountChartTemplate(models.AbstractModel):
         super()._post_load_data(template_code, company, template_data)
         company = get_first_parent(company or self.env.company)
 
+        # Settle the account_type recompute (scheduled when `code` was set) while the account is
+        # not yet a journal default. Otherwise a later flush triggers _check_account_is_bank_journal_bank_account
+        # on the already-linked receivable account and raises.
+        self.env["account.account"].flush_model(["account_type"])
+
         account_loan_journal_id = self.env.ref(f"account.{company.id}_account_loan_journal")
         account_loan_journal_id.default_account_id = self.env.ref(f"account.{company.id}_account_loan_account").id
 


### PR DESCRIPTION
## Summary

On install, `account_payment_loan` creates a receivable loan account and sets it as the loan journal's `default_account_id`. A recent core change to when `account.account.account_type` is recomputed makes a pending recompute fire on that already-linked receivable account during a later `flush_model('account_type')` (e.g. while the next company's accounts are created in the multi-company `post_init` loop). That re-runs `account.account._check_account_is_bank_journal_bank_account` and raises:

> You cannot change the type of an account set as Bank Account on a journal to Receivable or Payable.

breaking the module install in a fresh build.

The link (account as journal default) is never blocked at creation — the constraint only fires when `account_type` is written/recomputed on an account that is already a journal default. So the fix flushes `account_type` right after the accounts are created and **before** they are linked to the journal, so the pending recompute settles while no journal points to the account yet. Later flushes then have nothing pending to re-validate.

Minimal, no behavior change: the loan journal still keeps its `default_account_id`; no new fields, no data migration, no changes to how the loan account is read elsewhere.

Applied in both setup paths: `post_init_hook` and `AccountChartTemplate._post_load_data`.

## Test plan

- [x] `pre-commit` clean on changed files.
- [x] Mechanism verified in a shell against the patched core: creating a receivable account, linking it as a journal default, then forcing an `account_type` recompute reproduces the exact `ValidationError`; adding the pre-link flush makes it pass.
- [x] Fresh install reproduced locally against the patched core (multi-company, with demo): **without the fix** the install crashes with the exact traceback (`post_init_hook` -> `_check_account_is_bank_journal_bank_account` raise); **with the fix** `account_payment_loan` installs clean (registry loads, no `ValidationError`).
- [ ] Full fresh build in runbot once the core update is incorporated into the image.

Internal reference: https://www.adhoc.inc/odoo/helpdesk.ticket/123467