### PR TITLE
[FIX] l10n_latam_check_ux: do not delete the journal entry of a confirmed check payment

### DIFF
--- a/l10n_latam_check_ux/README.rst
+++ b/l10n_latam_check_ux/README.rst
@@ -18,6 +18,7 @@ This module extends the standard functionality of Odoo's l10n_latam_check module
 
 * Debit checks from payments: Adds a button in the check record to perform the debit action, streamlining check management.
 * Check number in PDF documents: Includes the check number when printing the receipt and payment PDFs, improving traceability.
+* Journal entry protection: The journal entry of a payment with checks cannot be deleted while the payment is confirmed, because deleting it and posting the payment again leaves the check with the wrong current journal. The payment has to be reset to draft to adjust its journal entry.
 
 Installation
 ============

--- a/l10n_latam_check_ux/models/__init__.py
+++ b/l10n_latam_check_ux/models/__init__.py
@@ -1,4 +1,5 @@
 from . import account_payment
+from . import account_move
 from . import account_journal
 from . import account_account
 from . import l10n_latam_check

--- a/l10n_latam_check_ux/models/account_move.py
+++ b/l10n_latam_check_ux/models/account_move.py
@@ -1,0 +1,35 @@
+from odoo import _, api, models
+from odoo.exceptions import UserError
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_confirmed_check_payment(self):
+        """No dejar borrar el asiento de un pago con cheques mientras el pago sigue confirmado.
+
+        Si se borra el asiento y se vuelve a postear el pago (account_ux regenera el asiento que
+        falta), el cheque queda con el diario actual equivocado: ``current_journal_id`` se computa
+        con la última operación del cheque ordenada por ``(date, write_date, id)``, y el repost
+        manda al final el ``write_date`` de la operación reposteada, así que una recepción vieja
+        pasa a tapar la transferencia posterior. Para ajustar el asiento hay que restablecer el
+        pago a borrador, que es el camino que recomputa las operaciones del cheque.
+
+        Igual que en los ondelete de core, ``force_delete`` sigue siendo la salida programática
+        (por ejemplo el borrado del asiento en borrador que hace ``account.payment.action_cancel``).
+        """
+        if self._context.get("force_delete"):
+            return
+        payments = self.origin_payment_id.filtered(
+            lambda payment: payment._is_latam_check_payment() and payment.state not in ("draft", "canceled")
+        )
+        if payments:
+            raise UserError(
+                _(
+                    "You cannot delete the journal entry of a payment with checks while the payment is confirmed. "
+                    "If you need to adjust the journal entry, reset the payment to draft first.\n"
+                    "Payments:\n%s",
+                    "\n".join("* %s" % payment.display_name for payment in payments),
+                )
+            )

--- a/l10n_latam_check_ux/tests/__init__.py
+++ b/l10n_latam_check_ux/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_check_payment_journal_entry

--- a/l10n_latam_check_ux/tests/test_check_payment_journal_entry.py
+++ b/l10n_latam_check_ux/tests/test_check_payment_journal_entry.py
@@ -1,0 +1,99 @@
+# © ADHOC SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import Command, fields
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestCheckPaymentJournalEntry(AccountTestInvoicingCommon):
+    """El asiento de un pago con cheques no se puede borrar mientras el pago está confirmado.
+
+    Borrarlo y volver a postear el pago —ahora ``account_ux`` regenera el asiento faltante— deja al
+    cheque con el diario actual equivocado: ``current_journal_id`` se resuelve por la última
+    operación del cheque ordenada por ``(date, write_date, id)``, y el repost mueve el
+    ``write_date``, así que una recepción vieja pasa a tapar la transferencia posterior. El camino
+    válido para tocar ese asiento es restablecer el pago a borrador.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Diario de efectivo con cheques de terceros nuevos: es el tipo de diario donde el core
+        # habilita ese método de pago (``l10n_latam_check/models/account_payment_method.py``), y
+        # liquida contra una cuenta puente, no contra la de efectivo.
+        cls.check_journal = cls.env["account.journal"].create(
+            {
+                "name": "Third Party Checks",
+                "code": "TPCUX",
+                "type": "cash",
+                "company_id": cls.company_data["company"].id,
+                "inbound_payment_method_line_ids": [
+                    Command.create(
+                        {
+                            "payment_method_id": cls.env.ref(
+                                "l10n_latam_check.account_payment_method_new_third_party_checks"
+                            ).id,
+                            "payment_account_id": cls.inbound_payment_method_line.payment_account_id.id,
+                        }
+                    )
+                ],
+            }
+        )
+        cls.check_payment_method_line = cls.check_journal.inbound_payment_method_line_ids.filtered(
+            lambda line: line.code == "new_third_party_checks"
+        )
+
+    def _create_third_party_check_payment(self, check_number="00000001"):
+        payment = self.env["account.payment"].create(
+            {
+                "payment_type": "inbound",
+                "partner_type": "customer",
+                "partner_id": self.partner_a.id,
+                "journal_id": self.check_journal.id,
+                "payment_method_line_id": self.check_payment_method_line.id,
+                "l10n_latam_new_check_ids": [
+                    Command.create(
+                        {
+                            "name": check_number,
+                            "payment_date": fields.Date.add(fields.Date.today(), months=1),
+                            "amount": 100.0,
+                        }
+                    )
+                ],
+            }
+        )
+        payment.action_post()
+        self.assertTrue(payment.move_id, "El pago con cheques se debe crear con su asiento contable.")
+        self.assertTrue(payment._is_latam_check_payment())
+        return payment
+
+    def test_cannot_delete_journal_entry_of_confirmed_check_payment(self):
+        payment = self._create_third_party_check_payment()
+        move = payment.move_id
+        move.button_draft()
+
+        with self.assertRaisesRegex(UserError, "payment with checks while the payment is confirmed"):
+            move.unlink()
+
+        self.assertEqual(payment.move_id, move, "El asiento del pago confirmado no se debe borrar.")
+
+    def test_can_delete_journal_entry_of_draft_check_payment(self):
+        """Restablecer el pago a borrador es el camino habilitado para tocarle el asiento."""
+        payment = self._create_third_party_check_payment()
+        payment.action_draft()
+
+        payment.move_id.unlink()
+
+        self.assertFalse(payment.move_id, "Con el pago en borrador el asiento se debe poder borrar.")
+
+    def test_force_delete_still_deletes_the_journal_entry(self):
+        """``force_delete`` sigue siendo la salida programática, igual que en los ondelete de core."""
+        payment = self._create_third_party_check_payment()
+        move = payment.move_id
+        move.button_draft()
+
+        move.with_context(force_delete=True).unlink()
+
+        self.assertFalse(payment.move_id)


### PR DESCRIPTION
## What

Blocks deleting the journal entry (`account.move`) of a payment with checks while the payment is confirmed (`state` not in `draft` / `canceled`), via an `@api.ondelete` guard on `account.move` in `l10n_latam_check_ux`.

## Why

Deleting the journal entry of a check payment and then posting the payment again — `account_ux` now regenerates the missing entry (ingadhoc/account-financial-tools#1007) — leaves the check with the wrong current journal:

`l10n_latam.check.current_journal_id` is computed from `_get_last_operation()`, which sorts the check operations by `(date, write_date, id)`. Reposting the entry pushes the `write_date` of an already-done operation to the end, so an older reception ends up hiding the later transfer, and the check looks like it is back in a journal it already left.

The corruption is on the check, not on the payment, so the guard lives in the checks module. The sanctioned path to touch that entry is resetting the payment to draft, which is what recomputes the check operations.

Notes on the implementation:

- Scope is `_is_latam_check_payment()`, i.e. all five check payment methods (`own_checks` and the four third-party ones): deleting the entry breaks the operation history of any check, not only of third-party ones.
- `force_delete` still goes through, consistent with the core `account.move` ondelete guards (`_unlink_account_audit_trail_except_once_post`, `_unlink_forbid_parts_of_chain`) and with `account_ux._check_payment_state`. That keeps the programmatic deletion of the draft entry done by `account.payment.action_cancel()` working; the manual deletion from the UI does not carry that context, so it is blocked.

## Test plan

New `l10n_latam_check_ux/tests/test_check_payment_journal_entry.py` (module had no tests, so the `tests` package is new). Fixture is self-contained on `AccountTestInvoicingCommon` — it builds a cash journal with the `new_third_party_checks` method line instead of inheriting `l10n_latam_check.tests.common`, which needs an AR company.

- `test_cannot_delete_journal_entry_of_confirmed_check_payment` — confirmed payment, entry reset to draft, `unlink()` raises `UserError`. Fails with `UserError not raised` without the guard.
- `test_can_delete_journal_entry_of_draft_check_payment` — after `action_draft()` the entry can be deleted.
- `test_force_delete_still_deletes_the_journal_entry` — the escape hatch keeps working.

`0 failed, 0 error(s) of 3 tests`. Also ran the suites of `account_payment_pro`, `account_payment_pro_receiptbook`, `account_payment_ux`, `account_internal_transfer` and `account_ux` for regressions: the only errors are pre-existing `env.ref` calls on demo data missing in the test database.

Same branch name as ingadhoc/account-financial-tools#1007 so both repos land in a single runbot build.