### PR TITLE
[IMP] account_payment_pro: reusable demo data and common test classes

### DIFF
--- a/account_payment_pro/__init__.py
+++ b/account_payment_pro/__init__.py
@@ -1,3 +1,4 @@
+from . import demo
 from . import models
 from . import wizards
 

--- a/account_payment_pro/__manifest__.py
+++ b/account_payment_pro/__manifest__.py
@@ -30,6 +30,8 @@
         "views/res_company_setting.xml",
         "views/report_payment_receipt_template.xml",
     ],
-    "demo": [],
+    "demo": [
+        "demo/account_payment_pro_demo.xml",
+    ],
     "post_init_hook": "_post_init_hooks",
 }

--- a/account_payment_pro/demo/__init__.py
+++ b/account_payment_pro/demo/__init__.py
@@ -1,0 +1,1 @@
+from . import account_payment_pro_demo

--- a/account_payment_pro/demo/account_payment_pro_demo.py
+++ b/account_payment_pro/demo/account_payment_pro_demo.py
@@ -1,0 +1,67 @@
+import logging
+
+from odoo import api, models
+
+_logger = logging.getLogger(__name__)
+
+
+# pylint: disable=consider-merging-classes-inherited
+# pylint: disable=R8180
+class AccountChartTemplate(models.AbstractModel):
+    _inherit = "account.chart.template"
+
+    @api.model
+    def _install_account_payment_pro_demo(self, companies=None):
+        """Load account_payment_pro demo data for the given companies.
+
+        Idempotent: xml_ids are company-prefixed by ``_load_data``
+        (``account.<company_id>_<xml_id>``) and stored with noupdate, so
+        calling it again (e.g. from a test setUpClass) does not duplicate
+        records. Reusable from tests via ``PaymentProCommon``.
+        """
+        for company in companies if companies is not None else self.env.company:
+            _logger.info("Creating account_payment_pro demo data for company %s", company.name)
+            template = self.with_company(company).sudo()
+            data = template._account_payment_pro_demo_data()
+            for journal_vals in data["account.journal"].values():
+                journal_vals["company_id"] = company.id
+            template._load_data(data)
+
+    @api.model
+    def _account_payment_pro_demo_data(self):
+        """Demo records, mapping {model: {xml_id: values}} for ``_load_data``."""
+        return {
+            "res.partner": {
+                "demo_partner_ri": {
+                    "name": "RI Partner (demo)",
+                    "vat": "34278580484",
+                    "country_id": "base.ar",
+                },
+            },
+            "product.product": {
+                "demo_product": {
+                    "name": "Payment Pro Demo Service",
+                    "type": "service",
+                    "list_price": 100.0,
+                },
+            },
+            "account.journal": {
+                "demo_bank_journal": {
+                    "name": "Demo Bank",
+                    "type": "bank",
+                    "code": "DBNK",
+                },
+                "demo_sale_journal": {
+                    "name": "Demo Sales",
+                    "type": "sale",
+                    "code": "DSALE",
+                    "l10n_latam_use_documents": False,
+                },
+                "demo_purchase_journal": {
+                    "name": "Demo Purchases",
+                    "type": "purchase",
+                    "code": "DPUR",
+                    "l10n_latam_use_documents": False,
+                },
+            },
+        }

--- a/account_payment_pro/demo/account_payment_pro_demo.xml
+++ b/account_payment_pro/demo/account_payment_pro_demo.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <function model="account.chart.template" name="_install_account_payment_pro_demo"/>
+</odoo>

--- a/account_payment_pro/tests/__init__.py
+++ b/account_payment_pro/tests/__init__.py
@@ -1,5 +1,7 @@
 from . import (
+    common,
     test_account_paymet_pro_unit_test,
+    test_demo_data,
     test_internal_transfer_multimoneda,
     test_pay_now,
     test_payment_multimoneda,

--- a/account_payment_pro/tests/common.py
+++ b/account_payment_pro/tests/common.py
@@ -1,0 +1,72 @@
+from odoo import Command, fields
+from odoo.tests import TransactionCase
+
+
+class PaymentProCommon(TransactionCase):
+    """Structural data shared by the account-payment branch test suites.
+
+    Installs the account_payment_pro demo data for the test company and
+    exposes the records as class attributes. Downstream modules inherit
+    from this class and add their own demo on top. Edge-case records
+    belong to each test with .create().
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.today = fields.Date.today()
+        cls.company = cls.env.company
+        cls.company.use_payment_pro = True
+        cls.chart_template = cls.env["account.chart.template"].with_company(cls.company)
+        cls.chart_template._install_account_payment_pro_demo(cls.company)
+        cls.partner_ri = cls.chart_template.ref("demo_partner_ri")
+        cls.product = cls.chart_template.ref("demo_product")
+        cls.bank_journal = cls.chart_template.ref("demo_bank_journal")
+        cls.sale_journal = cls.chart_template.ref("demo_sale_journal")
+        cls.purchase_journal = cls.chart_template.ref("demo_purchase_journal")
+        cls._setup_payment_accounts(cls.bank_journal)
+
+    @classmethod
+    def _setup_payment_accounts(cls, journal, account=None):
+        """Set a payment account on the journal's method lines missing one,
+        so posting a payment generates a journal entry right away (without
+        it Odoo defers the entry until bank matching)."""
+        account = account or cls.env["account.account"].search(
+            [("company_ids", "=", cls.company.id), ("account_type", "=", "asset_current")], limit=1
+        )
+        lines = journal.inbound_payment_method_line_ids + journal.outbound_payment_method_line_ids
+        lines.filtered(lambda line: not line.payment_account_id).payment_account_id = account
+
+    def _create_invoice(
+        self, move_type="out_invoice", amount=100.0, currency=None, journal=None, partner=None, date=None, post=True
+    ):
+        """Minimal invoice/refund on the demo journals, posted by default."""
+        if journal is None:
+            journal = self.purchase_journal if move_type.startswith("in_") else self.sale_journal
+        vals = {
+            "move_type": move_type,
+            "partner_id": (partner or self.partner_ri).id,
+            "invoice_date": date or self.today,
+            "journal_id": journal.id,
+            "company_id": self.company.id,
+            "invoice_line_ids": [
+                Command.create(
+                    {
+                        "product_id": self.product.id,
+                        "quantity": 1,
+                        "price_unit": amount,
+                    }
+                ),
+            ],
+        }
+        if currency is not None:
+            vals["currency_id"] = currency.id
+        move = self.env["account.move"].create(vals)
+        if post:
+            move.action_post()
+        return move
+
+    def _get_debt_lines(self, move, account_type=None):
+        """Receivable/payable lines of a move (the ones a payment can pay)."""
+        account_types = [account_type] if account_type else ["asset_receivable", "liability_payable"]
+        return move.line_ids.filtered(lambda line: line.account_id.account_type in account_types)

--- a/account_payment_pro/tests/test_account_paymet_pro_unit_test.py
+++ b/account_payment_pro/tests/test_account_paymet_pro_unit_test.py
@@ -1,37 +1,18 @@
 from datetime import timedelta
 
-from odoo import Command, fields
-from odoo.tests import common, tagged
+from odoo import Command
+from odoo.tests import tagged
+
+from .common import PaymentProCommon
 
 
 @tagged("post_install", "-at_install")
-class TestAccountPaymentProUnitTest(common.TransactionCase):
+class TestAccountPaymentProUnitTest(PaymentProCommon):
     @classmethod
     def setUpClass(cls):
-        super(TestAccountPaymentProUnitTest, cls).setUpClass()
-        cls.today = fields.Date.today()
-        cls.ar = ar = cls.env.ref("base.ar")
-
-        cls.company = cls.env.company
-        cls.company_bank_journal = cls.env["account.journal"].search(
-            [("company_id", "=", cls.company.id), ("type", "=", "bank")], limit=1
-        )
-        # Configurar cuentas outstanding en el diario de banco para que al postear
-        # se genere asiento contable (sin esto Odoo no crea journal entry)
-        outstanding_account = cls.env["account.account"].search(
-            [("company_ids", "=", cls.company.id), ("account_type", "=", "asset_current")], limit=1
-        )
-        if outstanding_account:
-            for pml in cls.company_bank_journal.inbound_payment_method_line_ids:
-                if not pml.payment_account_id:
-                    pml.payment_account_id = outstanding_account
-            for pml in cls.company_bank_journal.outbound_payment_method_line_ids:
-                if not pml.payment_account_id:
-                    pml.payment_account_id = outstanding_account
-        cls.company_journal = cls.env["account.journal"].search(
-            [("company_id", "=", cls.company.id), ("type", "=", "sale")], limit=1
-        )
-        cls.company.use_payment_pro = True
+        super().setUpClass()
+        # Tasas históricas de EUR: escenario propio de esta suite (congelamiento
+        # de accounting_rate), no de la Common
         cls.eur_currency = cls.env["res.currency"].with_context(active_test=False).search([("name", "=", "EUR")])
         cls.eur_currency.active = True
         cls.rates = cls.env["res.currency.rate"].create(
@@ -50,32 +31,12 @@ class TestAccountPaymentProUnitTest(common.TransactionCase):
                 },
             ]
         )
-        cls.partner_ri = cls.env["res.partner"].create(dict(name="RI Partner", vat="34278580484", country_id=ar.id))
 
     def test_create_payment_with_a_date_rate_then_change_rate(self):
-        invoice = self.env["account.move"].create(
-            {
-                "partner_id": self.partner_ri.id,
-                "invoice_date": self.today - timedelta(days=14),
-                "move_type": "out_invoice",
-                "journal_id": self.company_journal.id,
-                "company_id": self.company.id,
-                "currency_id": self.eur_currency.id,
-                "invoice_line_ids": [
-                    Command.create(
-                        {
-                            "product_id": self.env.ref("product.product_product_16").id,
-                            "quantity": 1,
-                            "price_unit": 100,
-                        }
-                    ),
-                ],
-            }
-        )
-        invoice.action_post()
+        invoice = self._create_invoice(currency=self.eur_currency, date=self.today - timedelta(days=14))
 
         vals = {
-            "journal_id": self.company_bank_journal.id,
+            "journal_id": self.bank_journal.id,
             "amount": invoice.amount_total,
             "currency_id": self.eur_currency.id,
             "date": self.today - timedelta(days=1),
@@ -121,30 +82,11 @@ class TestAccountPaymentProUnitTest(common.TransactionCase):
 
     def test_action_draft_unreconciles_payment(self):
         """Test that action_draft removes partial reconciliations when going back to draft"""
-        # Create invoice
-        invoice = self.env["account.move"].create(
-            {
-                "partner_id": self.partner_ri.id,
-                "invoice_date": self.today,
-                "move_type": "out_invoice",
-                "journal_id": self.company_journal.id,
-                "company_id": self.company.id,
-                "invoice_line_ids": [
-                    Command.create(
-                        {
-                            "product_id": self.env.ref("product.product_product_16").id,
-                            "quantity": 1,
-                            "price_unit": 100,
-                        }
-                    ),
-                ],
-            }
-        )
-        invoice.action_post()
+        invoice = self._create_invoice()
 
         # Create and post payment
         vals = {
-            "journal_id": self.company_bank_journal.id,
+            "journal_id": self.bank_journal.id,
             "amount": invoice.amount_total,
             "date": self.today,
         }
@@ -159,7 +101,6 @@ class TestAccountPaymentProUnitTest(common.TransactionCase):
         partials_before = payment_lines.mapped("matched_debit_ids") | payment_lines.mapped("matched_credit_ids")
 
         # Verify that partial reconciliations exist
-        # TODO improve. for this to work, saas_client_adhoc is needed to be installed (For setup of journal)
         self.assertTrue(partials_before, "There should be partial reconciliations after posting the payment")
         self.assertTrue(payment.move_id.posted_before, "posted_before should be True after posting")
 
@@ -199,35 +140,14 @@ class TestAccountPaymentProUnitTest(common.TransactionCase):
         """Pago de tipo inbound + supplier (nota de crédito de proveedor / reembolso).
         selected_debt, to_pay_amount y payment_difference deben calcularse
         correctamente con valores positivos."""
-        purchase_journal = self.env["account.journal"].search(
-            [("company_id", "=", self.company.id), ("type", "=", "purchase")], limit=1
-        )
-        # Crear nota de crédito de proveedor (in_refund genera débito en AP → amount_residual > 0)
-        credit_note = self.env["account.move"].create(
-            {
-                "partner_id": self.partner_ri.id,
-                "invoice_date": self.today,
-                "move_type": "in_refund",
-                "journal_id": purchase_journal.id,
-                "company_id": self.company.id,
-                "invoice_line_ids": [
-                    Command.create(
-                        {
-                            "product_id": self.env.ref("product.product_product_16").id,
-                            "quantity": 1,
-                            "price_unit": 500,
-                        }
-                    ),
-                ],
-            }
-        )
-        credit_note.action_post()
+        # Nota de crédito de proveedor (in_refund genera débito en AP → amount_residual > 0)
+        credit_note = self._create_invoice(move_type="in_refund", amount=500)
 
         # payment_type=inbound con partner_type=supplier (caso invertido)
-        debt_lines = credit_note.line_ids.filtered(lambda l: l.account_id.account_type == "liability_payable")
+        debt_lines = self._get_debt_lines(credit_note, "liability_payable")
         payment = self.env["account.payment"].create(
             {
-                "journal_id": self.company_bank_journal.id,
+                "journal_id": self.bank_journal.id,
                 "partner_id": self.partner_ri.id,
                 "partner_type": "supplier",
                 "payment_type": "inbound",
@@ -257,32 +177,14 @@ class TestAccountPaymentProUnitTest(common.TransactionCase):
         """Pago de tipo outbound + customer (nota de crédito a cliente / reembolso).
         selected_debt, to_pay_amount y payment_difference deben calcularse
         correctamente con valores positivos."""
-        # Crear nota de crédito de cliente (genera crédito en AR → amount_residual < 0)
-        credit_note = self.env["account.move"].create(
-            {
-                "partner_id": self.partner_ri.id,
-                "invoice_date": self.today,
-                "move_type": "out_refund",
-                "journal_id": self.company_journal.id,
-                "company_id": self.company.id,
-                "invoice_line_ids": [
-                    Command.create(
-                        {
-                            "product_id": self.env.ref("product.product_product_16").id,
-                            "quantity": 1,
-                            "price_unit": 300,
-                        }
-                    ),
-                ],
-            }
-        )
-        credit_note.action_post()
+        # Nota de crédito de cliente (genera crédito en AR → amount_residual < 0)
+        credit_note = self._create_invoice(move_type="out_refund", amount=300)
 
         # payment_type=outbound con partner_type=customer (caso invertido)
-        debt_lines = credit_note.line_ids.filtered(lambda l: l.account_id.account_type == "asset_receivable")
+        debt_lines = self._get_debt_lines(credit_note, "asset_receivable")
         payment = self.env["account.payment"].create(
             {
-                "journal_id": self.company_bank_journal.id,
+                "journal_id": self.bank_journal.id,
                 "partner_id": self.partner_ri.id,
                 "partner_type": "customer",
                 "payment_type": "outbound",
@@ -311,34 +213,13 @@ class TestAccountPaymentProUnitTest(common.TransactionCase):
     def test_reversed_payment_type_post(self):
         """Verificar que pagos con payment_type invertido se pueden postear
         y concilian la deuda correctamente."""
-        purchase_journal = self.env["account.journal"].search(
-            [("company_id", "=", self.company.id), ("type", "=", "purchase")], limit=1
-        )
         # Nota de crédito de proveedor (in_refund genera débito en AP → amount_residual > 0)
-        credit_note = self.env["account.move"].create(
-            {
-                "partner_id": self.partner_ri.id,
-                "invoice_date": self.today,
-                "move_type": "in_refund",
-                "journal_id": purchase_journal.id,
-                "company_id": self.company.id,
-                "invoice_line_ids": [
-                    Command.create(
-                        {
-                            "product_id": self.env.ref("product.product_product_16").id,
-                            "quantity": 1,
-                            "price_unit": 1000,
-                        }
-                    ),
-                ],
-            }
-        )
-        credit_note.action_post()
+        credit_note = self._create_invoice(move_type="in_refund", amount=1000)
 
-        debt_lines = credit_note.line_ids.filtered(lambda l: l.account_id.account_type == "liability_payable")
+        debt_lines = self._get_debt_lines(credit_note, "liability_payable")
         payment = self.env["account.payment"].create(
             {
-                "journal_id": self.company_bank_journal.id,
+                "journal_id": self.bank_journal.id,
                 "partner_id": self.partner_ri.id,
                 "partner_type": "supplier",
                 "payment_type": "inbound",

--- a/account_payment_pro/tests/test_demo_data.py
+++ b/account_payment_pro/tests/test_demo_data.py
@@ -1,0 +1,15 @@
+from odoo.tests import tagged
+
+from .common import PaymentProCommon
+
+
+@tagged("post_install", "-at_install")
+class TestPaymentProDemoData(PaymentProCommon):
+    def test_install_demo_idempotent(self):
+        """A second install must not duplicate records nor xml_ids."""
+        self.chart_template._install_account_payment_pro_demo(self.company)
+        count = self.env["ir.model.data"].search_count(
+            [("module", "=", "account"), ("name", "=", f"{self.company.id}_demo_partner_ri")]
+        )
+        self.assertEqual(count, 1, "el xml_id de la demo se duplicó en ir.model.data")
+        self.assertEqual(self.chart_template.ref("demo_partner_ri"), self.partner_ri)

--- a/account_payment_pro_receiptbook/tests/common.py
+++ b/account_payment_pro_receiptbook/tests/common.py
@@ -1,0 +1,17 @@
+from odoo.addons.account_payment_pro.tests.common import PaymentProCommon
+
+
+class ReceiptbookCommon(PaymentProCommon):
+    """PaymentProCommon plus receiptbooks enabled on the test company.
+
+    The receiptbooks themselves are module data created when
+    ``use_receiptbook`` is enabled, so there is no extra demo to install.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company.use_receiptbook = True
+        cls.receiptbook = cls.env["account.payment.receiptbook"].search(
+            [("company_id", "=", cls.company.id), ("name", "=", "Customer Receipts")]
+        )

--- a/account_payment_pro_receiptbook/tests/test_account_paymet_pro_receiptbook_unit_test.py
+++ b/account_payment_pro_receiptbook/tests/test_account_paymet_pro_receiptbook_unit_test.py
@@ -1,111 +1,32 @@
 import json
 
-from odoo import Command, fields
-from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.exceptions import UserError, ValidationError
 from odoo.tests import tagged
 
+from .common import ReceiptbookCommon
+
 
 @tagged("post_install", "-at_install")
-class TestAccountPaymentProReceiptbookUnitTest(AccountTestInvoicingCommon):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-
-    @classmethod
-    def get_default_groups(cls):
-        groups = super().get_default_groups()
-        product_mgmt_group = cls.env.ref(
-            "product_management_group.group_products_management",
-            raise_if_not_found=False,
-        )
-        if product_mgmt_group:
-            groups |= product_mgmt_group
-        return groups
-
-    @classmethod
-    def setup_armageddon_tax(cls, tax_name, company_data, **kwargs):
-        # Ensure a tax group exists for the company's fiscal country so that
-        # _compute_tax_group_id (which searches without sudo) can find one.
-        # This is necessary when running at_install tests against a localised
-        # company where country/fiscal-country state becomes inconsistent during
-        # AccountTestInvoicingCommon.setup_independent_company.
-        company = company_data["company"]
-        fiscal_country = company.account_fiscal_country_id or company.country_id
-        TaxGroup = cls.env["account.tax.group"].sudo()
-        for country_id in ([fiscal_country.id] if fiscal_country else []) + [False]:
-            if not TaxGroup.search(
-                [
-                    ("company_id", "parent_of", company.ids),
-                    ("country_id", "=", country_id),
-                ],
-                limit=1,
-            ):
-                TaxGroup.create(
-                    {
-                        "name": "Test Tax Group",
-                        "company_id": company.id,
-                        "country_id": country_id,
-                    }
-                )
-        return super().setup_armageddon_tax(tax_name, company_data, **kwargs)
-
-    def setUp(self):
-        super().setUp()
-        self.today = fields.Date.today()
-        self.company = self.env.company
-        self.company_bank_journal = self.env["account.journal"].search(
-            [("company_id", "=", self.company.id), ("type", "=", "bank")], limit=1
-        )
-        self.company_sale_journal = self.env["account.journal"].search(
-            [("company_id", "=", self.company.id), ("type", "=", "sale")], limit=1
-        )
-        self.company.use_payment_pro = True
-        self.company.use_receiptbook = True
-        ar = self.env.ref("base.ar")
-        self.partner_ri = self.env["res.partner"].create(dict(name="RI Partner", vat="34278580484", country_id=ar.id))
-        self.receiptbook = self.env["account.payment.receiptbook"].search(
-            [("company_id", "=", self.company.id), ("name", "=", "Customer Receipts")]
-        )
-
+class TestAccountPaymentProReceiptbookUnitTest(ReceiptbookCommon):
     def test_create_payment_with_receiptbook(self):
-        invoice = self.env["account.move"].create(
-            {
-                "partner_id": self.partner_ri.id,
-                "invoice_date": self.today,
-                "move_type": "out_invoice",
-                "journal_id": self.company_sale_journal.id,
-                "company_id": self.company.id,
-                "invoice_line_ids": [
-                    Command.create(
-                        {
-                            "product_id": self.env.ref("product.product_product_16").id,
-                            "quantity": 1,
-                            "price_unit": 100,
-                        }
-                    ),
-                ],
-            }
-        )
-        invoice.action_post()
-        receiptbook_id = self.env["account.payment.receiptbook"].search(
-            [("company_id", "=", self.company.id), ("name", "=", "Customer Receipts")]
-        )
-        name = "%s %s%s" % (
-            receiptbook_id.document_type_id.doc_code_prefix,
-            receiptbook_id.prefix,
-            str(1).zfill(8),
+        invoice = self._create_invoice()
+        # Próximo número de la secuencia del receiptbook antes de postear
+        # (robusto al orden de ejecución: la secuencia estándar no rollbackea)
+        expected_name = "%s %s%s" % (
+            self.receiptbook.document_type_id.doc_code_prefix,
+            self.receiptbook.prefix,
+            str(self.receiptbook.sequence_id.number_next_actual).zfill(8),
         )
 
         vals = {
-            "journal_id": self.company_bank_journal.id,
+            "journal_id": self.bank_journal.id,
             "amount": invoice.amount_total,
             "date": self.today,
         }
         action_context = invoice.action_register_payment()["context"]
         payment = self.env["account.payment"].with_context(**action_context).create(vals)
         payment.action_post()
-        self.assertEqual(payment.name, name, "no se tomo la secuencia correcta del pago")
+        self.assertEqual(payment.name, expected_name, "no se tomo la secuencia correcta del pago")
 
     def test_payment_amount_update(self):
         """Test creating a payment, posting it, resetting to draft, updating amount, and validating name."""
@@ -113,8 +34,8 @@ class TestAccountPaymentProReceiptbookUnitTest(AccountTestInvoicingCommon):
             {
                 "amount": 100,
                 "payment_type": "inbound",
-                "partner_id": self.partner_a.id,
-                "journal_id": self.company_bank_journal.id,
+                "partner_id": self.partner_ri.id,
+                "journal_id": self.bank_journal.id,
                 "date": self.today,
                 "company_id": self.company.id,
                 "receiptbook_id": self.receiptbook.id,
@@ -146,31 +67,20 @@ class TestAccountPaymentProReceiptbookUnitTest(AccountTestInvoicingCommon):
         Create 2 payments with bank and cash journals, post them,
         try to resequence the first one with the name of the second and validate ValidationError.
         """
-        # Search for cash journal (fallback to searching/creating if company_data entry is missing)
-        cash_journal = False
-        try:
-            cash_journal = self.company_data.get("default_journal_cash")
-        except Exception:
-            cash_journal = False
-        if not cash_journal:
-            cash_journal = self.env["account.journal"].search(
-                [("company_id", "=", self.company.id), ("type", "=", "cash")], limit=1
-            )
+        cash_journal = self.env["account.journal"].search(
+            [("company_id", "=", self.company.id), ("type", "=", "cash")], limit=1
+        )
         if not cash_journal:
             cash_journal = self.env["account.journal"].create(
                 {"type": "cash", "name": "Cash", "company_id": self.company.id}
             )
-        self.assertTrue(self.company_bank_journal, "No bank journal found")
-        self.assertTrue(cash_journal, "No cash journal found")
-        if cash_journal:
-            (cash_journal.outbound_payment_method_line_ids + cash_journal.inbound_payment_method_line_ids).write(
-                {"payment_account_id": cash_journal.default_account_id.id}
-            )
-
-        (
-            self.company_bank_journal.outbound_payment_method_line_ids
-            + self.company_bank_journal.inbound_payment_method_line_ids
-        ).write({"payment_account_id": self.company_bank_journal.default_account_id.id})
+        # Pagos directos contra la cuenta del diario (sin outstanding) a propósito
+        (cash_journal.outbound_payment_method_line_ids + cash_journal.inbound_payment_method_line_ids).write(
+            {"payment_account_id": cash_journal.default_account_id.id}
+        )
+        (self.bank_journal.outbound_payment_method_line_ids + self.bank_journal.inbound_payment_method_line_ids).write(
+            {"payment_account_id": self.bank_journal.default_account_id.id}
+        )
 
         # Create first payment (bank)
         payment1 = self.env["account.payment"].create(
@@ -178,7 +88,7 @@ class TestAccountPaymentProReceiptbookUnitTest(AccountTestInvoicingCommon):
                 "amount": 100,
                 "payment_type": "inbound",
                 "partner_id": self.partner_ri.id,
-                "journal_id": self.company_bank_journal.id,
+                "journal_id": self.bank_journal.id,
                 "date": self.today,
                 "company_id": self.company.id,
                 "receiptbook_id": self.receiptbook.id,


### PR DESCRIPTION
## What

Introduces reusable test data for the account-payment branch, defined once and shared by test suites instead of being rebuilt per file:

- **`account_payment_pro/demo/`**: demo data in Python (partner, product, bank/sale/purchase journals) loaded through `account.chart.template._load_data`. Xml_ids get company-prefixed (`account.<company_id>_<xml_id>`) and stored with `noupdate`, so the installer is idempotent and multi-company safe. Declared in the manifest `demo` section via `<function>`, so Odoo/Runbot load it automatically in demo mode — no hooks.
- **`account_payment_pro/tests/common.py`**: `PaymentProCommon` installs that demo for the test company in `setUpClass`, exposes the records as class attributes (`cls.partner_ri`, `cls.bank_journal`, ...) and provides the helpers the suites were duplicating (`_create_invoice`, `_get_debt_lines`, `_setup_payment_accounts`).
- **`account_payment_pro_receiptbook/tests/common.py`**: `ReceiptbookCommon(PaymentProCommon)` — downstream modules inherit the base setup and add their own on top.

Two suites are migrated as pilot: the unit test suite of `account_payment_pro` (-119 lines, -34%) and the receiptbook suite (-90 lines). The latter also drops the `get_default_groups` / `setup_armageddon_tax` workarounds that were only needed to survive `AccountTestInvoicingCommon` setup on full installations.

## Backwards compatibility

Adoption is incremental by design: no other suite is touched (`test_pay_now`, the multicurrency family and its cross-module inheritors keep working unchanged). Existing `.create()`-based tests remain valid; suites migrate opportunistically when touched for other reasons.

## Notes for review

- The receiptbook sequence assertion now derives the expected name from `sequence_id.number_next_actual` instead of hardcoding `00000001`: with the setup moved to `setUpClass`, standard sequences do not roll back between tests of the same class, so the old assertion would have been execution-order dependent.
- An idempotency test guards the demo installer (second call must not duplicate `ir.model.data` entries).
- Manifest version bump intentionally left out of this PR.

## Test plan

Fresh database with demo data:

```
odoo -d <db> --stop-after-init --with-demo \
  -i account_payment_pro,account_payment_pro_receiptbook \
  --test-tags /account_payment_pro,/account_payment_pro_receiptbook
```

Result: `0 failed, 0 error(s) of 16 tests`. The demo installer ran 5 times in that run (module install + each setUpClass) without duplicating records. The multicurrency suites skip on a vanilla DB (`TestArCommon` requires `l10n_ar`) — they run on the Runbot build.

Internal task: 67106
