### PR TITLE
[IMP] l10n_latam_check_ux: build the check liquidity lines without the core patch

### DIFF
--- a/account_payment_pro/tests/test_checks_payment_pro.py
+++ b/account_payment_pro/tests/test_checks_payment_pro.py
@@ -334,45 +334,51 @@ class TestChecksPaymentPro(TestArCommon):
         self.assertEqual(len(self._liquidity_lines(payment)), 3, "Reposting keeps one line per check")
         self.assertEqual(len(payment.move_id.line_ids), 4)
 
-    # def test_writing_amount_on_two_payments_at_once_crashes_today(self):
-    #     """EQUIVALENCE (task 70884, BUG-3).
-    #
-    #     Pins what the patched core does today: it classifies the new lines with
-    #     ``self.outstanding_account_id`` instead of ``pay.outstanding_account_id``
-    #     inside its own ``for pay in self`` loop, so writing a trigger field on
-    #     several payments whose moves are in draft and whose outstanding accounts
-    #     differ raises ``Expected singleton``. It is not check specific: any
-    #     payment reset to draft is affected.
-    #
-    #     Whether the relocation reproduces it depends on how
-    #     ``_synchronize_to_moves`` is ported: copying the patched method verbatim
-    #     keeps the crash, delegating to ``super()`` fixes it - and then this
-    #     assertion has to be inverted in that same PR.
-    #     """
-    #     other_account = self.env["account.account"].create(
-    #         {
-    #             "name": "Test Deferred Checks 2",
-    #             "code": "TPPDEFCHK2",
-    #             "account_type": "asset_current",
-    #             "reconcile": True,
-    #             "company_ids": [Command.set(self.company.ids)],
-    #         }
-    #     )
-    #     other_line = self.env["account.payment.method.line"].create(
-    #         {
-    #             "payment_method_id": self.own_checks_line.payment_method_id.id,
-    #             "name": "Own Checks 2",
-    #             "payment_account_id": other_account.id,
-    #             "journal_id": self.bank_journal.id,
-    #         }
-    #     )
-    #     first = self._own_check_payment([20, 30], ["00032301", "00032302"])
-    #     second = self._own_check_payment([20, 30], ["00032303", "00032304"])
-    #     second.payment_method_line_id = other_line
-    #     payments = first + second
-    #     payments.action_post()
-    #     payments.action_draft()
-    #     self.assertNotEqual(first.outstanding_account_id, second.outstanding_account_id)
-    #
-    #     with self.assertRaisesRegex(ValueError, "Expected singleton"):
-    #         payments.write({"amount": 50})
+    def test_writing_amount_on_two_payments_at_once(self):
+        """The patched core crashed here (task 70884, BUG-3): it classified the
+        new lines with ``self.outstanding_account_id`` instead of
+        ``pay.outstanding_account_id`` inside its own ``for pay in self`` loop, so
+        writing a trigger field on several payments whose moves are in draft and
+        whose outstanding accounts differ raised ``Expected singleton``. It was
+        not check specific: any payment reset to draft was affected.
+
+        The relocation delegates ``_synchronize_to_moves`` to ``super()`` instead
+        of copying the patched method, so the crash is gone. Each payment keeps
+        its own outstanding account and its own line per check.
+        """
+        other_account = self.env["account.account"].create(
+            {
+                "name": "Test Deferred Checks 2",
+                "code": "TPPDEFCHK2",
+                "account_type": "asset_current",
+                "reconcile": True,
+                "company_ids": [Command.set(self.company.ids)],
+            }
+        )
+        other_line = self.env["account.payment.method.line"].create(
+            {
+                "payment_method_id": self.own_checks_line.payment_method_id.id,
+                "name": "Own Checks 2",
+                "payment_account_id": other_account.id,
+                "journal_id": self.bank_journal.id,
+            }
+        )
+        first = self._own_check_payment([20, 30], ["00032301", "00032302"])
+        second = self._own_check_payment([20, 30], ["00032303", "00032304"])
+        second.payment_method_line_id = other_line
+        payments = first + second
+        payments.action_post()
+        payments.action_draft()
+        self.assertNotEqual(first.outstanding_account_id, second.outstanding_account_id)
+
+        payments.write({"amount": 50})
+
+        for payment in payments:
+            self.assert_balanced(payment)
+            lines = self._liquidity_lines(payment)
+            self.assertEqual(len(lines), 2, "Each payment keeps one liquidity line per check")
+            self.assertEqual(
+                lines.account_id,
+                payment.outstanding_account_id,
+                "Each payment's lines must use its own outstanding account, not the first one's",
+            )

--- a/l10n_latam_check_ux/models/account_payment.py
+++ b/l10n_latam_check_ux/models/account_payment.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from odoo import api, fields, models
+from odoo import Command, _, api, fields, models
 from odoo.exceptions import ValidationError
 
 
@@ -215,6 +215,62 @@ class AccountPayment(models.Model):
                     % rec.destination_journal_id.display_name
                 )
 
+    def _l10n_latam_check_liquidity_lines(self):
+        """Una línea de liquidez por cheque, con su nominal, su vencimiento y su link (tarea 70884).
+
+        Relocaliza lo que hace `l10n_latam_check` cuando la imagen mergea el PR odoo#248741, para
+        que el asiento salga igual con un core sin parchear. El balance queda a la cotización del
+        pago; la revaluación de abajo lo ajusta a la del asiento.
+        """
+        check_suffix = "".join([item[1] for item in self._get_aml_default_display_name_list()])
+        line_common_vals = {
+            "currency_id": self.currency_id.id,
+            "partner_id": self.partner_id.id,
+            "account_id": self.outstanding_account_id.id,
+        }
+        liquidity_vals = []
+        for check in self.l10n_latam_new_check_ids | self.l10n_latam_move_check_ids:
+            liquidity_amount = check.amount if self.payment_type == "inbound" else -check.amount
+            liquidity_vals.append(
+                {
+                    "name": _("Check %(check_number)s - %(suffix)s", check_number=check.name, suffix=check_suffix),
+                    "date_maturity": check.payment_date,
+                    "amount_currency": liquidity_amount,
+                    "balance": self.currency_id._convert(
+                        liquidity_amount, self.company_currency_id, self.company_id, self.date
+                    ),
+                    "l10n_latam_check_ids": [Command.set(check.ids)],
+                    **line_common_vals,
+                }
+            )
+        return liquidity_vals
+
+    def _l10n_latam_check_split_move(self):
+        """No-op: las líneas de liquidez de arriba reemplazan al split move."""
+        return
+
+    def _l10n_latam_check_unlink_split_move(self):
+        """Solo desarma el split move de los pagos posteados antes de este cambio: si no queda
+        posteado y huérfano, con el importe del cheque en la cuenta outstanding."""
+        self.ensure_one()
+        for check in self.l10n_latam_new_check_ids:
+            if not check.outstanding_line_id or self.move_id == check.outstanding_line_id.move_id:
+                continue
+            check.outstanding_line_id.move_id.button_draft()
+            check.outstanding_line_id.move_id.unlink()
+
+    def _synchronize_to_moves(self, changed_fields):
+        """Base bloquea escribir ``amount`` cuando el asiento tiene más de una línea de liquidez, y
+        los pagos con cheques tienen una por cheque: se saca del set y el mapeo lo sigue haciendo
+        base. Si ``amount`` es el único campo escrito no se re-sincroniza nada, inocuo porque se
+        recalcula desde los cheques."""
+        with_checks = self.filtered(lambda x: x.l10n_latam_new_check_ids or x.l10n_latam_move_check_ids)
+        super(AccountPayment, self - with_checks)._synchronize_to_moves(changed_fields)
+        if with_checks:
+            super(AccountPayment, with_checks)._synchronize_to_moves(
+                tuple(field for field in changed_fields if field != "amount")
+            )
+
     def _prepare_paired_payment_values(self):
         """Override to validate check payment method combinations on internal transfers.
 
@@ -346,8 +402,13 @@ class AccountPayment(models.Model):
         decidiendo dónde cae el resto del redondeo, así que no es un borrado a ciegas.
         """
         lines = super()._prepare_move_liquidity_lines(default_values)
+        if not lines[0].get("l10n_latam_check_ids") and (
+            self.l10n_latam_new_check_ids | self.l10n_latam_move_check_ids
+        ):
+            # core sin parchear: las armamos nosotros (tarea 70884)
+            lines = self._l10n_latam_check_liquidity_lines()
         if not lines[0].get("l10n_latam_check_ids") or not self.amount:
-            # no las armó `l10n_latam_check`: no hay una línea por cheque que revaluar
+            # no hay una línea por cheque que revaluar
             return lines
 
         balance = default_values["balance"]

--- a/l10n_latam_check_ux/models/l10n_latam_check.py
+++ b/l10n_latam_check_ux/models/l10n_latam_check.py
@@ -85,8 +85,22 @@ class l10nLatamAccountPaymentCheck(models.Model):
         if payment_method_change or partner_id_change:
             super()._compute_issuer_vat()
 
+    @api.depends("outstanding_line_id.amount_residual")
     def _compute_issue_state(self):
+        """Solo los cheques propios tienen estado de emisión (tarea 70884).
+
+        Con una línea de liquidez por cheque los de terceros también tienen ``outstanding_line_id``,
+        así que base les daría un estado y entrarían al índice único de abajo, donde el mismo número
+        de dos libradores distintos es válido.
+
+        El ``@api.depends`` no se puede sacar: el ORM lee las dependencias del método más derivado
+        del MRO. Efecto colateral pinneado por los tests ``_today``: un cheque propio en borrador
+        queda 'debited', porque su línea todavía no tiene residual.
+        """
         super()._compute_issue_state()
+        self.filtered(lambda r: r.payment_method_code != "own_checks").issue_state = False
+
+        # si la cuenta no es conciliable no queda nada por debitar
         for rec in self.filtered(lambda r: r.payment_method_code == "own_checks"):
             account = rec.outstanding_line_id.account_id
             if account and not account.reconcile:

--- a/l10n_latam_check_ux/tests/test_own_checks_ux.py
+++ b/l10n_latam_check_ux/tests/test_own_checks_ux.py
@@ -5,18 +5,18 @@
 """Own checks: journal entry shape, lifecycle and border cases.
 
 Part of the harness of task 70884: it pins the behaviour of the core check patch
-the ADHOC image carries, so relocating that patch into our modules can be proven
-equivalent.
+the ADHOC image carries, now relocated into our modules.
 
 Tests whose name ends in ``_today`` pin a side effect of the patch on purpose -
-they are not the desired behaviour, and the task documents each one. They are
-kept commented out: they belong to the relocation PR, which is where each of
-them either flips or is deleted.
+they are not the desired behaviour, and the task documents each one. They assert
+the relocation is equivalent; fixing any of them is a separate PR, which is where
+the assertion flips.
 """
 
 from unittest.mock import patch
 
 from odoo import Command, fields
+from odoo.addons.l10n_latam_check.models.account_payment import AccountPayment as CoreCheckPayment
 from odoo.exceptions import UserError, ValidationError
 from odoo.tests import tagged
 from odoo.tools import mute_logger
@@ -60,6 +60,28 @@ class TestOwnChecksEntry(LatamCheckCommon):
             [("line_ids.account_id", "=", self.deferred_check_account.id), ("company_id", "=", self.company.id)]
         )
         self.assertEqual(moves, payment.move_id, "Only the payment move should touch the deferred checks account")
+
+    def test_the_lines_are_built_here_when_the_core_does_not(self):
+        """Con un core sin parchear el modulo arma las N lineas por su cuenta (tarea 70884).
+
+        Se simula parcheando ``l10n_latam_check`` para que devuelva una sola linea de liquidez, que
+        es lo que hace el core vanilla. Sin esto la relocalizacion no tiene cobertura: con la imagen
+        parcheada -y en runbot- las lineas las arma el core y nunca se entra por esta rama.
+        """
+        payment = self._create_own_check_payment([20, 30], numbers=["00000301", "00000302"])
+        default_vals = {"name": "test", "amount_currency": -50.0, "balance": -50.0}
+        with patch.object(CoreCheckPayment, "_prepare_move_liquidity_lines", lambda self, vals: [dict(vals)]):
+            lines = payment._prepare_move_liquidity_lines(default_vals)
+
+        self.assertEqual([line["amount_currency"] for line in lines], [-20.0, -30.0])
+        self.assertEqual([line["balance"] for line in lines], [-20.0, -30.0])
+        self.assertEqual(
+            [line["date_maturity"] for line in lines], payment.l10n_latam_new_check_ids.mapped("payment_date")
+        )
+        for line, check in zip(lines, payment.l10n_latam_new_check_ids):
+            self.assertEqual(line["account_id"], payment.outstanding_account_id.id)
+            self.assertIn(check.name, line["name"])
+            self.assertEqual(line["l10n_latam_check_ids"], [Command.set(check.ids)])
 
 
 @tagged("post_install", "-at_install")
@@ -202,35 +224,35 @@ class TestOwnChecksMulticurrency(LatamCheckCommon):
 class TestOwnChecksLifecycle(LatamCheckCommon):
     """Draft / post / cancel / reset-to-draft and issue_state transitions."""
 
-    # def test_draft_check_is_debited_and_blocks_cancel_today(self):
-    #     """EQUIVALENCE (task 70884, BUG-1: draft issue_state).
-    #
-    #     Pins what the patched core does today, which the relocation must
-    #     reproduce: ``_compute_issue_state`` decides by ``payment_method_code``
-    #     instead of by ``outstanding_line_id``, so a draft own check -one that was
-    #     never handed out- comes out as 'debited'; and as a consequence the draft
-    #     payment cannot be cancelled.
-    #
-    #     It is a known defect; fixing it is a separate PR.
-    #     """
-    #     payment = self._create_own_check_payment([100], numbers=["00002101"])
-    #
-    #     self.assertEqual(payment.l10n_latam_new_check_ids.issue_state, "debited")
-    #     with self.assertRaises(UserError):
-    #         payment.action_cancel()
+    def test_draft_check_is_debited_today(self):
+        """EQUIVALENCE (task 70884, BUG-1: draft issue_state).
 
-    # @mute_logger("odoo.sql_db")
-    # def test_two_draft_payments_cannot_repeat_a_number_today(self):
-    #     """EQUIVALENCE (task 70884, BUG-1: draft issue_state).
-    #
-    #     Same root cause, pinned so the relocation reproduces it: the ux unique
-    #     index covers checks with an issue_state, and since drafts now get one,
-    #     two *draft* payments sharing a number already hit the database
-    #     constraint, which should only happen for handed checks. Separate PR.
-    #     """
-    #     self._create_own_check_payment([100], numbers=["00002301"])
-    #     with self.assertRaises(IntegrityError), self.cr.savepoint():
-    #         self._create_own_check_payment([100], numbers=["00002301"])
+        Un cheque propio en borrador -que nunca se entrego- sale 'debited', porque el estado se
+        decide por metodo de pago y su linea de liquidez todavia no existe. Es un defecto conocido y
+        arreglarlo es otro PR.
+
+        Cancelar el pago SI funciona: el guard de ``_get_reconciled_checks_error`` mira la cuenta de
+        la linea, que en borrador no hay.
+        """
+        payment = self._create_own_check_payment([100], numbers=["00002101"])
+
+        self.assertEqual(payment.l10n_latam_new_check_ids.issue_state, "debited")
+        self.assertFalse(payment.l10n_latam_new_check_ids.outstanding_line_id)
+        payment.action_cancel()
+        self.assertEqual(payment.state, "canceled")
+
+    @mute_logger("odoo.sql_db")
+    def test_two_draft_payments_cannot_repeat_a_number_today(self):
+        """EQUIVALENCE (task 70884, BUG-1: draft issue_state).
+
+        Same root cause, pinned because the relocation reproduces it: the ux
+        unique index covers checks with an issue_state, and since drafts now get
+        one, two *draft* payments sharing a number already hit the database
+        constraint, which should only happen for handed checks. Separate PR.
+        """
+        self._create_own_check_payment([100], numbers=["00002301"])
+        with self.assertRaises(IntegrityError), self.cr.savepoint():
+            self._create_own_check_payment([100], numbers=["00002301"])
 
     @mute_logger("odoo.sql_db")
     def test_check_number_is_unique_per_payment_method_line(self):
@@ -271,6 +293,35 @@ class TestOwnChecksLifecycle(LatamCheckCommon):
         payment.action_post()
         self.assert_move_balanced(payment.move_id)
         self.assert_check_lines_match(payment)
+
+    def test_legacy_split_move_is_still_unlinked(self):
+        """Un pago posteado antes de este cambio apunta a un asiento de split aparte, y al volver a
+        borrador se sigue desarmando. Se llama al metodo directo porque su gancho -``button_draft``
+        de ``account.move``- solo existe con el core sin parchear.
+        """
+        payment = self._create_own_check_payment([100], numbers=["00002601"])
+        payment.action_post()
+        check = payment.l10n_latam_new_check_ids
+        split_move = self.env["account.move"].create(
+            {
+                "journal_id": payment.journal_id.id,
+                "line_ids": [
+                    Command.create(
+                        {"name": "legacy split", "account_id": self.deferred_check_account.id, "debit": 100.0}
+                    ),
+                    Command.create(
+                        {"name": "legacy split", "account_id": self.deferred_check_account.id, "credit": 100.0}
+                    ),
+                ],
+            }
+        )
+        split_move.action_post()
+        check.outstanding_line_id = split_move.line_ids[0]
+
+        payment._l10n_latam_check_unlink_split_move()
+
+        self.assertFalse(split_move.exists(), "The legacy split move must be dropped")
+        self.assertTrue(payment.move_id.exists(), "The payment move is not the split move")
 
     def test_void_affects_only_its_check_and_blocks_reset_to_draft(self):
         """Anular 1 de 3 cheques: el cheque queda anulado y su linea conciliada


### PR DESCRIPTION
Tarea 70884. Baja a nuestros módulos el parche de core que la imagen ADHOC arrastra (odoo/odoo pr248741), para poder correr un core vanilla. Va sobre el harness de tests que se mergeó antes en esta misma tarea.

Rebasado sobre 19.0 después del PR 1175, que se metió en el medio y cambió el alcance de esto: ese PR ya puso un `_prepare_move_liquidity_lines` en `l10n_latam_check_ux`, pero como post-proceso — hace `super()` y revalúa las líneas **que el core ya armó**, con salida temprana si no vienen. Con un core sin parchear no viene ninguna, así que la relocalización sigue siendo necesaria; lo que cambia es que ahora no puede ser una copia del parche, tiene que convivir con esa revaluación.

## Qué hace

Todo en `l10n_latam_check_ux`:

| Override | Qué hace |
|---|---|
| `_l10n_latam_check_liquidity_lines` | Arma una línea de liquidez por cheque (propios y de terceros), con su nominal, su vencimiento y su link al cheque. El balance va a la cotización del pago; la revaluación del PR 1175 lo ajusta después a la del asiento |
| `_prepare_move_liquidity_lines` | Llama a lo de arriba **solo cuando el core no armó las líneas**, o sea con core vanilla. Con la imagen parcheada no cambia nada |
| `_l10n_latam_check_split_move` | No-op: ya no hace falta el asiento extra |
| `_l10n_latam_check_unlink_split_move` | Sigue desarmando el split move de los pagos posteados antes de este cambio. Si no, al volver uno a borrador ese asiento queda posteado y colgado, con el importe del cheque en la cuenta outstanding |
| `_compute_issue_state` | Solo los cheques propios tienen estado de emisión. No es opcional: con una línea por cheque los de terceros también tienen `outstanding_line_id`, así que base les daría un estado y entrarían al índice único del módulo, donde el mismo número de dos libradores distintos es válido. Delega en `super()` y limpia el resto, en vez de copiar el método |
| `_synchronize_to_moves` | Saca `amount` del set de disparadores para pagos con cheques y delega en `super()`, en vez de copiar el mapeo de base, para seguir heredando upstream |

## Tests

- `test_the_lines_are_built_here_when_the_core_does_not` parchea `l10n_latam_check` para que devuelva una sola línea de liquidez, que es lo que hace el core vanilla. Sin esto la relocalización no tiene ninguna cobertura: con la imagen parcheada, y en runbot, las líneas las arma el core y nunca se entra por esa rama.
- `test_legacy_split_move_is_still_unlinked` cubre la rama legacy del unlink llamando al método directo, porque su gancho (`button_draft` de `account.move`) solo existe con el core sin parchear.
- `test_draft_check_is_debited_today` sigue afirmando que un cheque propio en borrador sale `debited`, y ahora además que el pago **sí** se puede cancelar: el guard que agregó el PR de débito automático mira la cuenta de la línea del cheque, y un pago en borrador todavía no tiene línea.
- `test_writing_amount_on_two_payments_at_once` **se da vuelta acá**: base clasificaba las líneas nuevas con `self.outstanding_account_id` dentro de su propio loop sobre `self`, así que escribir sobre varios pagos en borrador con cuentas outstanding distintas tiraba `Expected singleton`. Delegar en `super()` saca el crash.
- Se cayó el test de equivalencia del cheque diferido con FX: el PR 1175 arregló que ese asiento no cerraba (ticket 123832) y tiene su propio test afirmando lo contrario.

## Sobre el split move viejo

El no-op del unlink se acotó a partir de la review. Para medir el riesgo sobre dato existente se cargaron dos KPIs sobre bases productivas 19.0: uno que cuenta líneas con link a cheque en asientos sin `origin_payment_id` (los split moves) y uno de control que cuenta líneas con link a cheque. El primero da **0 en las 178 bases**; el de control da >0 en 63, lo que confirma que la consulta corre de verdad. O sea hoy no hay ningún split move dando vueltas; la rama legacy queda para una base que venía operando con el core sin parchear y recién después instala el módulo.

## Estado

- Core parcheado + este PR: **60 tests, 0 failed** (`l10n_latam_check_ux` + `TestChecksPaymentPro`).
- Core vanilla + este PR: falta volver a medirlo después del rebase. La única roja conocida es el test del botón *Journal Entry*, que necesita el override de vista: ese override no se puede agregar todavía porque con el core parcheado el botón no existe y el xpath rompe la carga del módulo. Va junto con el desparche del core.
