### PR TITLE
[FIX] l10n_ar_payment_bundle: reconcile bundle counterpart lines together

### DIFF
--- a/l10n_ar_payment_bundle/models/account_payment.py
+++ b/l10n_ar_payment_bundle/models/account_payment.py
@@ -180,6 +180,38 @@ class AccountPayment(models.Model):
 
         return res
 
+    def _reconcile_after_post(self):
+        """Conciliamos las contrapartidas del bundle entre sí, además de contra la deuda.
+
+        El super concilia pago por pago: la contrapartida de cada pago contra las
+        to_pay_move_line_ids que todavía estén sin conciliar. Cuando una línea del bundle va
+        en sentido opuesto al resto (típico: el ajuste por redondeo, o un cheque rechazado que
+        se paga en el momento con efectivo), el primer pago cubre toda la deuda y queda con
+        residuo, y esa línea de sentido opuesto ya no encuentra deuda libre: sólo podía
+        compensarse contra el residuo del hermano, que no está en to_pay_move_line_ids. Queda
+        entonces una conciliación parcial con dos apuntes abiertos que netean cero.
+        """
+        res = super()._reconcile_after_post()
+        valid_account_types = self._get_valid_payment_account_types()
+        bundles = (self.mapped("main_payment_id") | self.filtered("is_main_payment")).filtered(
+            lambda x: x.company_id.use_payment_pro and not x.is_internal_transfer
+        )
+        for main in bundles:
+            amls = (main | main.link_payment_ids).move_id.line_ids.filtered(
+                lambda x: (
+                    not x.reconciled
+                    and x.move_id.state == "posted"
+                    and x.account_id.account_type in valid_account_types
+                )
+            )
+            for account in amls.account_id:
+                for partner in amls.partner_id:
+                    lines = amls.filtered(lambda x: x.account_id == account and x.partner_id == partner)
+                    residuals = lines.mapped("amount_residual")
+                    if any(residual > 0 for residual in residuals) and any(residual < 0 for residual in residuals):
+                        lines.reconcile()
+        return res
+
     def action_draft(self):
         active_links = self.link_payment_ids.filtered(lambda p: p.state != "canceled")
         res = super(AccountPayment, self + active_links).action_draft()

--- a/l10n_ar_payment_bundle/tests/__init__.py
+++ b/l10n_ar_payment_bundle/tests/__init__.py
@@ -1,1 +1,1 @@
-from . import test_payment_difference
+from . import test_bundle_reconcile, test_payment_difference

--- a/l10n_ar_payment_bundle/tests/test_bundle_reconcile.py
+++ b/l10n_ar_payment_bundle/tests/test_bundle_reconcile.py
@@ -1,0 +1,181 @@
+# © 2026 ADHOC SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import Command, fields
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestBundleReconcile(TransactionCase):
+    """Conciliación de un bundle con una línea de pago en sentido opuesto.
+
+    Caso del ticket 123989: una OP con un pago que excede la deuda más un ajuste por redondeo
+    en sentido contrario que la lleva a cero. El super de _reconcile_after_post concilia pago
+    por pago contra to_pay_move_line_ids, así que el pago grande cierra toda la deuda y queda
+    con residuo, y el ajuste ya no encuentra deuda libre contra la que conciliarse: quedaban
+    dos apuntes abiertos que netean cero (conciliación parcial).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.company
+        cls.company.use_payment_pro = True
+
+        bundle_journal_id = cls.company._get_bundle_journal("outbound")
+        if bundle_journal_id:
+            cls.bundle_journal = cls.env["account.journal"].browse(bundle_journal_id)
+        else:
+            cls.bundle_journal = cls.env["account.journal"].create(
+                {
+                    "name": "Payment Bundle",
+                    "type": "cash",
+                    "code": "PBUND",
+                    "company_id": cls.company.id,
+                }
+            )
+
+        cls.payment_method_bundle = cls.env["account.payment.method"].search([("code", "=", "payment_bundle")], limit=1)
+        cls.payment_method_line = cls.env["account.payment.method.line"].search(
+            [
+                ("journal_id", "=", cls.bundle_journal.id),
+                ("payment_method_id", "=", cls.payment_method_bundle.id),
+                ("payment_type", "=", "outbound"),
+            ],
+            limit=1,
+        )
+
+        # Diario del pago y diario del ajuste por redondeo: dos diarios de efectivo distintos,
+        # como los usa el cliente (Caja Principal Auxiliar + Ajuste por Redondeo).
+        cls.cash_journal = cls.env["account.journal"].create(
+            {
+                "name": "Caja Test",
+                "type": "cash",
+                "code": "CSHT1",
+                "company_id": cls.company.id,
+            }
+        )
+        cls.rounding_journal = cls.env["account.journal"].create(
+            {
+                "name": "Ajuste por Redondeo Test",
+                "type": "cash",
+                "code": "ROUND",
+                "company_id": cls.company.id,
+            }
+        )
+
+        cls.partner = cls.env["res.partner"].create(
+            {
+                "name": "Test Vendor",
+                "vat": "34278580484",
+                "country_id": cls.env.ref("base.ar").id,
+            }
+        )
+
+        cls.purchase_journal = cls.env["account.journal"].search(
+            [("company_id", "=", cls.company.id), ("type", "=", "purchase")], limit=1
+        )
+
+        # Con account_multi_store instalado, su demo asigna a todos los diarios de la compañía un
+        # store con only_allow_reonciliaton_of_this_store: los diarios que creamos acá tienen que
+        # quedar en el mismo store que la deuda, si no reconcile() rechaza la conciliación.
+        if "store_id" in cls.env["account.journal"]._fields:
+            (cls.bundle_journal | cls.cash_journal | cls.rounding_journal).store_id = cls.purchase_journal.store_id
+
+    def _create_bill(self, amount):
+        bill = self.env["account.move"].create(
+            {
+                "partner_id": self.partner.id,
+                "invoice_date": fields.Date.today(),
+                "move_type": "in_invoice",
+                "journal_id": self.purchase_journal.id,
+                "company_id": self.company.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.env.ref("product.product_product_16").id,
+                            "quantity": 1,
+                            "price_unit": amount,
+                        }
+                    ),
+                ],
+            }
+        )
+        bill.action_post()
+        return bill
+
+    def _create_linked_payment(self, main, amount, payment_type, journal):
+        return self.env["account.payment"].create(
+            {
+                "payment_type": payment_type,
+                "partner_type": "supplier",
+                "partner_id": self.partner.id,
+                "journal_id": journal.id,
+                "amount": amount,
+                "main_payment_id": main.id,
+            }
+        )
+
+    def test_bundle_with_opposite_sign_rounding_line(self):
+        """Pago de 1000.50 + ajuste inbound de 0.50 contra una deuda de 1000."""
+        bill = self._create_bill(1000.0)
+        debt_line = bill.line_ids.filtered(lambda x: x.account_id.account_type == "liability_payable")
+
+        main = self.env["account.payment"].create(
+            {
+                "payment_type": "outbound",
+                "partner_type": "supplier",
+                "partner_id": self.partner.id,
+                "journal_id": self.bundle_journal.id,
+                "payment_method_line_id": self.payment_method_line.id,
+                "amount": 0,
+                "to_pay_move_line_ids": [Command.set(debt_line.ids)],
+            }
+        )
+        payment = self._create_linked_payment(main, 1000.5, "outbound", self.cash_journal)
+        rounding = self._create_linked_payment(main, 0.5, "inbound", self.rounding_journal)
+
+        main.action_post()
+
+        self.assertTrue(debt_line.full_reconcile_id, "La deuda debería quedar totalmente conciliada")
+        counterpart_lines = (payment | rounding).move_id.line_ids.filtered(
+            lambda x: x.account_id.account_type == "liability_payable"
+        )
+        self.assertEqual(
+            len(counterpart_lines), 2, "Cada pago vinculado debería tener su contrapartida en la cuenta de proveedores"
+        )
+        for line in counterpart_lines:
+            self.assertAlmostEqual(
+                line.amount_residual,
+                0.0,
+                places=2,
+                msg=f"{line.move_id.name} quedó con residuo {line.amount_residual}: conciliación parcial",
+            )
+        self.assertAlmostEqual(
+            rounding.matched_amount, 0.5, places=2, msg="El ajuste por redondeo debería quedar imputado"
+        )
+
+    def test_bundle_same_sign_lines_still_reconcile(self):
+        """Control: dos pagos en el mismo sentido que cierran la deuda exacta siguen conciliando."""
+        bill = self._create_bill(1000.0)
+        debt_line = bill.line_ids.filtered(lambda x: x.account_id.account_type == "liability_payable")
+
+        main = self.env["account.payment"].create(
+            {
+                "payment_type": "outbound",
+                "partner_type": "supplier",
+                "partner_id": self.partner.id,
+                "journal_id": self.bundle_journal.id,
+                "payment_method_line_id": self.payment_method_line.id,
+                "amount": 0,
+                "to_pay_move_line_ids": [Command.set(debt_line.ids)],
+            }
+        )
+        self._create_linked_payment(main, 999.5, "outbound", self.cash_journal)
+        self._create_linked_payment(main, 0.5, "outbound", self.rounding_journal)
+
+        main.action_post()
+
+        self.assertTrue(debt_line.full_reconcile_id, "La deuda debería quedar totalmente conciliada")
+        self.assertAlmostEqual(main.unmatched_amount, 0.0, places=2, msg="No debería quedar importe sin imputar")


### PR DESCRIPTION
Helpdesk ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/123989

## Problem

`account_payment_pro._reconcile_after_post()` reconciles payment by payment: each
payment counterpart against the `to_pay_move_line_ids` that are still open.

In a payment bundle every linked payment has its own journal entry and inherits
`to_pay_move_line_ids` from the main payment. When one line of the bundle goes in the
opposite direction to the rest — typically a rounding adjustment, or a rejected check
paid on the spot with cash — the sequence is:

1. The payment covering the debt reconciles first and closes it completely, keeping a
   residual equal to the adjustment.
2. The opposite-sign line finds `to_pay_move_line_ids` fully reconciled, so `debt_aml`
   is empty and it is never reconciled at all. It could only be offset against its
   sibling's residual, which is not part of `to_pay_move_line_ids`.

Result: two open lines on the same account and partner that net to zero, the documents
partially reconciled, and the partner ledger showing unreconciled movements.

Adjustments that go in the *same* direction as the payment are unaffected (the debt
covers them), which is why this only shows up on the opposite-sign case.

## Fix

Override `_reconcile_after_post()` in `l10n_ar_payment_bundle` (the bundle concept lives
here, so `account_payment_pro` keeps its behaviour for the rest of the localizations) to
run a second pass at bundle level: reconcile the counterpart lines of the main payment
plus all its linked payments together, grouped by account and partner, whenever there
are residuals on both sides.

## Test plan

`l10n_ar_payment_bundle/tests/test_bundle_reconcile.py`:

- `test_bundle_with_opposite_sign_rounding_line` — vendor bill of 1000, bundle with an
  outbound payment of 1000.50 plus an inbound rounding adjustment of 0.50. Asserts the
  bill gets `full_reconcile_id`, both payment counterparts end with `amount_residual == 0`
  and the adjustment ends up matched. Fails on 18.0 without this fix (both counterparts
  keep ±0.50).
- `test_bundle_same_sign_lines_still_reconcile` — control: two outbound payments adding
  up to the exact debt still reconcile and leave no unmatched amount.
