### PR TITLE
[FIX] l10n_latam_check_ux: allow draft/cancel of own check payments when the checks account is not reconcilable

### DIFF
--- a/l10n_latam_check_ux/models/account_payment.py
+++ b/l10n_latam_check_ux/models/account_payment.py
@@ -115,6 +115,18 @@ class AccountPayment(models.Model):
 
         super().action_draft()
 
+    def _get_reconciled_checks_error(self):
+        """Odoo bloquea cancelar o reabrir un pago si algún cheque está debitado o anulado, para no
+        romper la conciliación del débito. Cuando la cuenta de cheques no permite conciliación
+        forzamos issue_state = 'debited' (ver l10n_latam.check._compute_issue_state) porque el
+        residual de la línea es 0 por definición, no porque exista un débito conciliado. En ese caso
+        no hay conciliación que romper y el pago debe poder volver a borrador o cancelarse.
+        """
+        payments = self.filtered(
+            lambda x: any(check.outstanding_line_id.account_id.reconcile for check in x.l10n_latam_new_check_ids)
+        )
+        return super(AccountPayment, payments)._get_reconciled_checks_error()
+
     def _is_latam_check_transfer(self):
         self.ensure_one()
         return super()._is_latam_check_transfer() or (

--- a/l10n_latam_check_ux/tests/__init__.py
+++ b/l10n_latam_check_ux/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_own_checks_non_reconcilable

--- a/l10n_latam_check_ux/tests/test_own_checks_non_reconcilable.py
+++ b/l10n_latam_check_ux/tests/test_own_checks_non_reconcilable.py
@@ -1,0 +1,91 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import Command, fields
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestOwnChecksNonReconcilable(AccountTestInvoicingCommon):
+    """Cuando la cuenta de cheques propios no permite conciliación, el issue_state se fuerza a
+    'debited' porque el residual de la línea es 0 por definición. Ese débito es nominal (no hay
+    asiento de débito conciliado), así que no debe impedir volver el pago a borrador ni cancelarlo.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.bank_journal = cls.company_data["default_journal_bank"]
+        cls.bank_journal.outbound_payment_method_line_ids = [
+            Command.create(
+                {
+                    "payment_method_id": cls.env.ref("l10n_latam_check.account_payment_method_own_checks").id,
+                    "name": "Own Checks",
+                }
+            )
+        ]
+        cls.own_checks_payment_method_line = cls.bank_journal.outbound_payment_method_line_ids.filtered(
+            lambda x: x.code == "own_checks"
+        )
+        cls.own_checks_account = cls.outbound_payment_method_line.payment_account_id.copy()
+        cls.own_checks_payment_method_line.payment_account_id = cls.own_checks_account
+
+    def _create_own_check_payment(self, number, amount=50):
+        payment = self.env["account.payment"].create(
+            {
+                "payment_type": "outbound",
+                "partner_id": self.partner_a.id,
+                "journal_id": self.bank_journal.id,
+                "payment_method_line_id": self.own_checks_payment_method_line.id,
+                "l10n_latam_new_check_ids": [
+                    Command.create(
+                        {
+                            "name": number,
+                            "payment_date": fields.Date.add(fields.Date.today(), months=1),
+                            "amount": amount,
+                        }
+                    )
+                ],
+            }
+        )
+        payment.action_post()
+        return payment
+
+    def test_draft_own_check_with_non_reconcilable_account(self):
+        """Con cuenta no conciliable el cheque queda debitado, pero el pago debe poder volver a borrador."""
+        self.own_checks_account.reconcile = False
+        payment = self._create_own_check_payment("00000010")
+
+        self.assertEqual(
+            payment.l10n_latam_new_check_ids.issue_state,
+            "debited",
+            "Con cuenta no conciliable el cheque se fuerza a debitado.",
+        )
+
+        payment.action_draft()
+        self.assertEqual(payment.state, "draft", "El pago debería poder volver a borrador.")
+
+    def test_cancel_own_check_with_non_reconcilable_account(self):
+        """Mismo escenario que el anterior, pero cancelando el pago."""
+        self.own_checks_account.reconcile = False
+        payment = self._create_own_check_payment("00000011")
+
+        payment.action_cancel()
+        self.assertEqual(payment.state, "canceled", "El pago debería poder cancelarse.")
+
+    def test_draft_own_check_with_reconcilable_account_is_blocked(self):
+        """No regresión: con cuenta conciliable y cheque anulado, Odoo sigue bloqueando el borrador."""
+        self.assertTrue(
+            self.own_checks_account.reconcile,
+            "La cuenta de cheques propios debería ser conciliable por defecto.",
+        )
+        payment = self._create_own_check_payment("00000012")
+        check = payment.l10n_latam_new_check_ids
+        check.action_void()
+        self.assertEqual(check.issue_state, "voided")
+
+        with self.assertRaises(UserError):
+            payment.action_draft()


### PR DESCRIPTION

When the own checks outstanding account is not reconcilable we force issue_state = 'debited' because there is no way to track the debit (the payment goes straight to the bank account). Odoo's _get_reconciled_checks_error then blocked resetting the payment to draft or cancelling it, even though that 'debited' is nominal: the line residual is 0 because the account is not reconcilable, not because a debit entry was reconciled, so there is no reconciliation to break.

Skip that error for payments whose checks live in a non reconcilable account, and add tests covering both scenarios plus the reconcilable one (still blocked).

