### PR TITLE
[FIX] account_payment_pro: keep the payment entry balanced with several check lines

### DIFF
--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -747,17 +747,18 @@ class AccountPayment(models.Model):
         # Cuando force_balance está definido, el balance ya fue forzado por base Odoo
         # (ej: paired payment de transferencia interna) y NO debe recalcularse.
         if self.accounting_rate and self.currency_id != self.company_currency_id and force_balance is None:
-            # Usar amount_exact si está disponible para evitar desbalances por redondeo.
-            # Cuando hay una sola línea de liquidez, usamos amount_exact directamente.
-            # Cuando hay múltiples líneas (cheques), usamos el amount_currency de cada una.
+            # Con una sola línea de liquidez el nominal sale de amount_exact, que conserva la
+            # precisión completa del importe. Solo fija el nominal: el balance lo deriva el loop de
+            # abajo, así que ese loop tiene que quedar DESPUÉS de este if.
             if len(liquidity_lines) == 1 and self.amount_exact and self.amount_exact != self.amount:
-                amount_for_balance = self.amount_exact
                 liq_sign = 1 if liquidity_lines[0]["amount_currency"] >= 0 else -1
-                liquidity_lines[0]["amount_currency"] = liq_sign * abs(amount_for_balance)
-                liquidity_lines[0]["balance"] = liquidity_lines[0]["amount_currency"] / self.accounting_rate
-            else:
-                for liq_line in liquidity_lines:
-                    liq_line["balance"] = liq_line["amount_currency"] / self.accounting_rate
+                liquidity_lines[0]["amount_currency"] = liq_sign * abs(self.amount_exact)
+            # El balance se redondea por línea porque así lo va a persistir el ORM y la
+            # contrapartida se arma más abajo con la suma: sin redondear acá,
+            # sum(round(línea)) != round(sum(líneas)) y el asiento cierra con centavos de
+            # diferencia por cada línea de más (ticket 123832).
+            for liq_line in liquidity_lines:
+                liq_line["balance"] = self.company_currency_id.round(liq_line["amount_currency"] / self.accounting_rate)
 
         # ── Recalcular balance de CONTRAPARTIDA para cerrar el asiento ────────────
         write_off_balance = sum(line["balance"] for line in res.get("write_off_lines", []))
@@ -769,29 +770,31 @@ class AccountPayment(models.Model):
         if self.is_internal_transfer:
             # Transferencia interna: la línea de cuenta puente va siempre en moneda
             # de compañía (C) para que ambos lados (original y paired) reconcilien
-            # correctamente en amount_currency y balance.
-            counterpart_lines[0].update(
-                {
-                    "currency_id": self.company_currency_id.id,
-                    "amount_currency": counterpart_lines[0]["balance"],
-                }
-            )
+            # correctamente en amount_currency y balance. El nominal lo espeja el
+            # bloque final, igual que en las otras ramas.
+            counterpart_lines[0]["currency_id"] = self.company_currency_id.id
         elif self.counterpart_currency_id and self.counterpart_currency_id != self.currency_id:
             # Si A != B1: la contrapartida va en moneda B1 (counterpart_currency_id)
-            cp_sign = 1 if counterpart_lines[0].get("amount_currency", 0) >= 0 else -1
-            # La contrapartida AP/AR cubre el TOTAL de la deuda cancelada: cash + write-off.
-            # counterpart_currency_amount = porción cash en B1, write_off_amount está en B2.
-            # Cuando B1 == B2 (caso estándar sin reconcile_on_company_currency) sumamos directo.
-            counterpart_amt = abs(self.counterpart_currency_amount)
-            if self.write_off_amount and self.destination_currency_id == self.counterpart_currency_id:
-                counterpart_amt += abs(self.write_off_amount)
-            counterpart_lines[0].update(
-                {
-                    "currency_id": self.counterpart_currency_id.id,
-                    "amount_currency": cp_sign * counterpart_amt,
-                }
-            )
+            counterpart_lines[0]["currency_id"] = self.counterpart_currency_id.id
+            # El nominal solo se calcula cuando B1 es una tercera moneda: si B1 == C lo espeja
+            # el balance más abajo, y calcularlo acá sería trabajo que se descarta.
+            if self.counterpart_currency_id != self.company_currency_id:
+                cp_sign = 1 if counterpart_lines[0].get("amount_currency", 0) >= 0 else -1
+                # La contrapartida AP/AR cubre el TOTAL de la deuda cancelada: cash + write-off.
+                # counterpart_currency_amount = porción cash en B1, write_off_amount está en B2.
+                # Cuando B1 == B2 (caso estándar sin reconcile_on_company_currency) sumamos directo.
+                counterpart_amt = abs(self.counterpart_currency_amount)
+                if self.write_off_amount and self.destination_currency_id == self.counterpart_currency_id:
+                    counterpart_amt += abs(self.write_off_amount)
+                counterpart_lines[0]["amount_currency"] = cp_sign * counterpart_amt
         # Si A == B1: la moneda ya es correcta (A), solo el balance se actualizó arriba
+
+        # Cualquiera de las ramas anteriores puede dejar la contrapartida en moneda de
+        # compañía, y ahí el nominal y el balance son la misma cifra por definición: tiene
+        # que salir del balance, porque calculado aparte (counterpart_currency_amount) se
+        # redondea solo y deja el asiento desbalanceado por centavos (ticket 123832).
+        if counterpart_lines[0].get("currency_id") == self.company_currency_id.id:
+            counterpart_lines[0]["amount_currency"] = counterpart_lines[0]["balance"]
 
         return res
 

--- a/account_payment_pro/tests/test_checks_payment_pro.py
+++ b/account_payment_pro/tests/test_checks_payment_pro.py
@@ -194,6 +194,78 @@ class TestChecksPaymentPro(TestArCommon):
         for line in self._liquidity_lines(manual):
             self.assertEqual(abs(line.balance), abs(line.amount_currency) * 1000)
 
+    def test_multi_checks_with_a_rate_that_does_not_divide_exactly(self):
+        """Ticket 123832: dos cheques y una tasa cuya división deja fracciones de
+        centavo. Cada cifra del asiento se redondea por separado, así que el balance
+        de la contrapartida y su nominal tienen que derivar de los balances ya
+        redondeados de las líneas de cheque; si alguno se calcula solo, ``action_post``
+        explota con "El asiento no está balanceado".
+        """
+        rate = 0.024841017488076312  # 1 USD = 40,256; la division no da exacta
+        payment = self._own_check_payment([39717.71, 39717.71], ["00031301", "00031302"], currency=self.usd)
+        payment.accounting_rate = rate
+        payment.action_post()
+
+        self.assert_balanced(payment)
+        lines = self._liquidity_lines(payment)
+        self.assertEqual(
+            [abs(line.balance) for line in lines],
+            [1598876.13, 1598876.13],
+            "Cheques iguales tienen que valer lo mismo: cada uno es su propia conversión",
+        )
+        self.assertEqual(len(payment.move_id.line_ids), 3, "Sin líneas de ajuste extra en el asiento")
+        counterpart = self._counterpart_line(payment)
+        self.assertEqual(
+            abs(counterpart.balance),
+            3197752.26,
+            "La contrapartida absorbe el residuo: es la suma de las conversiones de cada cheque",
+        )
+        self.assertEqual(
+            abs(counterpart.amount_currency),
+            abs(counterpart.balance),
+            "En moneda de compañía el nominal y el balance son la misma cifra",
+        )
+
+        # Misma operación con la contrapartida en la moneda del pago en vez de la de
+        # compañía: el otro camino por el que se desbalanceaba (B1 == A, counterpart_rate 1).
+        in_payment_currency = self._own_check_payment([39717.71, 39717.71], ["00031303", "00031304"], currency=self.usd)
+        in_payment_currency.counterpart_currency_id = self.usd
+        in_payment_currency.accounting_rate = rate
+        in_payment_currency.action_post()
+
+        self.assert_balanced(in_payment_currency)
+        counterpart = self._counterpart_line(in_payment_currency)
+        self.assertEqual(counterpart.currency_id, self.usd)
+        self.assertEqual(
+            abs(counterpart.balance),
+            3197752.26,
+            "También acá la contrapartida es la suma de las conversiones de cada cheque",
+        )
+        self.assertEqual(abs(counterpart.amount_currency), 79435.42)
+        self.assertEqual(
+            [abs(line.balance) for line in self._liquidity_lines(in_payment_currency)],
+            [1598876.13, 1598876.13],
+            "Cheques iguales, valores iguales, sea cual sea la moneda de la contrapartida",
+        )
+
+    def test_single_check_derives_its_balance_from_amount_exact(self):
+        """Con una sola línea de liquidez el balance deriva de ``amount_exact``, no del
+        nominal redondeado a la moneda del cheque."""
+        payment = self._own_check_payment([1000.02], ["00031401"], currency=self.usd)
+        payment.accounting_rate = 1 / 1247.35
+        payment.amount_exact = 1000.0234567
+        payment.action_post()
+
+        self.assert_balanced(payment)
+        line = self._liquidity_lines(payment)
+        self.assertEqual(len(line), 1)
+        self.assertEqual(abs(line.amount_currency), 1000.02, "El nominal se redondea a la moneda del cheque")
+        self.assertEqual(
+            abs(line.balance),
+            self.company.currency_id.round(1000.0234567 * 1247.35),
+            "El balance sale de amount_exact, no del nominal redondeado",
+        )
+
     def test_deferred_checks_in_foreign_currency_stay_balanced(self):
         """Deferred checks (payment_date well after the payment date).
 


### PR DESCRIPTION
## Problem

Posting a check payment fails with **"The entry is not balanced."** whenever the
payment carries **two or more checks** and the payment currency differs from the
company currency. With a single check it never fails, which is why it looks
intermittent. Reported on helpdesk ticket 123832.

## Root cause

Check payments are the only case where `_prepare_move_lines_per_type` receives
more than one liquidity line (`l10n_latam_check` builds one per check). Two
figures were each computed on their own while the ORM rounds every Monetary
value line by line:

1. Each liquidity balance was the exact quotient `amount_currency / accounting_rate`,
   and the single counterpart line was derived from their **unrounded** sum. Since
   the ORM rounds each line as it is written, `sum(round(x_i)) != round(sum(x_i))`
   and the entry closed with up to half a cent of difference per extra line.
2. When the counterpart ends up in company currency, its `amount_currency` came
   from `counterpart_currency_amount` (rounded independently) instead of the
   balance it has to mirror — in company currency both are the same figure by
   definition.

## Fix

- Round each liquidity balance with the company currency **before** the
  counterpart is built from their sum. Every check keeps its own conversion, so two
  identical checks are worth the same amount, and the counterpart absorbs the
  rounding residual.
- Mirror the counterpart nominal from its own balance whenever the line ends up in
  company currency, as a final step covering all three branches instead of a
  special case inside one of them. This replaces the equivalent guard that
  `l10n_ar_tax` carries downstream inside `if wth_lines:` (which is why it did not
  cover this case); that duplicate can be dropped in a follow-up.
- Collapsed the duplicated balance expression: the single-line branch now only
  fixes the nominal from `amount_exact` and the shared loop derives every balance,
  so the rounding rule lives in one place.
- Dropped the now-dead nominal computation in the `elif` branch and in the
  internal-transfer branch: when the counterpart ends in company currency the final
  mirror owns that value.

## Known behaviour, deliberately not addressed here

Because the counterpart absorbs the rounding residual, the accounted total can
differ by cents from the conversion of the payment amount — the figure shown on the
payment form (`counterpart_currency_amount`) and on the receipt (`payment_total`).

An earlier revision of this PR aligned those fields against the accounted move. It
was removed: a compute that reads back the move it feeds resolves inside
`_synchronize_to_moves` against the previous lines, and a tolerance window wide
enough to absorb the residual also absorbs write-off and withholding amounts. That
produced swallowed user corrections, double-counted write-offs and a
double-counted withholding total upstream of `l10n_ar_tax`. Aligning the displayed
figure needs a different mechanism (a rounding line in the entry, or a separate
read-only figure) and belongs in its own change.

Not touched either: `amount` stays equal to the sum of the checks.

## Test plan

`account_payment_pro/tests/test_checks_payment_pro.py`, two new tests:

- `test_multi_checks_with_a_rate_that_does_not_divide_exactly` — two checks and a
  rate whose division leaves fractions of a cent, with the counterpart both in
  company currency and in the payment currency. Fails on `action_post` without
  this fix. Also pins that identical checks are worth the same, that the entry
  keeps its three lines, and that the counterpart equals the sum of the rounded
  conversions.
- `test_single_check_derives_its_balance_from_amount_exact` — pins the
  single-liquidity-line path, which depends on the shared loop running after the
  nominal override.

- `-u account_payment_pro,l10n_latam_check_ux --test-tags /account_payment_pro,/l10n_latam_check_ux`
  → 83 post-tests, 0 failed. The one error in
  `TestAccountPaymentProUnitTest.test_change_product_includes_parent_company_taxes`
  is pre-existing and unrelated (reproduced on a clean tree, multi-company data).
- `l10n_ar_payment_bundle` (untouched by this PR) → 12 post-tests, 0 failed,
  including the withholding and internal-transfer cases.
- Matrix of 10 amount/rate combinations (1 to 12 checks, hand-typed rates, uneven
  amounts, one-cent checks): identical checks are equal, the counterpart equals
  their sum, every entry balances, and an exact division changes nothing.
- Also checked numerically over ~60k generated combinations (currencies rounding to
  0.01 / 1 / 0.001, table and hand-typed rates, with and without write-off).