### PR TITLE
[FIX] account_payment_pro: consider company hierarchy (branches) in invoice wizard taxes

### DIFF
--- a/account_payment_pro/tests/test_account_paymet_pro_unit_test.py
+++ b/account_payment_pro/tests/test_account_paymet_pro_unit_test.py
@@ -351,3 +351,53 @@ class TestAccountPaymentProUnitTest(common.TransactionCase):
 
         self.assertIn(payment.state, ["paid", "in_process"], "El pago invertido debe poder postearse")
         self.assertIn(credit_note.payment_state, ["paid", "in_payment"], "La nota de crédito debe quedar pagada")
+
+    def test_change_product_includes_parent_company_taxes(self):
+        """El wizard de factura debe incluir impuestos configurados en la compañía padre
+        (branches): antes filtraba por company_id == company exacto, sin considerar
+        jerarquía, y una sucursal nunca veía los impuestos de la casa central."""
+        branch = self.env["res.company"].create({"name": "Branch WizardTest", "parent_id": self.company.id})
+        branch_journal = self.env["account.journal"].create(
+            {"name": "Branch Sale", "type": "sale", "company_id": branch.id}
+        )
+        parent_tax = self.env["account.tax"].create(
+            {
+                "name": "Parent Tax 21%",
+                "amount": 21,
+                "amount_type": "percent",
+                "type_tax_use": "sale",
+                "company_id": self.company.id,
+            }
+        )
+        product = self.env.ref("product.product_product_16")
+        product.with_company(branch).write({"taxes_id": [Command.set(parent_tax.ids)]})
+
+        payment = self.env["account.payment"].create(
+            {
+                "amount": 100,
+                "payment_type": "inbound",
+                "partner_type": "customer",
+                "partner_id": self.partner_ri.id,
+                "journal_id": self.company_bank_journal.id,
+                "date": self.today,
+                "company_id": branch.id,
+            }
+        )
+        wizard = (
+            self.env["account.payment.invoice.wizard"]
+            .with_context(active_id=payment.id)
+            .create(
+                {
+                    "payment_id": payment.id,
+                    "journal_id": branch_journal.id,
+                    "product_id": product.id,
+                    "amount_total": 100,
+                }
+            )
+        )
+        wizard.change_product()
+        self.assertIn(
+            parent_tax,
+            wizard.tax_ids,
+            "El impuesto de la compañía padre debería estar disponible para la sucursal.",
+        )

--- a/account_payment_pro/wizards/account_payment_invoice_wizard.py
+++ b/account_payment_pro/wizards/account_payment_invoice_wizard.py
@@ -120,7 +120,11 @@ class AccountPaymentInvoiceWizard(models.TransientModel):
         else:
             taxes = self.product_id.taxes_id
         company = self.company_id or self.env.company
-        taxes = taxes.filtered(lambda r: r.company_id == company)
+        # account.tax ya define _check_company_domain = check_company_domain_parent_of,
+        # así que un impuesto de la compañía padre es válido para este wizard. El
+        # exact match de acá abajo era más estricto que esa constraint: si el producto
+        # tiene impuestos configurados en la padre, una sucursal no los veía nunca.
+        taxes = taxes.filtered_domain(self.env["account.tax"]._check_company_domain(company))
         self.tax_ids = self.payment_id.partner_id.with_company(company).property_account_position_id.map_tax(taxes)
 
     @api.onchange("amount_untaxed", "tax_ids")


### PR DESCRIPTION
`account.payment.invoice.wizard.change_product` filtered the product's taxes
with an exact `company_id` match, ignoring the company hierarchy (branches —
`parent_id`/`child_ids`). If a product's taxes were configured on the parent
company, a branch never saw them when registering a debit/credit note from a
payment, even though `account.tax` already allows it via `check_company`
(`_check_company_domain = check_company_domain_parent_of`).

Now reuses that same domain via `filtered_domain` instead of an exact match.

## Test plan

- `test_change_product_includes_parent_company_taxes` (new): fails without the
  fix, passes with it.
- `account_payment_pro` suite green locally (`--test-tags /account_payment_pro`).


Replaces #1156 — same commit, branch recreated as `19.0-t-71848-cav-taxes` to
follow the branch naming convention.
