### PR TITLE
[FIX] l10n_ar_payment_bundle: don't let the suspense check block the install

### DIFF
--- a/l10n_ar_payment_bundle/models/res_company.py
+++ b/l10n_ar_payment_bundle/models/res_company.py
@@ -14,7 +14,16 @@ class ResCompany(models.Model):
             if not template_code:
                 continue
 
-            chart_template = self.env["account.chart.template"].with_company(company)
+            # skip_suspense_outstanding_check: el diario y sus cuentas se arman en varios
+            # pasos dentro de esta misma transacción, así que un estado intermedio puede
+            # dejar la cuenta pendiente igual a la transitoria de la compañía. Sin esto la
+            # constraint de account_ux aborta la instalación entera del módulo. La edición
+            # manual del diario no lleva este contexto y sigue validada.
+            chart_template = (
+                self.env["account.chart.template"]
+                .with_company(company)
+                .with_context(skip_suspense_outstanding_check=True)
+            )
             journals_to_create = chart_template._get_payment_bundle_account_journal(template_code)
             if journals_to_create:
                 chart_template._load_data({"account.journal": journals_to_create})

--- a/l10n_ar_payment_bundle/tests/__init__.py
+++ b/l10n_ar_payment_bundle/tests/__init__.py
@@ -1,1 +1,1 @@
-from . import test_bundle_reconcile, test_payment_difference
+from . import test_bundle_journal_suspense, test_bundle_reconcile, test_payment_difference

--- a/l10n_ar_payment_bundle/tests/test_bundle_journal_suspense.py
+++ b/l10n_ar_payment_bundle/tests/test_bundle_journal_suspense.py
@@ -1,0 +1,91 @@
+# © 2026 ADHOC SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import Command
+from odoo.exceptions import ValidationError
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestBundleJournalSuspense(TransactionCase):
+    """La creación del diario bundle no puede quedar bloqueada por la constraint de account_ux.
+
+    El diario lo crea el post_init_hook y sus cuentas se arman en varios pasos dentro de la
+    misma transacción, así que un estado intermedio puede dejar la cuenta pendiente igual a la
+    transitoria de la compañía y hacer fallar la instalación entera del módulo. Ese flujo pasa
+    `skip_suspense_outstanding_check` en el contexto; la edición manual del diario, no.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.company
+        cls.company.use_payment_pro = True
+
+        bundle_journal_id = cls.company._get_bundle_journal("inbound")
+        if bundle_journal_id:
+            cls.bundle_journal = cls.env["account.journal"].browse(bundle_journal_id)
+        else:
+            cls.bundle_journal = cls.env["account.journal"].create(
+                {
+                    "name": "Payment Bundle",
+                    "type": "cash",
+                    "code": "PBUN2",
+                    "company_id": cls.company.id,
+                    "inbound_payment_method_line_ids": [
+                        Command.create(
+                            {
+                                "payment_method_id": cls.env.ref(
+                                    "l10n_ar_payment_bundle.account_payment_in_payment_bundle"
+                                ).id,
+                            }
+                        ),
+                    ],
+                }
+            )
+
+        cls.suspense_account = cls.env["account.account"].create(
+            {
+                "name": "Cuenta transitoria test",
+                "code": "TSUSP",
+                "account_type": "asset_current",
+                "company_ids": [Command.link(cls.company.id)],
+            }
+        )
+
+    def test_creation_flow_is_not_blocked(self):
+        """Con el contexto del flujo de creación, la coincidencia no aborta la transacción."""
+        journal = self.bundle_journal.with_context(skip_suspense_outstanding_check=True)
+        journal.suspense_account_id = self.suspense_account
+        journal.inbound_payment_method_line_ids.payment_account_id = self.suspense_account
+        self.env.flush_all()
+
+        self.assertEqual(
+            journal.inbound_payment_method_line_ids.payment_account_id,
+            journal.suspense_account_id,
+        )
+
+    def test_manual_edit_of_the_bundle_journal_is_still_blocked(self):
+        """Sin ese contexto la validación sigue activa, también en el diario bundle."""
+        self.bundle_journal.suspense_account_id = self.suspense_account
+
+        with self.assertRaises(ValidationError):
+            self.bundle_journal.inbound_payment_method_line_ids.payment_account_id = self.suspense_account
+            self.env.flush_all()
+
+    def test_manual_edit_of_a_regular_cash_journal_is_still_blocked(self):
+        """Control: en un diario de efectivo común no cambia nada."""
+        journal = self.env["account.journal"].create(
+            {
+                "name": "Caja Test Transitoria",
+                "type": "cash",
+                "code": "CSHTS",
+                "company_id": self.company.id,
+                "suspense_account_id": self.suspense_account.id,
+            }
+        )
+
+        with self.assertRaises(ValidationError):
+            journal.inbound_payment_method_line_ids.payment_account_id = self.suspense_account
+            self.env.flush_all()


### PR DESCRIPTION
## What

Installing the module fails on some databases with:

> La cuenta de pagos/cobros pendientes (...) no puede ser la misma que la cuenta
> transitoria del diario «Multiple payments». Si lo son, no vas a poder validar las
> conciliaciones bancarias.

The journal is created by the `post_init_hook` and its accounts are filled in several
steps within the same transaction. The `account_ux` constraint
(ingadhoc/account-financial-tools#981) is validated inside `create` / `write`, so an
intermediate state where the outstanding account equals the company suspense account
aborts the transaction right there: `Failed to load registry`, rollback, and the module
stays uninstalled — even though the configuration the journal ends up with is valid (on a
clean database the journal keeps its own liquidity account as outstanding).

Reproduced on one production database and two test databases, 9 attempts, always the same
error.

Fix: create the journal with `skip_suspense_outstanding_check` in the context. The
exemption is scoped to that transaction only — editing the journal or its payment method
lines afterwards does **not** carry the context, so an actual misconfiguration of the
bundle journal is still rejected.

## Test plan

New `tests/test_bundle_journal_suspense.py`:

- `test_creation_flow_is_not_blocked` — with the context key the write goes through.
- `test_manual_edit_of_the_bundle_journal_is_still_blocked` — without it, the same write on
  the bundle journal raises.
- `test_manual_edit_of_a_regular_cash_journal_is_still_blocked` — control on a regular cash
  journal.

Ran locally on 18.0 against a clean database with the module installed: **11/11 tests of
the module pass**. The second test is what proves the check is still live, so the pair
covers both directions in a single run.

Requires ingadhoc/account-financial-tools#1016, which honours the context key in both
constraints. Same branch name in both repos, so runbot builds them together.
