### PR TITLE
[FIX] l10n_latam_check_ux: make check flows company aware with branches

### DIFF
--- a/l10n_latam_check_ux/models/account_account.py
+++ b/l10n_latam_check_ux/models/account_account.py
@@ -7,10 +7,17 @@ class AccountAccount(models.Model):
     def write(self, vals):
         res = super().write(vals)
         if "reconcile" in vals:
-            checks = self.env["l10n_latam.check"].search(
-                [
-                    ("outstanding_line_id.account_id", "in", self.ids),
-                ]
+            # sudo: the account is shared across the whole company hierarchy, so the stored
+            # issue_state of checks living in branches the user has not enabled must be
+            # recomputed as well.
+            checks = (
+                self.env["l10n_latam.check"]
+                .sudo()
+                .search(
+                    [
+                        ("outstanding_line_id.account_id", "in", self.ids),
+                    ]
+                )
             )
             checks._compute_issue_state()
         return res

--- a/l10n_latam_check_ux/models/res_partner.py
+++ b/l10n_latam_check_ux/models/res_partner.py
@@ -11,21 +11,27 @@ class ResPartner(models.Model):
     def _credit_debit_get(self):
         super()._credit_debit_get()
         for partner in self.filtered("add_check_credit"):
-            partner_checks = self.env["l10n_latam.check"].search(
-                [
-                    # Partner actual
-                    ("partner_id", "=", partner.id),
-                    # Filtro por empresa actual
-                    ("company_id", "=", self.env.company.id),
-                    # Filtro On-Hand
-                    (
-                        "current_journal_id.inbound_payment_method_line_ids.payment_method_id.code",
-                        "=",
-                        "in_third_party_checks",
-                    ),
-                    # Cuya fecha de pago sea mayor a la de hoy
-                    ("payment_date", ">", fields.Date.context_today(self)),
-                ]
+            # sudo + child_of para alinearnos con el _credit_debit_get de core, que agrega los
+            # apuntes de toda la jerarquía de compañías (branches) con bypass_access.
+            partner_checks = (
+                self.env["l10n_latam.check"]
+                .sudo()
+                .search(
+                    [
+                        # Partner actual
+                        ("partner_id", "=", partner.id),
+                        # Filtro por la compañía activa y sus sucursales
+                        ("company_id", "child_of", self.env.company.root_id.id),
+                        # Filtro On-Hand
+                        (
+                            "current_journal_id.inbound_payment_method_line_ids.payment_method_id.code",
+                            "=",
+                            "in_third_party_checks",
+                        ),
+                        # Cuya fecha de pago sea mayor a la de hoy
+                        ("payment_date", ">", fields.Date.context_today(self)),
+                    ]
+                )
             )
 
             partner.credit += sum(partner_checks.mapped("amount"))

--- a/l10n_latam_check_ux/reports/report_checks_to_date.xml
+++ b/l10n_latam_check_ux/reports/report_checks_to_date.xml
@@ -6,8 +6,12 @@
     <t t-set="company" t-value="env.company"/>
         <t t-call="web.internal_layout">
             <h3 class="text-center">Listado de cheques pendientes al <span t-field="docs.to_date"/></h3>
+            <t t-set="report_companies" t-value="docs._get_report_companies()"/>
+            <div>
+                Compañía: <span t-out="', '.join(report_companies.mapped('name'))"/>
+            </div>
             <t t-if="docs.journal_id">
-                Diario: <span t-esc="docs.env['account.journal'].browse(docs.journal_id.id).name"/>
+                Diario: <span t-out="docs.journal_id.name"/>
             </t>
             <div class="page">
                 <t t-if="docs._get_checks_handed(docs.journal_id.id, docs.to_date)">
@@ -20,6 +24,7 @@
                                 <th class="text-left">Fecha contable</th>
                                 <th class="text-left">Fecha de pago</th>
                                 <th class="text-left">Empresa</th>
+                                <th t-if="len(report_companies) > 1" class="text-left">Compañía</th>
                                 <th class="text-left">Importe</th>
                             </tr>
                         </thead>
@@ -38,6 +43,9 @@
                                 </td>
                                 <td>
                                     <span t-out="tcheck.partner_id.name" />
+                                </td>
+                                <td t-if="len(report_companies) > 1">
+                                    <span t-out="tcheck.company_id.name"/>
                                 </td>
                                 <td>
                                     <span t-out="tcheck.amount"  t-options='{"widget": "monetary", "display_currency": tcheck.currency_id}'/>
@@ -66,6 +74,7 @@
                                 <th class="text-left">Fecha contable</th>
                                 <th class="text-left">Fecha de pago</th>
                                 <th class="text-left">Cuit</th>
+                                <th t-if="len(report_companies) > 1" class="text-left">Compañía</th>
                                 <th class="text-left">Importe</th>
                             </tr>
                         </thead>
@@ -84,6 +93,9 @@
                                 </td>
                                 <td>
                                     <span t-out="tcheck.issuer_vat" />
+                                </td>
+                                <td t-if="len(report_companies) > 1">
+                                    <span t-out="tcheck.company_id.name"/>
                                 </td>
                                 <td>
                                     <span t-out="tcheck.amount"  t-options='{"widget": "monetary", "display_currency": tcheck.currency_id}'/>

--- a/l10n_latam_check_ux/tests/test_check_transfers.py
+++ b/l10n_latam_check_ux/tests/test_check_transfers.py
@@ -1,6 +1,6 @@
 from odoo import Command, fields
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
 from odoo.tests.common import tagged
 
 
@@ -152,6 +152,23 @@ class TestL10nLatamCheckUxTransfers(AccountTestInvoicingCommon):
         payment.action_post()
         return payment.l10n_latam_new_check_ids
 
+    def _create_branch(self, name="Branch", parent=None):
+        """Sucursal que comparte el plan de cuentas de su padre.
+
+        Las propiedades company dependent del partner hay que setearlas para la sucursal
+        para poder postear pagos en ella.
+        """
+        parent = parent or self.company
+        branch = self.env["res.company"].create({"name": name, "parent_id": parent.id})
+        self.partner_a.with_company(branch).write(
+            {
+                "property_account_receivable_id": self.company_data["default_account_receivable"].id,
+                "property_account_payable_id": self.company_data["default_account_payable"].id,
+            }
+        )
+        branch.transfer_account_id = self.company.transfer_account_id
+        return branch
+
     def test_deposit_third_party_check_to_bank(self):
         check = self._create_third_party_check(self.third_party_check_journal, "UX-DEP-0001")
         bank_journal = self.company_bank_journal
@@ -173,16 +190,7 @@ class TestL10nLatamCheckUxTransfers(AccountTestInvoicingCommon):
         Las operaciones de la sucursal de origen tienen que seguir visibles en el historial del
         cheque después de transferirlo a un diario de la compañía padre.
         """
-        branch = self.env["res.company"].create({"name": "Branch", "parent_id": self.company.id})
-        # the branch shares the parent chart of accounts, but the company dependent properties of
-        # the partner have to be set for it so the receipt can be posted
-        self.partner_a.with_company(branch).write(
-            {
-                "property_account_receivable_id": self.company_data["default_account_receivable"].id,
-                "property_account_payable_id": self.company_data["default_account_payable"].id,
-            }
-        )
-        branch.transfer_account_id = self.company.transfer_account_id
+        branch = self._create_branch()
         self.assertTrue(branch.transfer_account_id, "An internal transfer account is required to run this test")
         branch_journal = self._create_check_journal("Branch Third Party Checks", "BTPC", company=branch)
         check = self._create_third_party_check(branch_journal, "UX-BRANCH-0001")
@@ -303,3 +311,21 @@ class TestL10nLatamCheckUxTransfers(AccountTestInvoicingCommon):
                     "amount": 200.0,
                 }
             )
+
+    def test_partner_check_credit_includes_branch_checks(self):
+        """El crédito por cheques tiene que abarcar el árbol de compañías, como el de core.
+
+        `_credit_debit_get` de core agrega los apuntes con `child_of` sobre la raíz, así que
+        sumar los cheques de una sola compañía deja el total inconsistente: la casa central ve
+        las facturas de la sucursal pero no sus cheques.
+        """
+        branch = self._create_branch()
+        branch_journal = self._create_check_journal("Branch Third Party Checks", "BTPC1", company=branch)
+        self._create_third_party_check(branch_journal, "UX-CREDIT-0001")
+
+        partner_from_parent = self.partner_a.with_company(self.company)
+        partner_from_parent.add_check_credit = False
+        credit_without_checks = partner_from_parent.credit
+        partner_from_parent.add_check_credit = True
+
+        self.assertEqual(partner_from_parent.credit - credit_without_checks, 100.0)

--- a/l10n_latam_check_ux/tests/test_check_transfers.py
+++ b/l10n_latam_check_ux/tests/test_check_transfers.py
@@ -329,3 +329,22 @@ class TestL10nLatamCheckUxTransfers(AccountTestInvoicingCommon):
         partner_from_parent.add_check_credit = True
 
         self.assertEqual(partner_from_parent.credit - credit_without_checks, 100.0)
+
+    def test_mass_transfer_destination_domain_reaches_the_root_company(self):
+        """El dominio del diario destino se arma sobre la raíz, no sobre el padre inmediato.
+
+        Con una jerarquía de más de dos niveles, `parent_id` se queda en la compañía
+        intermedia y deja afuera del dominio a la casa central y a las otras ramas.
+        """
+        branch = self._create_branch()
+        sub_branch = self._create_branch(name="Sub branch", parent=branch)
+        sub_branch_journal = self._create_check_journal("Sub Branch Checks", "SBC", company=sub_branch)
+        check = self._create_third_party_check(sub_branch_journal, "UX-ROOT-0001")
+
+        wizard = (
+            self.env["l10n_latam.payment.mass.transfer"]
+            .with_context(active_model="l10n_latam.check", active_ids=check.ids)
+            .create({})
+        )
+
+        self.assertEqual(wizard.main_company_id, self.company)

--- a/l10n_latam_check_ux/tests/test_check_transfers.py
+++ b/l10n_latam_check_ux/tests/test_check_transfers.py
@@ -349,6 +349,16 @@ class TestL10nLatamCheckUxTransfers(AccountTestInvoicingCommon):
 
         self.assertEqual(wizard.main_company_id, self.company)
 
+    def test_mass_transfer_view_exposes_the_fields_of_the_destination_domain(self):
+        """El desplegable del diario destino queda vacío si la vista no trae `main_company_id`.
+
+        El dominio de `destination_journal_id` lo lee, y el cliente web evalúa los dominios solo
+        con los campos que la vista carga: sin el campo, `main_company_id` es False, el `child_of`
+        no matchea ninguna compañía y el usuario no puede elegir ningún diario.
+        """
+        view = self.env["l10n_latam.payment.mass.transfer"].get_view()
+        self.assertIn("main_company_id", view["models"]["l10n_latam.payment.mass.transfer"])
+
     def test_reject_wizard_requires_a_journal_of_the_check_company(self):
         """Rechazar contra un diario de otra compañía migraría el cheque de compañía.
 

--- a/l10n_latam_check_ux/tests/test_check_transfers.py
+++ b/l10n_latam_check_ux/tests/test_check_transfers.py
@@ -348,3 +348,28 @@ class TestL10nLatamCheckUxTransfers(AccountTestInvoicingCommon):
         )
 
         self.assertEqual(wizard.main_company_id, self.company)
+
+    def test_reject_wizard_requires_a_journal_of_the_check_company(self):
+        """Rechazar contra un diario de otra compañía migraría el cheque de compañía.
+
+        `check_company` no lo frena porque en branches Odoo acepta registros de la compañía
+        padre sobre una hija, así que la validación tiene que ser explícita.
+        """
+        check = self._create_third_party_check(self.third_party_check_journal, "UX-REJ-COMP-0001")
+        self.env["l10n_latam.payment.mass.transfer"].with_context(
+            active_model="l10n_latam.check",
+            active_ids=check.ids,
+        ).create({"destination_journal_id": self.company_bank_journal.id})._create_payments()
+
+        branch = self._create_branch()
+        branch_rejected_journal = self._create_check_journal("Branch Rejected Checks", "BRJC", company=branch)
+
+        wizard = (
+            self.env["account.check.reject.wizard"]
+            .with_context(active_model="l10n_latam.check", active_ids=check.ids)
+            .create({"rejected_journal_id": branch_rejected_journal.id})
+        )
+
+        self.assertEqual(wizard.company_id, self.company)
+        with self.assertRaisesRegex(UserError, "belongs to"):
+            wizard.action_confirm()

--- a/l10n_latam_check_ux/wizards/account_check_action_wizard.py
+++ b/l10n_latam_check_ux/wizards/account_check_action_wizard.py
@@ -48,8 +48,15 @@ class AccountCheckActionWizard(models.TransientModel):
                     .create(new_mv_line_dicts)
                 )
                 wizard.reconcile()
+                # El label repite el número de cheque, que puede existir en más de una
+                # sucursal: sin el filtro de compañía el link podría apuntar al asiento de otra.
                 debit_move = self.env["account.move"].search(
-                    [("line_ids.name", "=", label), ("date", "=", self.date)], limit=1
+                    [
+                        ("line_ids.name", "=", label),
+                        ("date", "=", self.date),
+                        ("company_id", "=", check.company_id.id),
+                    ],
+                    limit=1,
                 )
             else:
                 amount = abs(sum(check.outstanding_line_id.mapped("balance")))

--- a/l10n_latam_check_ux/wizards/account_check_reject_wizard.py
+++ b/l10n_latam_check_ux/wizards/account_check_reject_wizard.py
@@ -16,11 +16,16 @@ class AccountCheckRejectWizard(models.TransientModel):
         default=fields.Date.context_today,
         required=True,
     )
+    company_id = fields.Many2one(
+        "res.company",
+        compute="_compute_company_id",
+        help="Company of the checks being rejected. The rejection is always processed within it.",
+    )
     rejected_journal_id = fields.Many2one(
         "account.journal",
         string="Rejected Checks Journal",
         required=True,
-        domain=[("type", "in", ("bank", "cash"))],
+        domain="[('type', 'in', ('bank', 'cash')), ('company_id', '=', company_id)]",
         help="Journal used for rejected third-party checks (e.g. 'Cheques de Terceros Rechazados').",
     )
     case_description = fields.Char(
@@ -39,6 +44,11 @@ class AccountCheckRejectWizard(models.TransientModel):
                     % check.name
                 )
         return res
+
+    @api.depends_context("active_ids")
+    def _compute_company_id(self):
+        for rec in self:
+            rec.company_id = rec._get_checks().company_id[:1]
 
     @api.depends("rejected_journal_id")
     def _compute_case_description(self):
@@ -74,6 +84,24 @@ class AccountCheckRejectWizard(models.TransientModel):
         checks = self._get_checks()
         if not checks:
             raise UserError(_("No checks selected."))
+
+        # The rejection must stay within the company that holds the check: creating the
+        # payments in another company of the branch tree silently moves the check there
+        # (company_id is computed from its last operation) and books the customer debt in
+        # the wrong company. check_company does not catch it because Odoo accepts records
+        # of a parent company on a branch.
+        companies = checks.company_id
+        if len(companies) > 1:
+            raise UserError(_("All selected checks must belong to the same company."))
+        if self.rejected_journal_id.company_id != companies:
+            raise UserError(
+                _("The journal '%(journal)s' belongs to '%(journal_company)s' but the check belongs to '%(company)s'.")
+                % {
+                    "journal": self.rejected_journal_id.display_name,
+                    "journal_company": self.rejected_journal_id.company_id.display_name,
+                    "company": companies.display_name,
+                }
+            )
 
         for check in checks:
             last_operation = check._get_last_operation()

--- a/l10n_latam_check_ux/wizards/account_check_reject_wizard_view.xml
+++ b/l10n_latam_check_ux/wizards/account_check_reject_wizard_view.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <form string="Reject Check">
                 <group>
+                    <field name="company_id" invisible="1"/>
                     <field name="date"/>
                     <field name="rejected_journal_id"/>
                 </group>

--- a/l10n_latam_check_ux/wizards/checks_to_date_report.py
+++ b/l10n_latam_check_ux/wizards/checks_to_date_report.py
@@ -10,20 +10,43 @@ class AccountCheckToDateReportWizard(models.TransientModel):
     _name = "account.check.to_date.report.wizard"
     _description = "account.check.to_date.report.wizard"
 
+    company_id = fields.Many2one(
+        "res.company",
+        string="Compañía",
+        compute="_compute_company_id",
+        help="Compañía activa. El reporte incluye sus sucursales habilitadas.",
+    )
     journal_id = fields.Many2one(
         "account.journal",
         string="Diario",
-        domain=[
-            "|",
-            ("outbound_payment_method_line_ids.code", "=", "check_printing"),
-            ("inbound_payment_method_line_ids.code", "=", "in_third_party_checks"),
-        ],
+        domain="""[
+            '&',
+            ('company_id', 'child_of', company_id),
+            '|',
+            ('outbound_payment_method_line_ids.code', '=', 'check_printing'),
+            ('inbound_payment_method_line_ids.code', '=', 'in_third_party_checks'),
+        ]""",
     )
     to_date = fields.Date(
         "Hasta Fecha",
         required=True,
         default=fields.Date.today,
     )
+
+    @api.depends_context("company")
+    def _compute_company_id(self):
+        for rec in self:
+            rec.company_id = self.env.company
+
+    @api.model
+    def _get_report_companies(self):
+        """Compañías que abarca el reporte: la activa más sus sucursales habilitadas.
+
+        Sin esto las queries crudas de abajo no filtran por compañía y el único corte
+        efectivo termina siendo la record rule del cheque, que abarca todas las compañías
+        habilitadas — incluso las de otro grupo económico.
+        """
+        return self.env.company._accessible_branches()
 
     def action_confirm(self):
         self.ensure_one()
@@ -68,6 +91,7 @@ class AccountCheckToDateReportWizard(models.TransientModel):
                         WHERE
                         apm.code = 'own_checks'
                         AND ap_move.date <= %(to_date)s
+                        AND ap_move.company_id = ANY(%(company_ids)s)
                         AND ap.state not in ('canceled', 'draft')
                         AND c.issue_state != 'voided'
                         ORDER BY c.id, ap_move.date desc
@@ -106,6 +130,7 @@ class AccountCheckToDateReportWizard(models.TransientModel):
                 ;
             """,
             to_date=to_date,
+            company_ids=self._get_report_companies().ids,
         )
         self.env.cr.execute(query)
         res = self.env.cr.fetchall()
@@ -205,6 +230,7 @@ class AccountCheckToDateReportWizard(models.TransientModel):
                 )
             )
             AND ap_move.date <= %s
+            AND ap_move.company_id = ANY(%s)
             UNION ALL
             SELECT c.id AS check_id, ap_move.date AS operation_date, apm.code AS operation_code
             FROM l10n_latam_check c
@@ -217,9 +243,11 @@ class AccountCheckToDateReportWizard(models.TransientModel):
                 apm.code in ('new_third_party_checks','in_third_party_checks')
                 AND c.current_journal_id IS NOT NULL
                 AND rel.check_id IS NULL
-                AND ap_move.date <= %s;
+                AND ap_move.date <= %s
+                AND ap_move.company_id = ANY(%s);
         """
-        self.env.cr.execute(query, (to_date, to_date, to_date))
+        company_ids = self._get_report_companies().ids
+        self.env.cr.execute(query, (to_date, to_date, company_ids, to_date, company_ids))
         res = self.env.cr.fetchall()
         check_ids = [x[0] for x in res]
         checks = self.env["l10n_latam.check"].search([("id", "in", check_ids)])

--- a/l10n_latam_check_ux/wizards/checks_to_date_view.xml
+++ b/l10n_latam_check_ux/wizards/checks_to_date_view.xml
@@ -6,6 +6,7 @@
             <field name="arch" type="xml">
                 <form string="Cheques a Fecha">
                     <group>
+                        <field name="company_id" invisible="1"/>
                         <field name="to_date"/>
                         <field name="journal_id"/>
                     </group>

--- a/l10n_latam_check_ux/wizards/l10n_latam_payment_mass_transfer.py
+++ b/l10n_latam_check_ux/wizards/l10n_latam_payment_mass_transfer.py
@@ -25,7 +25,9 @@ class L10nLatamPaymentMassTransfer(models.TransientModel):
     @api.depends("company_id")
     def _compute_main_company(self):
         for rec in self:
-            rec.main_company_id = rec.company_id.parent_id or rec.company_id
+            # root_id and not parent_id: with a hierarchy deeper than two levels, parent_id
+            # stops at the intermediate company and leaves the rest of the tree out.
+            rec.main_company_id = rec.company_id.root_id
 
     def _create_payments(self):
         if self.destination_journal_id.company_id != self.journal_id.company_id:

--- a/l10n_latam_check_ux/wizards/l10n_latam_payment_mass_transfer.xml
+++ b/l10n_latam_check_ux/wizards/l10n_latam_payment_mass_transfer.xml
@@ -8,6 +8,9 @@
             <field name="destination_journal_id" position="after">
                 <field name="split_payment"/>
                 <field name="company_id"/>
+                <!-- the domain of destination_journal_id reads main_company_id: without the field in
+                     the view the client evaluates it as False and the dropdown lists nothing -->
+                <field name="main_company_id" invisible="1"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Review de multicompañía / branches sobre `l10n_latam_check_ux`. El módulo ya era conciente de branches en algunos lugares, pero de forma parcial: quedaban puntos que asumían una sola compañía plana y otros que permitían cruzar compañías sin control.

### Qué corrige

| Sev | Qué | Dónde |
| --- | --- | --- |
| HIGH | El reporte "Cheques a fecha" no filtraba por compañía en ninguna de sus dos queries crudas: el único corte efectivo era la record rule del cheque, que abarca todas las compañías habilitadas (incluso de otro grupo económico), mientras el encabezado del PDF mostraba solo la compañía activa. Ahora las queries filtran por las sucursales accesibles de la compañía activa, el dominio del diario también, y el PDF informa las compañías incluidas (con columna por cheque si hay más de una). | `wizards/checks_to_date_report.py`, `reports/report_checks_to_date.xml` |
| HIGH | El crédito por cheques del partner se sumaba solo con la compañía activa, mientras el `_credit_debit_get` de core agrega los apuntes con `child_of` sobre la raíz y `bypass_access`: parado en la casa central se veían las facturas de la sucursal pero no sus cheques. Ahora usa `child_of` sobre `root_id` + `sudo`. | `models/res_partner.py` |
| HIGH | El wizard de rechazo aceptaba un diario de cualquier compañía. `check_company` no lo frena porque en branches Odoo acepta registros de la compañía padre, así que los pagos se creaban en otra compañía, el `_compute_company_id` del cheque lo seguía y el cheque migraba de compañía como efecto colateral del rechazo (con la deuda del cliente en la compañía equivocada). Ahora el dominio del diario se acota a la compañía del cheque y se valida al confirmar. | `wizards/account_check_reject_wizard.py` |
| MEDIUM | `main_company_id` de la transferencia masiva subía un solo nivel (`parent_id`): con jerarquías de más de dos niveles el `child_of` del dominio nunca llegaba a la raíz. Ahora usa `root_id`, como ya hace `models/l10n_latam_check.py`. | `wizards/l10n_latam_payment_mass_transfer.py` |
| MEDIUM | Al tocar "Permitir conciliación" en una cuenta compartida por el árbol, el recálculo del `issue_state` almacenado se salteaba los cheques de las branches no habilitadas y los dejaba desincronizados. Ahora el `search` es `sudo` (es un recálculo técnico). | `models/account_account.py` |
| LOW | La búsqueda del asiento de débito por label + fecha podía traer el asiento de otra sucursal que debitó el mismo día un cheque con el mismo número. Se agrega el filtro de compañía. | `wizards/account_check_action_wizard.py` |

### Tests

Tres tests nuevos en `tests/test_check_transfers.py`, verificados en rojo sin el fix y en verde con él:

- `test_partner_check_credit_includes_branch_checks`
- `test_mass_transfer_destination_domain_reaches_the_root_company`
- `test_reject_wizard_requires_a_journal_of_the_check_company`