### PR TITLE
[IMP] l10n_latam_check_ux, account_payment_pro: check payments test harness

### DIFF
--- a/account_payment_pro/tests/__init__.py
+++ b/account_payment_pro/tests/__init__.py
@@ -1,5 +1,6 @@
 from . import (
     test_account_paymet_pro_unit_test,
+    test_checks_payment_pro,
     test_internal_transfer_multimoneda,
     test_pay_now,
     test_payment_multimoneda,

--- a/account_payment_pro/tests/test_checks_payment_pro.py
+++ b/account_payment_pro/tests/test_checks_payment_pro.py
@@ -1,0 +1,293 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+"""account_payment_pro x check payments: several liquidity lines in one payment.
+
+``_prepare_move_lines_per_type`` here rewrites the liquidity and counterpart
+balances of every payment. Check payments are the only case where it receives
+more than one liquidity line, so this is where the two features meet: the FX
+rate, the write-off and the counterpart currency must all still add up when a
+payment carries one line per check.
+
+The suite that owns the check mechanics itself lives in
+``l10n_latam_check_ux/tests``. Part of the harness of task 70884.
+"""
+
+from odoo import Command, fields
+from odoo.addons.l10n_ar.tests.common import TestArCommon
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestChecksPaymentPro(TestArCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.today = fields.Date.today()
+        cls.company = cls.company_ri
+        cls.company.use_payment_pro = True
+        cls.env = cls.env(context=dict(cls.env.context, allowed_company_ids=cls.company.ids))
+
+        cls.ars = cls.company.currency_id
+        cls.usd = cls.env["res.currency"].with_context(active_test=False).search([("name", "=", "USD")])
+        cls.usd.active = True
+        cls.env["res.currency.rate"].search(
+            [("currency_id", "=", cls.usd.id), ("company_id", "=", cls.company.id)]
+        ).unlink()
+        cls.env["res.currency.rate"].create(
+            [
+                {
+                    "name": cls.today,
+                    "currency_id": cls.usd.id,
+                    "company_id": cls.company.id,
+                    "inverse_company_rate": 1200.0,
+                },
+                {
+                    "name": fields.Date.add(cls.today, days=30),
+                    "currency_id": cls.usd.id,
+                    "company_id": cls.company.id,
+                    "inverse_company_rate": 2400.0,
+                },
+            ]
+        )
+
+        cls.partner = cls.res_partner_adhoc
+        cls.deferred_check_account = cls.env["account.account"].create(
+            {
+                "name": "Test Deferred Checks",
+                "code": "TPPDEFCHK",
+                "account_type": "asset_current",
+                "reconcile": True,
+                "company_ids": [Command.set(cls.company.ids)],
+            }
+        )
+        cls.write_off_account = cls.env["account.account"].create(
+            {
+                "name": "Test Write Off",
+                "code": "TPPWO",
+                "account_type": "expense",
+                "company_ids": [Command.set(cls.company.ids)],
+            }
+        )
+        cls.bank_journal = cls.env["account.journal"].create(
+            {"name": "Test PPro Checks Bank", "code": "TPPB", "type": "bank", "company_id": cls.company.id}
+        )
+        cls.own_checks_line = cls.env["account.payment.method.line"].create(
+            {
+                "payment_method_id": cls.env.ref("l10n_latam_check.account_payment_method_own_checks").id,
+                "name": "Own Checks",
+                "payment_account_id": cls.deferred_check_account.id,
+                "journal_id": cls.bank_journal.id,
+            }
+        )
+        cls.write_off_type = cls.env["account.write_off.type"].create(
+            {"name": "Test Write Off Type", "account_id": cls.write_off_account.id}
+        )
+
+    # ------------------------------------------------------------------
+    def _own_check_payment(self, amounts, numbers, currency=None, check_dates=None, **kwargs):
+        check_dates = check_dates or [self.today] * len(amounts)
+        vals = {
+            "payment_type": "outbound",
+            "partner_type": "supplier",
+            "partner_id": self.partner.id,
+            "journal_id": self.bank_journal.id,
+            "company_id": self.company.id,
+            "date": self.today,
+            "currency_id": (currency or self.ars).id,
+            "payment_method_line_id": self.own_checks_line.id,
+            "l10n_latam_new_check_ids": [
+                Command.create({"amount": amount, "payment_date": check_dates[i], "name": numbers[i]})
+                for i, amount in enumerate(amounts)
+            ],
+        }
+        vals.update(kwargs)
+        return self.env["account.payment"].create(vals)
+
+    def _liquidity_lines(self, payment):
+        return payment.move_id.line_ids.filtered("l10n_latam_check_ids").sorted("id")
+
+    def _counterpart_line(self, payment):
+        return payment.move_id.line_ids.filtered(
+            lambda line: line.account_id.account_type in ("liability_payable", "asset_receivable")
+        )
+
+    def assert_balanced(self, payment):
+        self.assertEqual(
+            self.company.currency_id.round(sum(payment.move_id.line_ids.mapped("balance"))),
+            0.0,
+            "Entry %s is not balanced: %s"
+            % (
+                payment.move_id.name,
+                [(line.name, line.amount_currency, line.balance) for line in payment.move_id.line_ids],
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # company currency
+    # ------------------------------------------------------------------
+    def test_multi_checks_company_currency(self):
+        payment = self._own_check_payment([20, 30, 70], ["00030001", "00030002", "00030003"])
+        payment.action_post()
+
+        self.assert_balanced(payment)
+        self.assertEqual(len(self._liquidity_lines(payment)), 3)
+        self.assertEqual(sum(self._liquidity_lines(payment).mapped("balance")), -120)
+        self.assertEqual(self._counterpart_line(payment).balance, 120)
+
+    def test_multi_checks_with_write_off(self):
+        """The write-off adds to the debt cancelled, not to the checks handed."""
+        payment = self._own_check_payment(
+            [40, 60],
+            ["00030101", "00030102"],
+            write_off_type_id=self.write_off_type.id,
+            write_off_amount=5.0,
+        )
+        payment.action_post()
+
+        self.assert_balanced(payment)
+        self.assertEqual(sum(self._liquidity_lines(payment).mapped("balance")), -100, "Checks handed: 100")
+        self.assertEqual(self._counterpart_line(payment).balance, 105, "Debt cancelled: 100 + 5 write-off")
+        write_off_line = payment.move_id.line_ids.filtered(lambda line: line.account_id == self.write_off_account)
+        self.assertEqual(write_off_line.balance, -5)
+
+    def test_uneven_amounts_are_not_redistributed(self):
+        payment = self._own_check_payment([33.33, 33.33, 33.34], ["00030201", "00030202", "00030203"])
+        payment.action_post()
+
+        self.assert_balanced(payment)
+        self.assertEqual(sorted(abs(line.balance) for line in self._liquidity_lines(payment)), [33.33, 33.33, 33.34])
+
+    # ------------------------------------------------------------------
+    # foreign currency (A != C)
+    # ------------------------------------------------------------------
+    def test_multi_checks_foreign_currency_uses_accounting_rate(self):
+        """La tasa del pago manda sobre *todas* las lineas de cheque, no solo
+        sobre la primera - tanto la tasa de la tabla como una tipeada a mano."""
+        payment = self._own_check_payment([20, 30, 70], ["00031001", "00031002", "00031003"], currency=self.usd)
+        payment.action_post()
+
+        self.assert_balanced(payment)
+        lines = self._liquidity_lines(payment)
+        self.assertEqual(len(lines), 3)
+        for line in lines:
+            self.assertEqual(line.currency_id, self.usd, "The nominal stays in the check currency")
+            self.assertEqual(
+                abs(line.balance),
+                self.company.currency_id.round(abs(line.amount_currency) / payment.accounting_rate),
+                "Every check line converts with the payment accounting rate",
+            )
+        self.assertEqual(abs(sum(lines.mapped("amount_currency"))), 120)
+        self.assertEqual(abs(sum(lines.mapped("balance"))), 144000, "120 USD at 1200 ARS")
+
+        counterpart = self._counterpart_line(payment)
+        self.assertEqual(len(counterpart), 1, "One counterpart line regardless of the number of checks")
+        self.assertEqual(abs(counterpart.balance), abs(sum(lines.mapped("balance"))))
+
+        manual = self._own_check_payment([20, 30, 70], ["00031101", "00031102", "00031103"], currency=self.usd)
+        manual.accounting_rate = 1 / 1000.0
+        manual.action_post()
+
+        self.assert_balanced(manual)
+        self.assertEqual(abs(sum(self._liquidity_lines(manual).mapped("balance"))), 120000, "120 USD at 1000 ARS")
+        for line in self._liquidity_lines(manual):
+            self.assertEqual(abs(line.balance), abs(line.amount_currency) * 1000)
+
+    def test_deferred_checks_in_foreign_currency_stay_balanced(self):
+        """Deferred checks (payment_date well after the payment date).
+
+        The rate moves between both dates; the entry must still balance and every
+        line must be converted at the payment date. NOTE: with payment_pro
+        disabled this very case fails today (BUG-2 of task 70884), because the
+        patch converts each check at its own date while the counterpart keeps the
+        payment date; payment_pro recomputes both and hides it.
+        """
+        payment = self._own_check_payment(
+            [20, 30, 70],
+            ["00031201", "00031202", "00031203"],
+            currency=self.usd,
+            check_dates=[fields.Date.add(self.today, days=40)] * 3,
+        )
+        payment.action_post()
+
+        self.assert_balanced(payment)
+        self.assertEqual(
+            abs(sum(self._liquidity_lines(payment).mapped("balance"))),
+            144000,
+            "Conversion must use the payment date rate (1200), not the check date one (2400)",
+        )
+
+    # ------------------------------------------------------------------
+    # synchronization
+    # ------------------------------------------------------------------
+    def test_amount_can_be_written_on_a_multi_check_payment_with_a_draft_move(self):
+        """Base Odoo blocks writing ``amount`` when a payment has several
+        liquidity lines. Check payments legitimately have several, so the block
+        must not apply to them: this is the single core behaviour a relocation of
+        the patch has to reproduce.
+
+        The payment is reset to draft on purpose: ``_synchronize_to_moves``
+        returns early when the move is already posted, so writing on a posted
+        payment would never reach the guard and the test would pass for the
+        wrong reason.
+        """
+        payment = self._own_check_payment([20, 30, 70], ["00032001", "00032002", "00032003"])
+        payment.action_post()
+        payment.action_draft()
+        self.assertEqual(payment.move_id.state, "draft")
+        self.assertEqual(len(self._liquidity_lines(payment)), 3, "The draft move keeps one line per check")
+
+        payment.write({"amount": 120})
+
+        self.assert_balanced(payment)
+        self.assertEqual(len(self._liquidity_lines(payment)), 3, "The check lines must survive the sync")
+        self.assertEqual(len(payment.move_id.line_ids), 4)
+
+        payment.action_post()
+        self.assert_balanced(payment)
+        self.assertEqual(len(self._liquidity_lines(payment)), 3, "Reposting keeps one line per check")
+        self.assertEqual(len(payment.move_id.line_ids), 4)
+
+    # def test_writing_amount_on_two_payments_at_once_crashes_today(self):
+    #     """EQUIVALENCE (task 70884, BUG-3).
+    #
+    #     Pins what the patched core does today: it classifies the new lines with
+    #     ``self.outstanding_account_id`` instead of ``pay.outstanding_account_id``
+    #     inside its own ``for pay in self`` loop, so writing a trigger field on
+    #     several payments whose moves are in draft and whose outstanding accounts
+    #     differ raises ``Expected singleton``. It is not check specific: any
+    #     payment reset to draft is affected.
+    #
+    #     Whether the relocation reproduces it depends on how
+    #     ``_synchronize_to_moves`` is ported: copying the patched method verbatim
+    #     keeps the crash, delegating to ``super()`` fixes it - and then this
+    #     assertion has to be inverted in that same PR.
+    #     """
+    #     other_account = self.env["account.account"].create(
+    #         {
+    #             "name": "Test Deferred Checks 2",
+    #             "code": "TPPDEFCHK2",
+    #             "account_type": "asset_current",
+    #             "reconcile": True,
+    #             "company_ids": [Command.set(self.company.ids)],
+    #         }
+    #     )
+    #     other_line = self.env["account.payment.method.line"].create(
+    #         {
+    #             "payment_method_id": self.own_checks_line.payment_method_id.id,
+    #             "name": "Own Checks 2",
+    #             "payment_account_id": other_account.id,
+    #             "journal_id": self.bank_journal.id,
+    #         }
+    #     )
+    #     first = self._own_check_payment([20, 30], ["00032301", "00032302"])
+    #     second = self._own_check_payment([20, 30], ["00032303", "00032304"])
+    #     second.payment_method_line_id = other_line
+    #     payments = first + second
+    #     payments.action_post()
+    #     payments.action_draft()
+    #     self.assertNotEqual(first.outstanding_account_id, second.outstanding_account_id)
+    #
+    #     with self.assertRaisesRegex(ValueError, "Expected singleton"):
+    #         payments.write({"amount": 50})

--- a/l10n_latam_check_ux/tests/__init__.py
+++ b/l10n_latam_check_ux/tests/__init__.py
@@ -1,2 +1,6 @@
+from . import common
 from . import test_check_transfers
 from . import test_check_payment_journal_entry
+from . import test_own_checks_ux
+from . import test_third_party_checks_ux
+from . import test_check_outstanding_consumers

--- a/l10n_latam_check_ux/tests/common.py
+++ b/l10n_latam_check_ux/tests/common.py
@@ -1,0 +1,334 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import Command, fields
+from odoo.tests import TransactionCase
+
+
+class LatamCheckCommon(TransactionCase):
+    """Self-contained check setup for the l10n_latam_check_ux suites.
+
+    Builds its own journals, payment method lines and outstanding accounts on
+    ``env.company`` with ``.create()``, so the suite does not depend on a
+    localization being installed nor on demo data.
+
+    The core ``l10n_latam_check`` tests cannot be reused: their common calls
+    ``setup_other_company(country_id=base.ar)`` twice, and creating an extra
+    Argentine company is rejected on OBA databases by
+    ``saas_client_account._check_country_currency`` ("You cannot select a
+    currency that is different from the country's currency"), so they error out
+    at ``setUpClass``. Inheriting ``AccountTestInvoicingCommon`` on its own is
+    fine - what breaks is the extra company.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.today = fields.Date.today()
+        cls.company = cls.env.company
+        cls.company_currency = cls.company.currency_id
+        cls.env = cls.env(context=dict(cls.env.context, allowed_company_ids=cls.company.ids))
+
+        cls.partner = cls.env["res.partner"].create({"name": "Check Test Partner", "vat": "30710158254"})
+        cls.bank = cls.env["res.bank"].search([], limit=1) or cls.env["res.bank"].create({"name": "Test Bank"})
+
+        # Accounts: one reconcilable outstanding account per check type + a
+        # non-reconcilable one to exercise the ux issue_state override.
+        cls.deferred_check_account = cls._create_account("TDEFCHK", "Test Deferred Checks", reconcile=True)
+        cls.third_party_account = cls._create_account("TTPCHK", "Test Third Party Checks", reconcile=True)
+        cls.manual_outstanding_account = cls._create_account("TOUTMAN", "Test Outstanding Manual", reconcile=True)
+        cls.destination_account = cls._create_account(
+            "TDEST", "Test Payable", account_type="liability_payable", reconcile=True
+        )
+        cls.receivable_account = cls._create_account(
+            "TRECV", "Test Receivable", account_type="asset_receivable", reconcile=True
+        )
+        cls.expense_account = cls._create_account("TEXP", "Test Expense", account_type="expense")
+        # internal transfers need it and it is not set on every database
+        if not cls.company.transfer_account_id:
+            cls.company.transfer_account_id = cls._create_account("TTRANSF", "Test Internal Transfer", reconcile=True)
+
+        # payment_pro rewrites the liquidity/counterpart balances of every payment
+        # when enabled, which would hide what these tests are about (the core +
+        # l10n_latam_check_ux mechanism). Its own suite covers the combination.
+        if "use_payment_pro" in cls.env["res.company"]._fields:
+            cls.company.use_payment_pro = False
+
+        cls.own_checks_method = cls.env.ref("l10n_latam_check.account_payment_method_own_checks")
+        cls.new_third_party_method = cls.env.ref("l10n_latam_check.account_payment_method_new_third_party_checks")
+        cls.in_third_party_method = cls.env.ref("l10n_latam_check.account_payment_method_in_third_party_checks")
+        cls.out_third_party_method = cls.env.ref("l10n_latam_check.account_payment_method_out_third_party_checks")
+        cls.return_third_party_method = cls.env.ref("l10n_latam_check.account_payment_method_return_third_party_checks")
+        cls.manual_out_method = cls.env.ref("account.account_payment_method_manual_out")
+        cls.manual_in_method = cls.env.ref("account.account_payment_method_manual_in")
+
+        # Bank journal issuing own checks (+ manual method, needed by the debit wizard).
+        cls.bank_journal = cls.env["account.journal"].create(
+            {
+                "name": "Test Checks Bank",
+                "code": "TCHKB",
+                "type": "bank",
+                "company_id": cls.company.id,
+                "check_add_debit_button": True,
+            }
+        )
+        cls.own_checks_line = cls._add_method_line(
+            cls.bank_journal, cls.own_checks_method, "Own Checks", cls.deferred_check_account
+        )
+        cls.manual_out_line = cls._add_method_line(
+            cls.bank_journal, cls.manual_out_method, "Manual", cls.manual_outstanding_account
+        )
+        cls._add_method_line(cls.bank_journal, cls.manual_in_method, "Manual", cls.manual_outstanding_account)
+        # needed to move a deposited check out of the bank journal (rejections)
+        cls._add_method_line(
+            cls.bank_journal, cls.return_third_party_method, "Return Third Party Checks", cls.third_party_account
+        )
+
+        # Two third party check journals (a regular one and the rejected one).
+        cls.third_party_journal = cls._create_third_party_journal("Test Third Party Checks", "TTPC")
+        cls.rejected_journal = cls._create_third_party_journal("Test Rejected Checks", "TRJC")
+        cls.new_third_party_line = cls._get_method_line(cls.third_party_journal, "new_third_party_checks")
+        cls.in_third_party_line = cls._get_method_line(cls.third_party_journal, "in_third_party_checks")
+        cls.out_third_party_line = cls._get_method_line(cls.third_party_journal, "out_third_party_checks")
+
+        # Foreign currency with a rate on the payment date and a *different* rate
+        # 30 days later, so deferred checks (payment_date > date) can tell apart
+        # a conversion done at the payment date from one done at the check date.
+        cls.foreign_currency = cls._setup_foreign_currency()
+
+    # ------------------------------------------------------------------
+    # setup helpers
+    # ------------------------------------------------------------------
+    @classmethod
+    def _create_account(cls, code, name, account_type="asset_current", reconcile=False):
+        return cls.env["account.account"].create(
+            {
+                "name": name,
+                "code": code,
+                "account_type": account_type,
+                "reconcile": reconcile,
+                "company_ids": [Command.set(cls.company.ids)],
+            }
+        )
+
+    @classmethod
+    def _add_method_line(cls, journal, payment_method, name, account):
+        field = (
+            "inbound_payment_method_line_ids"
+            if payment_method.payment_type == "inbound"
+            else "outbound_payment_method_line_ids"
+        )
+        journal.write(
+            {
+                field: [
+                    Command.create(
+                        {"payment_method_id": payment_method.id, "name": name, "payment_account_id": account.id}
+                    )
+                ]
+            }
+        )
+        return journal[field].filtered(lambda line: line.payment_method_id == payment_method)[-1]
+
+    @classmethod
+    def _create_third_party_journal(cls, name, code):
+        journal = cls.env["account.journal"].create(
+            {"name": name, "code": code, "type": "cash", "company_id": cls.company.id}
+        )
+        for method, label in (
+            (cls.new_third_party_method, "New Third Party Checks"),
+            (cls.in_third_party_method, "Existing Third Party Checks"),
+            (cls.out_third_party_method, "Deliver Third Party Checks"),
+        ):
+            cls._add_method_line(journal, method, label, cls.third_party_account)
+        return journal
+
+    @classmethod
+    def _get_method_line(cls, journal, code):
+        lines = journal.inbound_payment_method_line_ids + journal.outbound_payment_method_line_ids
+        return lines.filtered(lambda line: line.code == code)[:1]
+
+    @classmethod
+    def _setup_foreign_currency(cls):
+        """Currency other than the company one, created instead of reused.
+
+        Which currencies exist and which are active depends on the database (a
+        ``search`` here silently returns nothing when the candidates are
+        archived), and the rates have to be exactly these two: one today and a
+        different one 30 days later, so a deferred check can tell apart a
+        conversion made at the payment date from one made at the check date.
+        """
+        currency = cls.env["res.currency"].create(
+            {
+                "name": "TCK",
+                "symbol": "T$",
+                "rounding": 0.01,
+            }
+        )
+        cls.env["res.currency.rate"].create(
+            [
+                {
+                    "name": cls.today,
+                    "currency_id": currency.id,
+                    "company_id": cls.company.id,
+                    "rate": 1 / 100.0,
+                },
+                {
+                    "name": fields.Date.add(cls.today, days=30),
+                    "currency_id": currency.id,
+                    "company_id": cls.company.id,
+                    "rate": 1 / 200.0,
+                },
+            ]
+        )
+        return currency
+
+    # ------------------------------------------------------------------
+    # payment factories
+    # ------------------------------------------------------------------
+    def _new_check_vals(self, amount, number=None, payment_date=None, issuer=False):
+        vals = {"amount": amount, "payment_date": payment_date or self.today, "name": number}
+        if issuer:
+            vals.update({"issuer_vat": "30710158254", "bank_id": self.bank.id})
+        return vals
+
+    def _create_own_check_payment(
+        self, amounts, numbers=None, currency=None, date=None, check_dates=None, method_line=None
+    ):
+        """Outbound payment issuing one own check per amount.
+
+        ``method_line`` (and its journal) is set at create time on purpose: the
+        unique index on the check covers ``payment_method_line_id``, so moving a
+        payment to another checkbook afterwards would leave the check colliding
+        with its siblings until the write lands.
+        """
+        numbers = numbers or [None] * len(amounts)
+        check_dates = check_dates or [date or self.today] * len(amounts)
+        method_line = method_line or self.own_checks_line
+        return self.env["account.payment"].create(
+            {
+                "payment_type": "outbound",
+                "partner_type": "supplier",
+                "partner_id": self.partner.id,
+                "journal_id": method_line.journal_id.id,
+                "company_id": self.company.id,
+                "date": date or self.today,
+                "currency_id": (currency or self.company_currency).id,
+                "payment_method_line_id": method_line.id,
+                "l10n_latam_new_check_ids": [
+                    Command.create(self._new_check_vals(amount, numbers[i], check_dates[i]))
+                    for i, amount in enumerate(amounts)
+                ],
+            }
+        )
+
+    def _receive_third_party_checks(self, amounts, numbers=None, currency=None, date=None):
+        """Inbound payment receiving new third party checks."""
+        numbers = numbers or [None] * len(amounts)
+        return self.env["account.payment"].create(
+            {
+                "payment_type": "inbound",
+                "partner_type": "customer",
+                "partner_id": self.partner.id,
+                "journal_id": self.third_party_journal.id,
+                "company_id": self.company.id,
+                "date": date or self.today,
+                "currency_id": (currency or self.company_currency).id,
+                "payment_method_line_id": self.new_third_party_line.id,
+                "l10n_latam_new_check_ids": [
+                    Command.create(self._new_check_vals(amount, numbers[i], issuer=True))
+                    for i, amount in enumerate(amounts)
+                ],
+            }
+        )
+
+    def _deliver_third_party_checks(self, checks, date=None):
+        """Outbound payment endorsing existing third party checks to a vendor."""
+        return self.env["account.payment"].create(
+            {
+                "payment_type": "outbound",
+                "partner_type": "supplier",
+                "partner_id": self.partner.id,
+                "journal_id": self.third_party_journal.id,
+                "company_id": self.company.id,
+                "date": date or self.today,
+                "payment_method_line_id": self.out_third_party_line.id,
+                "l10n_latam_move_check_ids": [Command.set(checks.ids)],
+            }
+        )
+
+    def _create_debt_move(self, amount, account=None, date=None):
+        """Posted journal entry with a payable/receivable line the payment can reconcile with."""
+        account = account or self.destination_account
+        counterpart = self.expense_account
+        move = self.env["account.move"].create(
+            {
+                "move_type": "entry",
+                "date": date or self.today,
+                "company_id": self.company.id,
+                "line_ids": [
+                    Command.create(
+                        {
+                            "name": "debt",
+                            "account_id": account.id,
+                            "partner_id": self.partner.id,
+                            "credit": amount,
+                        }
+                    ),
+                    Command.create({"name": "debt cp", "account_id": counterpart.id, "debit": amount}),
+                ],
+            }
+        )
+        move.action_post()
+        return move.line_ids.filtered(lambda line: line.account_id == account)
+
+    # ------------------------------------------------------------------
+    # assertion helpers
+    # ------------------------------------------------------------------
+    def _check_lines(self, payment):
+        """Liquidity lines carrying a check (one per check with the new mechanism)."""
+        return payment.move_id.line_ids.filtered("l10n_latam_check_ids").sorted("id")
+
+    def _counterpart_lines(self, payment):
+        return payment.move_id.line_ids.filtered(
+            lambda line: line.account_id.account_type in ("liability_payable", "asset_receivable")
+        )
+
+    def assert_move_balanced(self, move, msg=""):
+        self.assertEqual(
+            move.company_currency_id.round(sum(move.line_ids.mapped("balance"))),
+            0.0,
+            "Journal entry %s is not balanced. %s" % (move.name, msg),
+        )
+
+    def assert_check_lines_match(self, payment, msg=""):
+        """Every check has its own liquidity line, on the outstanding account,
+        holding its nominal amount, maturing on its own date, labelled with its
+        number and reachable back from the check.
+
+        Everything a check line must satisfy lives here on purpose: every suite
+        calling this helper gets the full contract instead of each test
+        re-asserting a slice of it.
+        """
+        checks = payment.l10n_latam_new_check_ids or payment.l10n_latam_move_check_ids
+        lines = self._check_lines(payment)
+        self.assertEqual(len(lines), len(checks), "One liquidity line per check expected. %s" % msg)
+        for check in checks:
+            line = lines.filtered(lambda x: check in x.l10n_latam_check_ids)
+            self.assertEqual(len(line), 1, "Check %s must be linked to exactly one line" % check.name)
+            self.assertEqual(
+                abs(line.amount_currency),
+                check.amount,
+                "Line of check %s must hold the check nominal in the payment currency" % check.name,
+            )
+            self.assertEqual(
+                line.date_maturity, check.payment_date, "Line of check %s must mature on the check date" % check.name
+            )
+            self.assertEqual(
+                line.account_id,
+                payment.outstanding_account_id,
+                "Line of check %s must sit on the outstanding account" % check.name,
+            )
+            self.assertEqual(check.outstanding_line_id, line, "Check %s must point back to its own line" % check.name)
+            if check.name:
+                self.assertIn(check.name, line.name or "", "The line label must carry the check number")

--- a/l10n_latam_check_ux/tests/test_check_outstanding_consumers.py
+++ b/l10n_latam_check_ux/tests/test_check_outstanding_consumers.py
@@ -1,0 +1,149 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+"""Everything that reads ``l10n_latam.check.outstanding_line_id`` downstream.
+
+These are the places that silently change meaning when the liquidity line of a
+check payment moves (split move -> line inside the payment move) or when third
+party checks start carrying an outstanding line. Part of the harness of task
+70884.
+"""
+
+from odoo import fields
+from odoo.tests import tagged
+
+from .common import LatamCheckCommon
+
+
+@tagged("post_install", "-at_install")
+class TestChecksToDateReport(LatamCheckCommon):
+    """``account.check.to_date.report.wizard`` reads outstanding_line_id in raw SQL."""
+
+    def setUp(self):
+        super().setUp()
+        self.report = self.env["account.check.to_date.report.wizard"]
+        self.tomorrow = fields.Date.add(self.today, days=1)
+
+    def _handed(self, journal=None, to_date=None):
+        # the report runs raw SQL, so pending ORM values must hit the database
+        self.env.flush_all()
+        return self.report._get_checks_handed((journal or self.bank_journal).id, to_date or self.tomorrow)
+
+    def _on_hand(self, journal=None, to_date=None):
+        self.env.flush_all()
+        return self.report._get_checks_on_hand((journal or self.third_party_journal).id, to_date or self.tomorrow)
+
+    def _debit(self, check, date):
+        wizard = (
+            self.env["account.check.action.wizard"]
+            .with_context(active_model="l10n_latam.check", active_ids=check.ids)
+            .create({"date": date})
+        )
+        wizard.action_confirm()
+
+    def test_only_handed_checks_are_listed(self):
+        """El reporte lista un renglon por cheque entregado, deja afuera los
+        borradores y los anulados, y el QWeb los imprime."""
+        handed = self._create_own_check_payment([20, 30, 70], numbers=["00020001", "00020002", "00020003"])
+        handed.action_post()
+        voided = self._create_own_check_payment([50], numbers=["00020401"])
+        voided.action_post()
+        voided.l10n_latam_new_check_ids.action_void()
+        draft = self._create_own_check_payment([50], numbers=["00020301"])
+
+        reported = self._handed()
+
+        self.assertEqual(
+            handed.l10n_latam_new_check_ids,
+            reported & handed.l10n_latam_new_check_ids,
+            "Every handed check must show up in the report",
+        )
+        self.assertNotIn(voided.l10n_latam_new_check_ids, reported)
+        self.assertNotIn(draft.l10n_latam_new_check_ids, reported)
+
+        wizard = self.report.create({"journal_id": self.bank_journal.id, "to_date": self.tomorrow})
+        self.env.flush_all()
+        report = self.env.ref("l10n_latam_check_ux.checks_to_date_report")
+        html = report._render_qweb_html(report.report_name, wizard.ids)[0]
+        self.assertIn(b"00020001", html)
+        self.assertIn(b"00020002", html)
+        self.assertNotIn(b"00020301", html, "A draft check must not be printed either")
+
+    def test_the_report_date_decides_which_checks_are_still_handed(self):
+        """Un cheque debitado antes de la fecha del reporte sale del listado;
+        uno debitado despues seguia entregado a esa fecha, asi que queda."""
+        payment = self._create_own_check_payment([20, 30, 70], numbers=["00020101", "00020102", "00020103"])
+        payment.action_post()
+        debited_now, debited_later, untouched = payment.l10n_latam_new_check_ids
+
+        self._debit(debited_now, self.today)
+        self._debit(debited_later, fields.Date.add(self.today, days=10))
+
+        reported = self._handed()
+        self.assertNotIn(debited_now, reported, "A debited check is no longer handed")
+        self.assertEqual(
+            debited_later + untouched,
+            reported & payment.l10n_latam_new_check_ids,
+            "A check debited after the report date was still handed at that date",
+        )
+
+    def test_third_party_checks_on_hand_until_deposited(self):
+        payment = self._receive_third_party_checks([55, 45], numbers=["00020501", "00020502"])
+        payment.action_post()
+        checks = payment.l10n_latam_new_check_ids
+
+        self.assertEqual(checks, self._on_hand() & checks, "Checks received and not yet moved are on hand")
+
+        wizard = (
+            self.env["l10n_latam.payment.mass.transfer"]
+            .with_context(active_model="l10n_latam.check", active_ids=checks.ids)
+            .create(
+                {
+                    "journal_id": self.third_party_journal.id,
+                    "destination_journal_id": self.bank_journal.id,
+                    "payment_date": self.today,
+                }
+            )
+        )
+        wizard._create_payments()
+
+        self.assertFalse(self._on_hand() & checks, "Deposited checks left the third party journal")
+
+
+@tagged("post_install", "-at_install")
+class TestOutstandingAccountConsumers(LatamCheckCommon):
+    """Other places that walk ``outstanding_line_id``."""
+
+    def test_toggling_reconcile_on_the_account_recomputes_issue_state(self):
+        """``account.account.write`` recomputes the issue_state of the checks
+        whose outstanding line sits on that account."""
+        payment = self._create_own_check_payment([20, 30], numbers=["00021001", "00021002"])
+        payment.action_post()
+        self.assertEqual(payment.l10n_latam_new_check_ids.mapped("issue_state"), ["handed", "handed"])
+
+        self.deferred_check_account.write({"reconcile": False})
+        self.assertEqual(
+            payment.l10n_latam_new_check_ids.mapped("issue_state"),
+            ["debited", "debited"],
+            "Without reconciliation there is nothing left to debit",
+        )
+
+        self.deferred_check_account.write({"reconcile": True})
+        self.assertEqual(payment.l10n_latam_new_check_ids.mapped("issue_state"), ["handed", "handed"])
+
+    def test_partner_credit_includes_deferred_third_party_checks(self):
+        """``res.partner.add_check_credit`` counts checks on hand not yet due."""
+        self.partner.add_check_credit = True
+        payment = self._receive_third_party_checks([55], numbers=["00021301"])
+        payment.l10n_latam_new_check_ids.payment_date = fields.Date.add(self.today, days=30)
+        payment.action_post()
+
+        credit_with_checks = self.partner.with_company(self.company).credit
+        self.partner.add_check_credit = False
+        self.partner.invalidate_recordset(["credit"])
+        credit_without_checks = self.partner.with_company(self.company).credit
+
+        self.assertEqual(
+            credit_with_checks - credit_without_checks, 55.0, "The deferred check must add up to the partner credit"
+        )

--- a/l10n_latam_check_ux/tests/test_own_checks_ux.py
+++ b/l10n_latam_check_ux/tests/test_own_checks_ux.py
@@ -1,0 +1,370 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+"""Own checks: journal entry shape, lifecycle and border cases.
+
+Part of the harness of task 70884: it pins the behaviour of the core check patch
+the ADHOC image carries, so relocating that patch into our modules can be proven
+equivalent.
+
+Tests whose name ends in ``_today`` pin a side effect of the patch on purpose -
+they are not the desired behaviour, and the task documents each one. They are
+kept commented out: they belong to the relocation PR, which is where each of
+them either flips or is deleted.
+"""
+
+from odoo import Command, fields
+from odoo.exceptions import UserError, ValidationError
+from odoo.tests import tagged
+from odoo.tools import mute_logger
+from psycopg2 import IntegrityError
+
+from .common import LatamCheckCommon
+
+
+@tagged("post_install", "-at_install")
+class TestOwnChecksEntry(LatamCheckCommon):
+    """The journal entry generated when issuing own checks."""
+
+    def test_multi_check_entry_shape(self):
+        """3 cheques diferidos con montos que no dividen parejo: una linea de
+        liquidez por cheque dentro del asiento del pago (con su nominal, su
+        vencimiento, su numero y su cuenta, ver ``assert_check_lines_match``),
+        una sola contrapartida y ningun asiento extra."""
+        dates = [fields.Date.add(self.today, days=days) for days in (10, 20, 30)]
+        payment = self._create_own_check_payment(
+            [33.33, 33.33, 33.34], numbers=["00000201", "00000202", "00000203"], check_dates=dates
+        )
+        payment.action_post()
+
+        self.assert_move_balanced(payment.move_id)
+        self.assert_check_lines_match(payment)
+        lines = self._check_lines(payment)
+        self.assertEqual(payment.amount, 100)
+        self.assertEqual(len(payment.move_id.line_ids), 4, "3 liquidity lines + 1 counterpart")
+        self.assertEqual(sum(lines.mapped("amount_currency")), -100)
+        self.assertEqual(lines.mapped("partner_id"), self.partner)
+        # amounts that do not divide evenly must not be redistributed
+        self.assertEqual(sorted(abs(line.amount_currency) for line in lines), [33.33, 33.33, 33.34])
+        self.assertEqual(sorted(lines.mapped("date_maturity")), dates)
+
+        counterpart = self._counterpart_lines(payment)
+        self.assertEqual(len(counterpart), 1, "A single counterpart line regardless of the number of checks")
+        self.assertEqual(abs(counterpart.amount_currency), 100.0)
+
+        # the old core mechanism posted an extra 'split move'; there must be none
+        moves = self.env["account.move"].search(
+            [("line_ids.account_id", "=", self.deferred_check_account.id), ("company_id", "=", self.company.id)]
+        )
+        self.assertEqual(moves, payment.move_id, "Only the payment move should touch the deferred checks account")
+
+
+@tagged("post_install", "-at_install")
+class TestOwnChecksMulticurrency(LatamCheckCommon):
+    """Own checks in a currency other than the company one."""
+
+    def test_nominal_in_currency_conversion_in_balance(self):
+        """Cada cheque guarda su nominal en ``amount_currency`` y la conversion a
+        la fecha del pago en ``balance``, linea por linea y en el total."""
+        payment = self._create_own_check_payment(
+            [20, 30, 70], numbers=["00001001", "00001002", "00001003"], currency=self.foreign_currency
+        )
+        payment.action_post()
+
+        self.assert_move_balanced(payment.move_id)
+        self.assert_check_lines_match(payment)
+        lines = self._check_lines(payment)
+        for line in lines:
+            self.assertEqual(line.currency_id, self.foreign_currency)
+            expected = self.foreign_currency._convert(
+                abs(line.amount_currency), self.company_currency, self.company, payment.date
+            )
+            self.assertEqual(abs(line.balance), expected, "Balance must be the nominal converted at the payment date")
+
+        self.assertEqual(sum(lines.mapped("amount_currency")), -120)
+        expected_total = self.foreign_currency._convert(120, self.company_currency, self.company, payment.date)
+        self.assertEqual(abs(sum(lines.mapped("balance"))), expected_total)
+
+    # def test_deferred_checks_fx_entry_is_unbalanced_today(self):
+    #     """EQUIVALENCE (task 70884, BUG-2: deferred FX).
+    #
+    #     Pins what the patched core does today, which the relocation must
+    #     reproduce: each check is converted at ``check.payment_date`` while the
+    #     counterpart keeps the conversion at ``payment.date``, so a deferred check
+    #     with a moving rate makes the entry unbalanced and posting is rejected.
+    #
+    #     It is a known defect (fixing it means converting at the payment date),
+    #     but fixing it is a separate PR: this assertion flips there, not here.
+    #     """
+    #     payment = self._create_own_check_payment(
+    #         [20, 30, 70],
+    #         numbers=["00001201", "00001202", "00001203"],
+    #         currency=self.foreign_currency,
+    #         check_dates=[fields.Date.add(self.today, days=40)] * 3,
+    #     )
+    #     with self.assertRaisesRegex(UserError, "not balanced"):
+    #         payment.action_post()
+
+
+@tagged("post_install", "-at_install")
+class TestOwnChecksLifecycle(LatamCheckCommon):
+    """Draft / post / cancel / reset-to-draft and issue_state transitions."""
+
+    # def test_draft_check_is_debited_and_blocks_cancel_today(self):
+    #     """EQUIVALENCE (task 70884, BUG-1: draft issue_state).
+    #
+    #     Pins what the patched core does today, which the relocation must
+    #     reproduce: ``_compute_issue_state`` decides by ``payment_method_code``
+    #     instead of by ``outstanding_line_id``, so a draft own check -one that was
+    #     never handed out- comes out as 'debited'; and as a consequence the draft
+    #     payment cannot be cancelled.
+    #
+    #     It is a known defect; fixing it is a separate PR.
+    #     """
+    #     payment = self._create_own_check_payment([100], numbers=["00002101"])
+    #
+    #     self.assertEqual(payment.l10n_latam_new_check_ids.issue_state, "debited")
+    #     with self.assertRaises(UserError):
+    #         payment.action_cancel()
+
+    # @mute_logger("odoo.sql_db")
+    # def test_two_draft_payments_cannot_repeat_a_number_today(self):
+    #     """EQUIVALENCE (task 70884, BUG-1: draft issue_state).
+    #
+    #     Same root cause, pinned so the relocation reproduces it: the ux unique
+    #     index covers checks with an issue_state, and since drafts now get one,
+    #     two *draft* payments sharing a number already hit the database
+    #     constraint, which should only happen for handed checks. Separate PR.
+    #     """
+    #     self._create_own_check_payment([100], numbers=["00002301"])
+    #     with self.assertRaises(IntegrityError), self.cr.savepoint():
+    #         self._create_own_check_payment([100], numbers=["00002301"])
+
+    @mute_logger("odoo.sql_db")
+    def test_check_number_is_unique_per_payment_method_line(self):
+        """El numero de cheque propio es unico por linea de metodo de pago (o
+        sea, por chequera / diario emisor): repetirlo en el mismo diario da
+        error, pero el mismo numero puede existir en otro diario, porque cada
+        banco numera sus cheques por su cuenta."""
+        first = self._create_own_check_payment([100], numbers=["00002401"])
+        first.action_post()
+
+        other_journal = self.env["account.journal"].create(
+            {"name": "Test Checks Bank 2", "code": "TCKB2", "type": "bank", "company_id": self.company.id}
+        )
+        other_line = self._add_method_line(
+            other_journal, self.own_checks_method, "Own Checks 2", self.deferred_check_account
+        )
+        other_bank = self._create_own_check_payment([100], numbers=["00002401"], method_line=other_line)
+        other_bank.action_post()
+        self.assertEqual(other_bank.move_id.state, "posted", "Another journal may re-use the number")
+
+        with self.assertRaises(IntegrityError), self.cr.savepoint():
+            second = self._create_own_check_payment([100], numbers=["00002401"])
+            second.action_post()
+
+    def test_reset_to_draft_keeps_checks_linked_and_can_post_again(self):
+        payment = self._create_own_check_payment([20, 30, 70], numbers=["00002501", "00002502", "00002503"])
+        payment.action_post()
+        payment.action_draft()
+
+        self.assertEqual(payment.state, "draft")
+        for check in payment.l10n_latam_new_check_ids:
+            self.assertEqual(
+                check.outstanding_line_id.move_id,
+                payment.move_id,
+                "There is no split move to unlink, checks stay linked to the payment move",
+            )
+
+        payment.action_post()
+        self.assert_move_balanced(payment.move_id)
+        self.assert_check_lines_match(payment)
+
+    def test_void_affects_only_its_check_and_blocks_reset_to_draft(self):
+        """Anular 1 de 3 cheques: el cheque queda anulado y su linea conciliada
+        contra un asiento de anulacion que devuelve exactamente su nominal; los
+        otros dos siguen entregados y pendientes; y el pago ya no puede volver a
+        borrador porque uno de sus cheques dejo de ser reversible.
+
+        Es la prueba de que la anulacion es *por cheque*: con una sola linea de
+        liquidez agrupada no habria forma de devolver solo estos 30.
+        """
+        payment = self._create_own_check_payment([20, 30, 70], numbers=["00002801", "00002802", "00002803"])
+        payment.action_post()
+        target = payment.l10n_latam_new_check_ids[1]
+
+        target.action_void()
+
+        self.assertEqual(target.issue_state, "voided")
+        siblings = payment.l10n_latam_new_check_ids - target
+        self.assertEqual(siblings.mapped("issue_state"), ["handed", "handed"])
+        for check in siblings:
+            self.assertTrue(check.outstanding_line_id.amount_residual, "Siblings must stay outstanding")
+
+        void_move = target.outstanding_line_id.matched_debit_ids.debit_move_id.move_id
+        self.assertTrue(void_move, "Voiding reconciles the check line against a new entry")
+        self.assert_move_balanced(void_move)
+        self.assertEqual(
+            abs(
+                sum(
+                    void_move.line_ids.filtered(lambda x: x.account_id == self.deferred_check_account).mapped("balance")
+                )
+            ),
+            30.0,
+            "Only the voided check amount goes back",
+        )
+
+        with self.assertRaises(UserError):
+            payment.action_draft()
+
+    def test_payment_amount_follows_the_checks(self):
+        """El importe del pago lo mandan los cheques: cambiar un cheque lo
+        recalcula, y forzar un importe que no coincide bloquea el posteo."""
+        payment = self._create_own_check_payment([20, 30], numbers=["00003101", "00003102"])
+        payment.l10n_latam_new_check_ids[0].amount = 25
+        self.assertEqual(payment.amount, 55, "The payment amount follows the checks")
+        payment.action_post()
+        self.assert_move_balanced(payment.move_id)
+        self.assert_check_lines_match(payment)
+
+        mismatched = self._create_own_check_payment([50, 50], numbers=["00003201", "00003202"])
+        mismatched.write({"amount": 120})
+        with self.assertRaises(ValidationError):
+            mismatched.action_post()
+
+
+@tagged("post_install", "-at_install")
+class TestOwnChecksDraftResync(LatamCheckCommon):
+    """Re-synchronization while the move is still in draft.
+
+    ``_synchronize_to_moves`` returns early on posted moves, so this is the only
+    state where the core mapping (and the guard the patch comments out) actually
+    runs on a payment carrying several liquidity lines.
+    """
+
+    def test_removing_a_check_drops_its_liquidity_line(self):
+        """The mapping has to delete the liquidity line left over when a check
+        goes away, which is where the patch swapped ``Command.delete`` for
+        ``Command.unlink``."""
+        payment = self._create_own_check_payment([20, 30, 70], numbers=["00005001", "00005002", "00005003"])
+        payment.action_post()
+        payment.action_draft()
+
+        payment.write({"l10n_latam_new_check_ids": [Command.delete(payment.l10n_latam_new_check_ids[0].id)]})
+
+        self.assertEqual(payment.amount, 100)
+        self.assert_move_balanced(payment.move_id)
+        self.assert_check_lines_match(payment)
+        self.assertEqual(len(payment.move_id.line_ids), 3, "2 liquidity lines + 1 counterpart")
+
+    def test_internal_transfer_with_several_own_checks(self):
+        """Internal transfer: the counterpart is a single line on the transfer
+        account (which the patched mapping classifies apart), and it survives a
+        re-sync in draft."""
+        destination = self.env["account.journal"].create(
+            {"name": "Test Transfer Destination", "code": "TDSTJ", "type": "cash", "company_id": self.company.id}
+        )
+        self._add_method_line(destination, self.manual_in_method, "Manual", self.manual_outstanding_account)
+        payment = self._create_own_check_payment([40, 60], numbers=["00005101", "00005102"])
+        payment.write({"is_internal_transfer": True, "destination_journal_id": destination.id})
+        payment.action_post()
+
+        self.assert_move_balanced(payment.move_id)
+        self.assert_check_lines_match(payment)
+        transfer_lines = payment.move_id.line_ids.filtered(
+            lambda line: line.account_id == self.company.transfer_account_id
+        )
+        self.assertEqual(len(transfer_lines), 1, "A single line on the transfer account")
+        self.assertTrue(payment.paired_internal_transfer_payment_id)
+        self.assert_move_balanced(payment.paired_internal_transfer_payment_id.move_id)
+
+        payment.action_draft()
+        payment.write({"amount": payment.amount})
+        self.assert_move_balanced(payment.move_id)
+        self.assert_check_lines_match(payment)
+
+
+@tagged("post_install", "-at_install")
+class TestCheckViews(LatamCheckCommon):
+    def test_check_form_has_no_journal_entry_button(self):
+        """Tripwire de la relocation, no una verificacion de UI.
+
+        El parche de core borra ``action_show_journal_entry`` y su boton (con el
+        asiento por cheque ya no apunta a nada util). Un modulo no puede borrar
+        un metodo de core, asi que al despatchar core el boton vuelve a
+        aparecer y hay que taparlo con un override de vista. Este test esta en
+        verde hoy y se pone en rojo exactamente en ese momento: es lo unico del
+        harness que avisa que falta ese override.
+        """
+        view = self.env.ref("l10n_latam_check.l10n_latam_check_view_form")
+        arch = self.env["l10n_latam.check"].get_view(view.id, "form")["arch"]
+        self.assertNotIn("action_show_journal_entry", arch)
+
+
+@tagged("post_install", "-at_install")
+class TestOwnChecksReconciliation(LatamCheckCommon):
+    """Own checks against debt, and what happens after the bank debits them."""
+
+    def test_payment_reconciles_the_debt(self):
+        payment = self._create_own_check_payment([20, 30, 70], numbers=["00004001", "00004002", "00004003"])
+        debt_line = self._create_debt_move(120, account=payment.destination_account_id)
+        payment.action_post()
+
+        counterpart = self._counterpart_lines(payment)
+        self.assertEqual(len(counterpart), 1, "A single counterpart line regardless of the number of checks")
+        (counterpart + debt_line).reconcile()
+        self.assertEqual(debt_line.amount_residual, 0.0, "The debt must be fully paid")
+        self.assertEqual(
+            payment.l10n_latam_new_check_ids.mapped("issue_state"),
+            ["handed"] * 3,
+            "Paying the debt does not debit the checks",
+        )
+
+    def test_debit_one_check_of_many(self):
+        """El wizard debita un cheque de N: solo ese queda debitado, el asiento
+        de debito mueve exactamente su nominal y queda alcanzable desde el
+        cheque."""
+        payment = self._create_own_check_payment([20, 30, 70], numbers=["00004101", "00004102", "00004103"])
+        payment.action_post()
+        target = payment.l10n_latam_new_check_ids[2]
+
+        wizard = (
+            self.env["account.check.action.wizard"]
+            .with_context(active_model="l10n_latam.check", active_ids=target.ids)
+            .create({"date": self.today})
+        )
+        wizard.action_confirm()
+
+        self.assertEqual(target.issue_state, "debited")
+        self.assertFalse(target.outstanding_line_id.amount_residual)
+        self.assertTrue(target._get_reconciled_move(), "The debit entry must be reachable from the check")
+        self.assertEqual((payment.l10n_latam_new_check_ids - target).mapped("issue_state"), ["handed", "handed"])
+
+        debit_lines = self.env["account.move.line"].search(
+            [("account_id", "=", self.manual_outstanding_account.id), ("company_id", "=", self.company.id)]
+        )
+        self.assertEqual(abs(sum(debit_lines.mapped("balance"))), 70.0, "Only the debited check amount must be moved")
+
+    def test_debit_guards(self):
+        """El wizard de debito no corre si el diario no lo habilita, ni con una
+        fecha anterior a la del pago."""
+        payment = self._create_own_check_payment([50], numbers=["00004301"])
+        payment.action_post()
+
+        past_wizard = (
+            self.env["account.check.action.wizard"]
+            .with_context(active_model="l10n_latam.check", active_ids=payment.l10n_latam_new_check_ids.ids)
+            .create({"date": fields.Date.subtract(self.today, days=5)})
+        )
+        with self.assertRaisesRegex(UserError, "no puede ser inferior"):
+            past_wizard.action_confirm()
+
+        self.bank_journal.check_add_debit_button = False
+        wizard = (
+            self.env["account.check.action.wizard"]
+            .with_context(active_model="l10n_latam.check", active_ids=payment.l10n_latam_new_check_ids.ids)
+            .create({"date": self.today})
+        )
+        with self.assertRaisesRegex(UserError, "Add Debit Date"):
+            wizard.action_confirm()

--- a/l10n_latam_check_ux/tests/test_third_party_checks_ux.py
+++ b/l10n_latam_check_ux/tests/test_third_party_checks_ux.py
@@ -1,0 +1,268 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+"""Third party checks: reception, endorsement, deposit and rejection.
+
+The core patch this suite guards also rewrites the liquidity lines of third
+party check payments (not only own checks): one line per check instead of a
+single grouped line. Everything asserted here is what a relocation of that
+patch into our modules must keep working. Part of the harness of task 70884.
+"""
+
+from odoo import Command
+from odoo.exceptions import UserError, ValidationError
+from odoo.tests import tagged
+
+from .common import LatamCheckCommon
+
+
+@tagged("post_install", "-at_install")
+class TestThirdPartyChecksEntry(LatamCheckCommon):
+    """Journal entry shape when receiving / delivering third party checks."""
+
+    def test_receive_checks(self):
+        """Recibir N cheques: una linea de liquidez por cheque en la cuenta de
+        cheques de terceros, cheques en cartera, sin issue_state (es solo de
+        cheques propios) y con outstanding_line_id apuntando al asiento del pago.
+
+        Ese ultimo punto es nuevo del parche: los consumidores de
+        ``outstanding_line_id`` (reportes, wizards, el recompute de
+        ``account.account``) ahora tambien ven cheques de terceros.
+        """
+        payment = self._receive_third_party_checks([55, 45], numbers=["00010001", "00010002"])
+        payment.action_post()
+
+        self.assert_move_balanced(payment.move_id)
+        self.assert_check_lines_match(payment)
+        self.assertEqual(payment.amount, 100)
+        self.assertEqual(len(payment.move_id.line_ids), 3, "2 liquidity lines + 1 counterpart")
+        for line in self._check_lines(payment):
+            self.assertEqual(line.account_id, self.third_party_account)
+            self.assertGreater(line.amount_currency, 0, "Receiving checks debits the check account")
+
+        checks = payment.l10n_latam_new_check_ids
+        self.assertEqual(checks.mapped("current_journal_id"), self.third_party_journal)
+        self.assertFalse(any(checks.mapped("issue_state")), "issue_state is only for own checks")
+        for check in checks:
+            self.assertEqual(check.outstanding_line_id.move_id, payment.move_id)
+            self.assertEqual(abs(check.outstanding_line_id.amount_currency), check.amount)
+
+    def test_deliver_checks_to_vendor(self):
+        """Endosar N cheques: una linea por cheque, cheques fuera de cartera,
+        operacion trackeada, y el ``outstanding_line_id`` pasa a apuntar al
+        asiento del endoso (es un Many2one: gana la ultima operacion)."""
+        payment = self._receive_third_party_checks([55, 45], numbers=["00010301", "00010302"])
+        payment.action_post()
+        checks = payment.l10n_latam_new_check_ids
+
+        delivery = self._deliver_third_party_checks(checks)
+        delivery.action_post()
+
+        self.assert_move_balanced(delivery.move_id)
+        self.assertEqual(delivery.amount, 100)
+        self.assertEqual(len(self._check_lines(delivery)), 2, "One line per delivered check")
+        for line in self._check_lines(delivery):
+            self.assertLess(line.amount_currency, 0, "Delivering checks credits the check account")
+        self.assertFalse(checks.mapped("current_journal_id"), "Delivered checks are no longer on hand")
+        self.assertEqual(checks.mapped("outstanding_line_id.move_id"), delivery.move_id)
+        self.assertEqual(checks[0].operation_ids, delivery)
+        self.assertEqual(checks[0]._get_last_operation(), delivery)
+
+
+@tagged("post_install", "-at_install")
+class TestThirdPartyChecksGuards(LatamCheckCommon):
+    """Blocking validations of l10n_latam_check + l10n_latam_check_ux."""
+
+    def test_cannot_deliver_a_draft_check(self):
+        payment = self._receive_third_party_checks([55], numbers=["00011001"])
+        delivery = self._deliver_third_party_checks(payment.l10n_latam_new_check_ids)
+        with self.assertRaises(ValidationError):
+            delivery.action_post()
+
+    def test_cannot_deliver_the_same_check_twice(self):
+        payment = self._receive_third_party_checks([55], numbers=["00011101"])
+        payment.action_post()
+        check = payment.l10n_latam_new_check_ids
+
+        first = self._deliver_third_party_checks(check)
+        first.action_post()
+        second = self._deliver_third_party_checks(check)
+        with self.assertRaises(ValidationError):
+            second.action_post()
+
+    def test_cannot_confirm_the_same_check_in_two_payments_at_once(self):
+        """l10n_latam_check_ux guard: two draft payments sharing a check."""
+        payment = self._receive_third_party_checks([55], numbers=["00011201"])
+        payment.action_post()
+        check = payment.l10n_latam_new_check_ids
+
+        first = self._deliver_third_party_checks(check)
+        second = self._deliver_third_party_checks(check)
+        with self.assertRaises(ValidationError):
+            (first + second).action_post()
+
+    def test_duplicated_third_party_check_number_warns(self):
+        payment = self._receive_third_party_checks([55], numbers=["00011301"])
+        payment.action_post()
+
+        duplicated = self._receive_third_party_checks([55], numbers=["00011301"])
+        self.assertTrue(duplicated.l10n_latam_check_warning_msg, "Receiving a check with an existing number must warn")
+        with self.assertRaises(ValidationError):
+            duplicated.action_post()
+
+    def test_reset_to_draft_blocked_when_not_last_operation(self):
+        payment = self._receive_third_party_checks([55], numbers=["00011401"])
+        payment.action_post()
+        delivery = self._deliver_third_party_checks(payment.l10n_latam_new_check_ids)
+        delivery.action_post()
+
+        with self.assertRaises(ValidationError):
+            payment.action_draft()
+
+    def test_payment_method_line_with_checks_cannot_be_deleted(self):
+        payment = self._receive_third_party_checks([55], numbers=["00011501"])
+        payment.action_post()
+
+        with self.assertRaises(UserError):
+            self.new_third_party_line.unlink()
+
+
+@tagged("post_install", "-at_install")
+class TestThirdPartyChecksDeposit(LatamCheckCommon):
+    """Depositing third party checks into a bank journal (mass transfer)."""
+
+    def _deposit(self, checks, split=False):
+        wizard = (
+            self.env["l10n_latam.payment.mass.transfer"]
+            .with_context(active_model="l10n_latam.check", active_ids=checks.ids)
+            .create(
+                {
+                    "journal_id": self.third_party_journal.id,
+                    "destination_journal_id": self.bank_journal.id,
+                    "payment_date": self.today,
+                    "split_payment": split,
+                }
+            )
+        )
+        return wizard._create_payments()
+
+    def test_deposit_to_bank(self):
+        """Depositar N cheques: quedan en el diario banco, la transferencia
+        saliente y su par entrante se concilian, y el asiento **bancario** queda
+        partido en una linea por cheque (antes era una sola linea agrupada: eso es lo
+        que ve la conciliacion bancaria)."""
+        payment = self._receive_third_party_checks([55, 45], numbers=["00012001", "00012002"])
+        payment.action_post()
+        checks = payment.l10n_latam_new_check_ids
+
+        self._deposit(checks)
+
+        self.assertEqual(checks.mapped("current_journal_id"), self.bank_journal)
+        operations = checks.operation_ids
+        self.assertEqual(len(operations), 2, "An outbound transfer and its paired inbound payment")
+        for operation in operations:
+            self.assert_move_balanced(operation.move_id)
+
+        outbound = operations.filtered(lambda p: p.payment_type == "outbound")
+        self.assertEqual(outbound.payment_method_line_id.code, "out_third_party_checks")
+        self.assertTrue(
+            outbound.move_id.line_ids.mapped("full_reconcile_id"), "Both sides of the transfer must reconcile"
+        )
+
+        inbound = operations.filtered(lambda p: p.payment_type == "inbound")
+        self.assertEqual(inbound.journal_id, self.bank_journal)
+        self.assertEqual(len(self._check_lines(inbound)), 2, "One bank line per deposited check")
+
+    def test_split_deposit_creates_one_payment_per_check(self):
+        payment = self._receive_third_party_checks([55, 45], numbers=["00012301", "00012302"])
+        payment.action_post()
+        checks = payment.l10n_latam_new_check_ids
+
+        self._deposit(checks, split=True)
+
+        outbounds = checks.operation_ids.filtered(lambda p: p.payment_type == "outbound")
+        self.assertEqual(len(outbounds), 2, "One transfer per check")
+        for outbound in outbounds:
+            self.assertEqual(len(outbound.l10n_latam_move_check_ids), 1)
+            self.assert_move_balanced(outbound.move_id)
+
+
+@tagged("post_install", "-at_install")
+class TestThirdPartyChecksRejection(LatamCheckCommon):
+    """Rejection of an endorsed / deposited third party check."""
+
+    def test_endorsed_check_rejection(self):
+        """Rechazo de un cheque endosado: se recupera del proveedor, se devuelve
+        al cliente (reabriendo la deuda) y todos los asientos balancean.
+
+        Solo se puede rechazar lo que salio de cartera: en cartera no hay nada
+        que rechazar."""
+        payment = self._receive_third_party_checks([55], numbers=["00013001"])
+        payment.action_post()
+        check = payment.l10n_latam_new_check_ids
+        self.assertFalse(check.can_reject, "A check still on hand has nothing to reject")
+
+        delivery = self._deliver_third_party_checks(check)
+        delivery.action_post()
+
+        self.assertTrue(check.can_reject)
+        wizard = (
+            self.env["account.check.reject.wizard"]
+            .with_context(active_model="l10n_latam.check", active_ids=check.ids)
+            .create({"date": self.today, "rejected_journal_id": self.rejected_journal.id})
+        )
+        wizard.action_confirm()
+
+        codes = check.operation_ids.mapped("payment_method_line_id.code")
+        self.assertIn("in_third_party_checks", codes, "The check is recovered from the vendor")
+        self.assertIn("out_third_party_checks", codes)
+        for operation in check.operation_ids:
+            self.assert_move_balanced(operation.move_id)
+
+        customer_return = check.operation_ids.filtered(
+            lambda p: p.partner_type == "customer" and p.payment_type == "outbound"
+        )
+        self.assertTrue(customer_return, "The check must be returned to the customer, re-opening the debt")
+        self.assertEqual(customer_return.partner_id, self.partner)
+        self.assertEqual(customer_return.amount, 55)
+
+
+@tagged("post_install", "-at_install")
+class TestThirdPartyChecksMulticurrency(LatamCheckCommon):
+    """Third party checks in a currency other than the company one."""
+
+    def test_receive_and_deliver_foreign_currency_checks(self):
+        """Recepcion y endoso en moneda extranjera: en las dos puntas cada cheque
+        conserva su nominal y convierte a la fecha de su propio pago."""
+        payment = self._receive_third_party_checks(
+            [55, 45], numbers=["00014001", "00014002"], currency=self.foreign_currency
+        )
+        payment.action_post()
+        checks = payment.l10n_latam_new_check_ids
+
+        self.assert_move_balanced(payment.move_id)
+        self.assert_check_lines_match(payment)
+        for line in self._check_lines(payment):
+            expected = self.foreign_currency._convert(
+                abs(line.amount_currency), self.company_currency, self.company, payment.date
+            )
+            self.assertEqual(abs(line.balance), expected)
+
+        delivery = self.env["account.payment"].create(
+            {
+                "payment_type": "outbound",
+                "partner_type": "supplier",
+                "partner_id": self.partner.id,
+                "journal_id": self.third_party_journal.id,
+                "company_id": self.company.id,
+                "date": self.today,
+                "currency_id": self.foreign_currency.id,
+                "payment_method_line_id": self.out_third_party_line.id,
+                "l10n_latam_move_check_ids": [Command.set(checks.ids)],
+            }
+        )
+        delivery.action_post()
+
+        self.assert_move_balanced(delivery.move_id)
+        self.assert_check_lines_match(delivery)


### PR DESCRIPTION
Regression harness for task 70884. The ADHOC image runs a patched core so that
check payments post one liquidity line per check, and we want to relocate that
patch into our modules to stop drifting from upstream. **This PR only adds the
tests** — the relocation itself goes in a separate PR, so that it can be reviewed
against a measured baseline instead of a guess.

**35 tests**, one behaviour per test. The full contract of a check line (its own
outstanding account, its own nominal, its own maturity, its number in the label
and the check pointing back to it) lives in `assert_check_lines_match`, so every
suite verifies all of it instead of each test asserting a slice.

## Why it did not exist before

The core `l10n_latam_check` tests **error out at `setUpClass` on any of our
databases**: their common calls `setup_other_company(country_id=base.ar)` twice,
and creating an extra Argentine company is rejected by
`saas_client_account._check_country_currency` ("You cannot select a currency that
is different from the country's currency"). So the check flows had no automated
protection here beyond a handful of accounting tests. That is why this harness
builds its own fixture with `.create()` — own checks journal, two third party
journals, outstanding accounts and a foreign currency with two different rates —
on `env.company`, instead of reusing that common.

## What is covered

### `l10n_latam_check_ux` — own checks (12)

| Test | Behaviour |
|---|---|
| `test_multi_check_entry_shape` | 3 deferred checks with amounts that do not divide evenly: one liquidity line per check inside the payment move, a single counterpart, no extra journal entry, and no redistribution of the rounding |
| `test_nominal_in_currency_conversion_in_balance` | Foreign currency: each check keeps its nominal in `amount_currency` and converts at the payment date in `balance`, line by line and in total |
| `test_check_number_is_unique_per_payment_method_line` | The own check number is unique per payment method line (per checkbook): repeating it in the same journal raises, in another journal it is allowed |
| `test_reset_to_draft_keeps_checks_linked_and_can_post_again` | Back to draft there is no split move to unlink; the checks stay linked to the payment move and it posts again cleanly |
| `test_void_affects_only_its_check_and_blocks_reset_to_draft` | Voiding 1 of 3: only that check is voided and the void entry gives back exactly its nominal; the siblings stay handed and outstanding; the payment can no longer go back to draft |
| `test_payment_amount_follows_the_checks` | The payment amount is driven by the checks, and forcing a mismatching amount blocks posting |
| `test_removing_a_check_drops_its_liquidity_line` | Removing a check in draft deletes its leftover liquidity line (where the patch swapped `Command.delete` for `Command.unlink`) |
| `test_internal_transfer_with_several_own_checks` | Internal transfer: a single line on the transfer account, paired payment balanced, and it survives a re-sync in draft |
| `test_payment_reconciles_the_debt` | A single counterpart line cancels the debt, and paying does not debit the checks |
| `test_debit_one_check_of_many` | The wizard debits 1 of 3: only that one is debited, the debit entry moves exactly its nominal and stays reachable from the check |
| `test_debit_guards` | The debit wizard refuses a journal without the option enabled, and a date earlier than the payment |
| `test_check_form_has_no_journal_entry_button` | Tripwire, not a UI check: the patch drops `action_show_journal_entry`; when core goes vanilla the button comes back and needs a view override. This is the only test that warns about that step |

### `l10n_latam_check_ux` — third party checks (12)

| Test | Behaviour |
|---|---|
| `test_receive_checks` | Receiving N checks: one liquidity line per check on the third party account, checks on hand, no `issue_state` (own checks only) and `outstanding_line_id` pointing at the payment move |
| `test_deliver_checks_to_vendor` | Endorsing N checks: one line per check, checks out of hand, operation tracked, and `outstanding_line_id` moves to the endorsement entry |
| `test_cannot_deliver_a_draft_check` | A draft check cannot be endorsed |
| `test_cannot_deliver_the_same_check_twice` | The same check cannot be endorsed twice |
| `test_cannot_confirm_the_same_check_in_two_payments_at_once` | Two draft payments sharing a check cannot both be posted |
| `test_duplicated_third_party_check_number_warns` | Receiving a check with an existing number warns and blocks posting |
| `test_reset_to_draft_blocked_when_not_last_operation` | A payment cannot go back to draft if the check has a later operation |
| `test_payment_method_line_with_checks_cannot_be_deleted` | A payment method line with checks on hand cannot be deleted |
| `test_deposit_to_bank` | Depositing N checks: they land on the bank journal, the transfer and its pair reconcile, and the **bank** entry is split one line per check (that is what bank reconciliation sees) |
| `test_split_deposit_creates_one_payment_per_check` | With `split_payment`, one transfer per check |
| `test_endorsed_check_rejection` | Rejecting an endorsed check: recovered from the vendor and returned to the customer, re-opening the debt, every entry balanced. A check still on hand has nothing to reject |
| `test_receive_and_deliver_foreign_currency_checks` | Foreign currency on both ends: each check keeps its nominal and converts at the date of its own payment |

### `l10n_latam_check_ux` — consumers of `outstanding_line_id` (5)

These are the places that silently change meaning when the liquidity line moves
into the payment move, or when third party checks start carrying an outstanding
line.

| Test | Behaviour |
|---|---|
| `test_only_handed_checks_are_listed` | The checks-to-date report lists one row per handed check, leaves out drafts and voided ones, and the QWeb prints them |
| `test_the_report_date_decides_which_checks_are_still_handed` | A check debited before the report date leaves the listing; one debited after it was still handed at that date, so it stays |
| `test_third_party_checks_on_hand_until_deposited` | Third party checks are on hand until the mass transfer deposits them |
| `test_toggling_reconcile_on_the_account_recomputes_issue_state` | Toggling `reconcile` on the outstanding account recomputes the `issue_state` of its checks, both ways |
| `test_partner_credit_includes_deferred_third_party_checks` | `add_check_credit` adds checks on hand not yet due to the partner credit |

### `account_payment_pro` — several liquidity lines in one payment (6)

`_prepare_move_lines_per_type` rewrites the liquidity and counterpart balances of
every payment. Check payments are the only case where it receives more than one
liquidity line, so this is where both features meet.

| Test | Behaviour |
|---|---|
| `test_multi_checks_company_currency` | 3 checks in company currency: 3 liquidity lines, 1 counterpart, entry balanced |
| `test_multi_checks_with_write_off` | The write-off adds to the debt cancelled, not to the checks handed |
| `test_uneven_amounts_are_not_redistributed` | Amounts that do not divide evenly keep their nominal — the rewrite must not spread the rounding across checks |
| `test_multi_checks_foreign_currency_uses_accounting_rate` | The payment rate drives **every** check line, not only the first — both the table rate and one typed by the user |
| `test_deferred_checks_in_foreign_currency_stay_balanced` | Deferred checks in foreign currency: payment_pro converts everything at the payment date and the entry still balances |
| `test_amount_can_be_written_on_a_multi_check_payment_with_a_draft_move` | Base Odoo blocks writing `amount` with several liquidity lines; check payments legitimately have several, so the block must not apply. The move is reset to draft on purpose — `_synchronize_to_moves` returns early on posted moves |

## The four `_today` tests, commented out

They pin a side effect of the patched core: they assert what happens today, not
what should happen. They are kept in the code, commented out, because each one
belongs to the relocation PR — that is where it flips or gets deleted.

| Test | Side effect pinned |
|---|---|
| `test_draft_check_is_debited_and_blocks_cancel_today` | BUG-1: `_compute_issue_state` decides by `payment_method_code` instead of `outstanding_line_id`, so a draft own check comes out as 'debited' and the payment cannot be cancelled |
| `test_two_draft_payments_cannot_repeat_a_number_today` | BUG-1, same root cause: since drafts get an `issue_state`, two *draft* payments sharing a number already hit the unique index |
| `test_deferred_checks_fx_entry_is_unbalanced_today` | BUG-2: each check converts at its own `payment_date` while the counterpart keeps the payment date, so a deferred check with a moving rate unbalances the entry |
| `test_writing_amount_on_two_payments_at_once_crashes_today` | BUG-3: the patch classifies lines with `self.outstanding_account_id` inside its own `for pay in self` loop, so writing `amount` on several draft payments with different outstanding accounts raises `Expected singleton` |

## Test plan

```bash
odoo-bin -d <db> -u l10n_latam_check_ux,account_payment_pro \
  --test-enable --test-tags '/l10n_latam_check_ux,/account_payment_pro:TestChecksPaymentPro'
```

43 tests, 0 failed, 0 errors — the 35 above plus the 8 pre-existing ones in
`test_check_transfers` and `test_check_payment_journal_entry`. That is the
baseline this PR exists to establish.

Measured against a vanilla core, a large share of them fail, and some of those
already existed in these repos: the patch is load bearing for real accounting
(checks plus withholdings), not cosmetic.

Related: https://github.com/ingadhoc/odoo-argentina/pull/1526 adds one test to the
withholding suite for the same harness.
