### PR TITLE
[IMP] account_payment_pro_receiptbook: show company in receiptbook name with branches

### DIFF
--- a/account_payment_pro_receiptbook/models/account_payment_receiptbook.py
+++ b/account_payment_pro_receiptbook/models/account_payment_receiptbook.py
@@ -77,6 +77,24 @@ class AccountPaymentReceiptbook(models.Model):
         required=True,
     )
 
+    @api.depends("name", "company_id")
+    @api.depends_context("allowed_company_ids")
+    def _compute_display_name(self):
+        """Disambiguate receiptbooks of a branch tree by suffixing the company.
+
+        Same idea as account.tax / project.project in core: only when the user
+        has more than one active company, and only if the tree actually has
+        branches (otherwise the suffix is noise for single-company databases).
+        """
+        super()._compute_display_name()
+        if len(self.env.context.get("allowed_company_ids") or []) <= 1:
+            return
+        for rec in self:
+            # sudo: child_ids is filtered by the res.company record rule, so
+            # without it the suffix would show up only for some users.
+            if rec.company_id.sudo().root_id.child_ids:
+                rec.display_name = f"{rec.display_name} - {rec.company_id.name}"
+
     @api.constrains("company_id", "prefix", "document_type_id", "partner_type")
     def _check_unique_receipt(self):
         for rec in self:


### PR DESCRIPTION
When a company tree has branches, the receiptbooks of the parent and of each
branch look identical in the payment form: the name (`Customer Receipts`,
`Vendor Receipts`, ...) does not carry the company, so the user picking a
receiptbook cannot tell them apart.

`_compute_display_name` now appends the company to the displayed name,
following the core pattern (`account.tax`, `project.project` in
`hr_timesheet`):

- only when the user has more than one active company (`allowed_company_ids`),
- and only if the tree actually has branches (`company_id.root_id.child_ids`),
  so single-company databases are unaffected;
- `sudo()` on `child_ids` because the `res.company` record rule would
  otherwise hide the branches from some users and make the suffix
  inconsistent between them.

Only the displayed name changes. The stored `name`, the `prefix` and the
`ir.sequence` stay the same, so numbering and `name_search` are untouched.

Related task: https://www.adhoc.inc/odoo/my-tasks/71848

## Test plan

- Multi-company database with a parent company and a branch, both with
  receiptbooks, and both companies active: the receiptbook field of a payment
  shows `Customer Receipts - <company>` for each one.
- Same database with a single active company: the name shows plain, without
  suffix.
- Database without branches: no change.