### PR TITLE
[ADD] account_cashbox: behaviour test suite and invariants battery

### DIFF
--- a/account_cashbox/models/account_cashbox_session.py
+++ b/account_cashbox/models/account_cashbox_session.py
@@ -121,13 +121,13 @@ class AccountCashboxSession(models.Model):
                 for journal in rec.cashbox_id.journal_ids
             ]
 
-            @api.constrains("user_ids", "cashbox_id")
-            def _check_user_ids_allowed(self):
-                for rec in self:
-                    if rec.cashbox_id.restrict_users and rec.user_ids:
-                        allowed = set(rec.cashbox_id.allowed_res_users_ids.ids)
-                        if not set(rec.user_ids.ids).issubset(allowed):
-                            raise ValidationError(_("All session users must be allowed on the cashbox."))
+    @api.constrains("user_ids", "cashbox_id")
+    def _check_user_ids_allowed(self):
+        for rec in self:
+            if rec.cashbox_id.restrict_users and rec.user_ids:
+                allowed = set(rec.cashbox_id.allowed_res_users_ids.ids)
+                if not set(rec.user_ids.ids).issubset(allowed):
+                    raise ValidationError(_("All session users must be allowed on the cashbox."))
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -226,11 +226,15 @@ class AccountCashboxSession(models.Model):
                 # if amounts are the same do not check
                 if rec.company_id.currency_id.compare_amounts(line.balance_end, line.balance_end_real) == 0:
                     continue
-                max_diff_in_currency = line.cashbox_session_id.cashbox_id.max_diff
-                if line.journal_id.currency_id:
-                    max_diff_in_currency = line.journal_id.currency_id._convert(
-                        line.cashbox_session_id.cashbox_id.max_diff,
-                        line.cashbox_session_id.cashbox_id.company_id.currency_id,
+                max_diff_in_currency = rec.cashbox_id.max_diff
+                if line.journal_id.currency_id and line.journal_id.currency_id != rec.company_id.currency_id:
+                    # max_diff se configura en la moneda de la compañía (ver help del campo) y la
+                    # diferencia de la línea viene en la moneda del diario: el tope se lleva a esa moneda.
+                    max_diff_in_currency = rec.company_id.currency_id._convert(
+                        rec.cashbox_id.max_diff,
+                        line.journal_id.currency_id,
+                        rec.company_id,
+                        fields.Date.context_today(rec),
                     )
 
                 diff = abs(line.balance_end - line.balance_end_real)

--- a/account_cashbox/tests/__init__.py
+++ b/account_cashbox/tests/__init__.py
@@ -1,1 +1,14 @@
-from . import test_internal_transfer_cashbox_session, test_cashbox_allowed_users_view_payments
+from . import (
+    common,
+    invariants,
+    test_branch_sessions,
+    test_cash_control_closing,
+    test_cashbox_allowed_users_view_payments,
+    test_cashbox_invariants,
+    test_cashbox_security,
+    test_internal_transfer_batch,
+    test_internal_transfer_cashbox_session,
+    test_payment_binding,
+    test_session_concurrency,
+    test_session_lifecycle,
+)

--- a/account_cashbox/tests/common.py
+++ b/account_cashbox/tests/common.py
@@ -1,0 +1,213 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+"""Configuración de los escenarios de las suites de caja.
+
+Separa las tres categorías de datos que las suites usan, que no son dos:
+
+* **Entorno** — plan de cuentas y cuentas que la contabilidad necesita para
+  existir. Sale de la base: recrearlo es caro, no aporta señal y nadie lo
+  mantiene.
+* **Configuración del escenario** — diarios, cajas, secuencias, usuarios,
+  monedas. **La crea esta clase**, con ``.create()``. Es lo que decide qué se
+  está probando, y crearla es lo que permite que la suite corra en cualquier
+  base sin depender de qué localización esté instalada.
+* **Documentos** — pagos, sesiones, asientos. **Siempre los crea el test**, que
+  es lo que mide.
+
+Por qué importa acá en particular: la base de un cliente (y la de demo) puede
+tener cajas y sesiones abiertas propias. Si la suite se apoyara en ellas, un
+assert como "esta sesión no está entre las disponibles" se degrada solo — para
+que pase con datos ajenos alrededor, alguien lo reescribe como "hay al menos
+una", y ese assert flojo es el que deja pasar incidentes en verde.
+
+La aislación no se logra relajando asserts sino por construcción: todas las
+cajas de la suite nacen con ``restrict_users=True`` y con **solo los usuarios de
+la suite** permitidos, así las sesiones ajenas nunca entran en el dominio de
+disponibles del usuario de test.
+"""
+
+from odoo import Command, fields
+from odoo.tests import TransactionCase
+
+from .invariants import CashboxInvariantsMixin
+
+
+class CashboxCommon(CashboxInvariantsMixin, TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.company
+        cls.env = cls.env(context=dict(cls.env.context, allowed_company_ids=cls.company.ids))
+        cls.currency = cls.company.currency_id
+
+        # Moneda propia de la suite, con cotización fija: no tocamos las tasas de
+        # la base ni dependemos de que alguna moneda esté activa con cotización.
+        cls.foreign_currency = cls.env["res.currency"].create(
+            {"name": "TCB", "symbol": "TCB", "rounding": 0.01, "active": True}
+        )
+        cls.env["res.currency.rate"].create(
+            {
+                "currency_id": cls.foreign_currency.id,
+                "rate": 2.0,  # 1 unidad de la moneda de la compañía = 2 TCB
+                "company_id": cls.company.id,
+                "name": fields.Date.context_today(cls.env["res.currency"]),
+            }
+        )
+
+        cls.cashbox_user = cls._create_user("cashbox_operator", "Cashbox Operator")
+        cls.viewer_user = cls._create_user("cashbox_viewer", "Cashbox Viewer")
+        cls.other_user = cls._create_user("cashbox_other", "Cashbox Other")
+
+        cls.partner = cls.env["res.partner"].create({"name": "Test Cashbox Partner"})
+
+        cls.journal_cash = cls._create_journal("Test Cashbox Cash", "TCBC", "cash")
+        cls.journal_bank = cls._create_journal("Test Cashbox Bank", "TCBB", "bank")
+
+    # ------------------------------------------------------------------
+    # configuración del escenario
+    # ------------------------------------------------------------------
+    @classmethod
+    def _create_user(cls, login, name, groups=("base.group_user", "account.group_account_invoice")):
+        return (
+            cls.env["res.users"]
+            .with_context(no_reset_password=True)
+            .create(
+                {
+                    "name": name,
+                    "login": login,
+                    "company_id": cls.company.id,
+                    "company_ids": [Command.set(cls.company.ids)],
+                    "group_ids": [Command.set([cls.env.ref(g).id for g in groups])],
+                }
+            )
+        )
+
+    @classmethod
+    def _create_journal(cls, name, code, journal_type="cash", currency=None):
+        vals = {"name": name, "code": code, "type": journal_type, "company_id": cls.company.id}
+        if currency:
+            vals["currency_id"] = currency.id
+        return cls.env["account.journal"].create(vals)
+
+    @classmethod
+    def _create_cashbox(cls, name, journals, **kwargs):
+        """Caja de la suite. Restringida a los usuarios de la suite por default.
+
+        La restricción es lo que aísla la suite de las cajas y sesiones que la
+        base ya tenga: sin ella, una sesión ajena abierta entra en el dominio de
+        sesiones disponibles y los asserts de disponibilidad dejan de significar
+        lo que dicen.
+        """
+        users = kwargs.pop("users", None)
+        if users is None:
+            users = cls.cashbox_user | cls.viewer_user | cls.other_user
+        vals = {
+            "name": name,
+            "company_id": cls.company.id,
+            "journal_ids": [Command.set(journals.ids)],
+            "restrict_users": True,
+            "allowed_res_users_ids": [Command.set(users.ids)],
+        }
+        if not kwargs.get("allow_concurrent_sessions"):
+            # sin sesiones concurrentes el nombre de la sesión lo pone la secuencia de la caja
+            vals["sequence_id"] = (
+                cls.env["ir.sequence"]
+                .create(
+                    {
+                        "name": "Test Cashbox Sequence %s" % name,
+                        "code": "account_cashbox_sequence",
+                        "prefix": "%s-" % code_prefix(name),
+                        "padding": 5,
+                        "company_id": cls.company.id,
+                    }
+                )
+                .id
+            )
+        vals.update(kwargs)
+        return cls.env["account.cashbox"].create(vals)
+
+    @classmethod
+    def _create_account(cls, code, name, account_type, reconcile=False):
+        return cls.env["account.account"].create(
+            {
+                "name": name,
+                "code": code,
+                "account_type": account_type,
+                "reconcile": reconcile,
+                "company_ids": [Command.set(cls.company.ids)],
+            }
+        )
+
+    # ------------------------------------------------------------------
+    # documentos
+    # ------------------------------------------------------------------
+    def _create_invoice(self, amount=100.0):
+        """Factura de cliente mínima, sin producto: solo lo que el pago necesita."""
+        income = self._create_account("TCBI", "Test Cashbox Income", "income")
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.partner.id,
+                "invoice_date": fields.Date.context_today(self.env["account.move"]),
+                "company_id": self.company.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "name": "Test Cashbox line",
+                            "quantity": 1,
+                            "price_unit": amount,
+                            "account_id": income.id,
+                            "tax_ids": [Command.clear()],
+                        }
+                    )
+                ],
+            }
+        )
+        invoice.action_post()
+        return invoice
+
+    def _create_session(self, cashbox, user=None, name=None, open_it=False, allowed_companies=None):
+        """`allowed_companies` es necesario para cajas de otra compañía del árbol:
+        la record rule de sesiones se evalúa contra las compañías habilitadas en
+        el contexto, no contra las del usuario."""
+        user = user or self.cashbox_user
+        Session = self.env["account.cashbox.session"].with_user(user)
+        if allowed_companies is not None:
+            Session = Session.with_context(allowed_company_ids=allowed_companies.ids)
+        vals = {"cashbox_id": cashbox.id, "user_ids": [Command.set(user.ids)]}
+        if cashbox.allow_concurrent_sessions:
+            # con sesiones concurrentes la secuencia no interviene: el nombre lo pone quien la crea
+            vals["name"] = name or "Session %s/%s" % (cashbox.name, len(cashbox.session_ids) + 1)
+        session = Session.create(vals)
+        if open_it:
+            session.action_account_cashbox_session_open()
+        # se crea como el usuario (para ejercitar el ACL y el compute de user_ids) pero se
+        # devuelve en el env de la suite: cada test declara con qué usuario opera
+        return session.sudo().with_env(self.env)
+
+    def _create_payment(self, journal, amount=100.0, session=None, user=None, post=True, **kwargs):
+        user = user or self.cashbox_user
+        vals = {
+            "journal_id": journal.id,
+            "amount": amount,
+            "date": fields.Date.context_today(self.env["account.payment"]),
+            "payment_type": "inbound",
+            "partner_type": "customer",
+            "partner_id": self.partner.id,
+        }
+        if session is not None:
+            # session=False deja el pago explícitamente sin sesión: sin eso el compute le
+            # asignaría la única sesión abierta y el escenario mediría otra cosa
+            vals["cashbox_session_id"] = session.id if session else False
+        vals.update(kwargs)
+        payment = self.env["account.payment"].with_user(user).create(vals)
+        if post:
+            payment.action_post()
+        return payment.sudo().with_env(self.env)
+
+
+def code_prefix(name):
+    """Prefijo de secuencia derivado del nombre de la caja, sin espacios."""
+    return "".join(ch for ch in name.upper() if ch.isalnum())[:8]

--- a/account_cashbox/tests/invariants.py
+++ b/account_cashbox/tests/invariants.py
@@ -1,0 +1,187 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+"""Batería de invariantes de las suites de caja.
+
+Estas verificaciones no son de un caso: son las que **toda** operación de caja
+tiene que cumplir siempre. La suite las llama después de cada operación, además
+de los asserts puntuales que cada escenario declara.
+
+    class TestAlgo(CashboxCommon):
+        def test_algo(self):
+            ...
+            self.assert_cashbox_invariants(session)
+            self.assert_payment_invariants(payment)
+
+El archivo tiene dos mitades:
+
+* **Asiento y pago** — que el asiento cierre, que no lo haya cerrado Odoo con
+  una línea de relleno, que no queden líneas en cero, que en multimoneda cierre
+  en las dos monedas. Estas mismas verificaciones se están escribiendo en
+  ``account_ux/tests/invariants.py`` como batería compartida de cobros y pagos
+  (tarea 71623, todavía sin mergear y en otro repo). **Están duplicadas acá a
+  propósito**, para que esta suite no quede bloqueada por ese PR: cuando aquel
+  mergee, esta mitad se borra y la clase pasa a heredar de allá. La
+  deduplicación se resuelve desde ese PR.
+* **Sesión de caja** — propias de este módulo y sin equivalente arriba: usan
+  ``cashbox_session_id``, ``line_ids`` y los ``balance_*``.
+
+Regla de uso, importante: **la batería no lleva flags para saltear
+invariantes**. Si un escenario legítimamente viola una, la excepción se declara
+en el test —a la vista y con el motivo escrito al lado— y no se esconde acá
+adentro. Un helper con condicionales deja de ser una base y pasa a ser el lugar
+donde se entierran los casos que nadie verifica.
+"""
+
+
+class CashboxInvariantsMixin:
+    # ------------------------------------------------------------------
+    # invariantes del asiento
+    # (duplicadas de la batería de account_ux — ver docstring del módulo)
+    # ------------------------------------------------------------------
+    def assert_move_sums_zero(self, move, msg=""):
+        """El asiento cierra en la moneda de la compañía."""
+        total = move.company_currency_id.round(sum(move.line_ids.mapped("balance")))
+        self.assertEqual(total, 0.0, "El asiento %s no suma cero (%s). %s" % (move.name, total, msg))
+
+    def assert_no_automatic_balancing_line(self, move, msg=""):
+        """No hay línea de balanceo automático.
+
+        Odoo agrega una cuando el asiento no cierra por su cuenta. Que aparezca
+        significa que el importe lo completó el sistema, no la operación: el
+        asiento "cierra" y el error queda tapado.
+
+        Se la identifica por **nombre**, que es como la identifica el propio
+        Odoo en ``_sync_unbalanced_lines``. Buscarla por cuenta no sirve:
+        ``_get_automatic_balancing_account()`` devuelve la cuenta del diario
+        cuando el diario tiene una, así que en cualquier pago de banco o caja la
+        línea de liquidez legítima cae en esa misma cuenta y el chequeo da
+        positivo siempre.
+        """
+        balance_name = self.env._("Automatic Balancing Line")
+        balancing = move.line_ids.filtered(lambda line: line.name == balance_name)
+        self.assertFalse(
+            balancing,
+            "El asiento %s tiene línea de balanceo automático por %s. %s"
+            % (move.name, sum(balancing.mapped("balance")), msg),
+        )
+
+    def assert_no_zero_lines(self, move, msg=""):
+        """Ninguna línea en cero.
+
+        Una línea en $0 es un mecanismo que se disparó sin tener nada que
+        hacer. Ensucia el mayor y esconde el error real.
+        """
+        zero_lines = move.line_ids.filtered(lambda line: not line.debit and not line.credit)
+        self.assertFalse(
+            zero_lines,
+            "El asiento %s tiene %s línea(s) en cero: %s. %s"
+            % (move.name, len(zero_lines), zero_lines.mapped("name"), msg),
+        )
+
+    def assert_closes_in_both_currencies(self, move, msg=""):
+        """En multimoneda el asiento cierra también en la moneda del comprobante."""
+        self.assert_move_sums_zero(move, msg)
+        by_currency = {}
+        for line in move.line_ids.filtered(lambda line: line.currency_id != line.company_currency_id):
+            by_currency.setdefault(line.currency_id, 0.0)
+            by_currency[line.currency_id] += line.amount_currency
+        for currency, total in by_currency.items():
+            self.assertEqual(
+                currency.round(total),
+                0.0,
+                "El asiento %s no cierra en %s (%s). %s" % (move.name, currency.name, total, msg),
+            )
+
+    def assert_payment_invariants(self, payment, msg=""):
+        """Las invariantes que todo pago tiene que cumplir, en un solo lugar."""
+        move = payment.move_id
+        self.assert_move_sums_zero(move, msg)
+        self.assert_no_automatic_balancing_line(move, msg)
+        self.assert_no_zero_lines(move, msg)
+        if payment.currency_id != payment.company_currency_id:
+            self.assert_closes_in_both_currencies(move, msg)
+
+    # ------------------------------------------------------------------
+    # invariantes de la sesión de caja (propias de este módulo)
+    # ------------------------------------------------------------------
+    def assert_session_line_coverage(self, session, msg=""):
+        """Las líneas de control de la sesión son una por diario, y coherentes.
+
+        No se compara contra los diarios *actuales* de la caja a propósito: una
+        sesión vieja conserva las líneas con las que nació aunque después le
+        cambien los diarios a la caja, y eso es deliberado (ver el comentario en
+        ``_compute_available_journal_ids``). Lo que sí tiene que valer siempre
+        es que no haya diarios repetidos ni líneas sin diario.
+        """
+        lines = session.line_ids
+        self.assertTrue(
+            all(lines.mapped("journal_id")),
+            "La sesión %s tiene línea(s) sin diario. %s" % (session.name, msg),
+        )
+        journals = lines.mapped("journal_id")
+        self.assertEqual(
+            len(journals),
+            len(lines),
+            "La sesión %s tiene diarios repetidos en sus líneas (%s líneas, %s diarios). %s"
+            % (session.name, len(lines), len(journals), msg),
+        )
+        ajenos = journals.filtered(lambda j: j.type not in ("bank", "cash"))
+        self.assertFalse(
+            ajenos,
+            "La sesión %s tiene líneas de diarios que no son de banco ni caja: %s. %s"
+            % (session.name, ajenos.mapped("name"), msg),
+        )
+
+    def assert_session_balances_consistent(self, session, msg=""):
+        """Ningún pago de la sesión queda fuera de los saldos, y los saldos cierran.
+
+        La primera parte es la que importa: un pago cuya sesión no tiene línea
+        para su diario **desaparece de todos los balances**. No falla nada, no
+        hay error: la plata simplemente no se cuenta al cerrar. Es el modo de
+        falla que ningún test puntual mira, porque cada test mira el saldo que
+        fue a buscar.
+        """
+        session.line_ids.invalidate_recordset(["amount", "balance_end", "balance_difference"])
+        payments = session.payment_ids.filtered(lambda p: p.state not in ("draft", "canceled"))
+        con_linea = session.line_ids.mapped("journal_id")
+        huerfanos = payments.filtered(lambda p: p.journal_id not in con_linea)
+        self.assertFalse(
+            huerfanos,
+            "La sesión %s tiene %s pago(s) en diarios sin línea de control (%s): su importe no entra en ningún "
+            "saldo. %s" % (session.name, len(huerfanos), huerfanos.mapped("journal_id.name"), msg),
+        )
+        for line in session.line_ids:
+            currency = line.currency_id
+            self.assertEqual(
+                currency,
+                line.journal_id.currency_id or line.journal_id.company_id.currency_id,
+                "La línea del diario %s declara la moneda %s, que no es la del diario ni la de la compañía. %s"
+                % (line.journal_id.name, currency.name, msg),
+            )
+            self.assertEqual(
+                currency.round(line.balance_end),
+                currency.round(line.balance_start + line.amount),
+                "En el diario %s el saldo final (%s) no es el inicial (%s) más el movimiento (%s). %s"
+                % (line.journal_id.name, line.balance_end, line.balance_start, line.amount, msg),
+            )
+            self.assertEqual(
+                currency.round(line.balance_difference),
+                currency.round(line.balance_end_real - line.balance_end),
+                "En el diario %s la diferencia (%s) no es el final real (%s) menos el final (%s). %s"
+                % (line.journal_id.name, line.balance_difference, line.balance_end_real, line.balance_end, msg),
+            )
+
+    def assert_cashbox_invariants(self, session, msg=""):
+        """Las invariantes que toda sesión tiene que cumplir, en un solo lugar.
+
+        No entra acá "la compañía del pago pertenece al árbol de la del diario",
+        que era candidata: el ``_check_company`` del propio ORM impide construir
+        el estado que detectaría, así que no se la puede probar en rojo. Una
+        invariante que nadie vio fallar no demostró mirar, y en una batería
+        compartida eso es peor que no tenerla. La propiedad se verifica igual,
+        como assert del escenario de sucursales, donde sí tiene camino rojo.
+        """
+        self.assert_session_line_coverage(session, msg)
+        self.assert_session_balances_consistent(session, msg)

--- a/account_cashbox/tests/test_branch_sessions.py
+++ b/account_cashbox/tests/test_branch_sessions.py
@@ -1,0 +1,123 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import Command
+from odoo.tests import tagged
+
+from .common import CashboxCommon
+
+
+@tagged("post_install", "-at_install")
+class TestBranchSessions(CashboxCommon):
+    """Sesiones disponibles cuando el usuario está parado en una sucursal.
+
+    Es la lógica que decide a qué caja se imputa un cobro en un cliente con
+    sucursales. No rompe ruidosamente cuando está mal: imputa a la caja
+    equivocada, que es de las cosas más caras de depurar en producción.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.branch = cls.env["res.company"].create({"name": "Test Cashbox Branch", "parent_id": cls.company.id})
+        cls.sibling = cls.env["res.company"].create({"name": "Test Cashbox Sibling", "parent_id": cls.company.id})
+        cls.cashbox_user.write({"company_ids": [Command.set((cls.company | cls.branch | cls.sibling).ids)]})
+        cls.journal_branch = cls.env["account.journal"].create(
+            {"name": "Test Branch Cash", "code": "TBRC", "type": "cash", "company_id": cls.branch.id}
+        )
+        cls.journal_sibling = cls.env["account.journal"].create(
+            {"name": "Test Sibling Cash", "code": "TSIC", "type": "cash", "company_id": cls.sibling.id}
+        )
+
+    def _cashbox_en(self, company, name, journal):
+        """Caja de otra compañía del árbol: se crea con with_company para que los
+        chequeos de compañía del ORM la evalúen desde ahí."""
+        return (
+            self.env["account.cashbox"]
+            .with_company(company)
+            .create(
+                {
+                    "name": name,
+                    "company_id": company.id,
+                    "journal_ids": [Command.set(journal.ids)],
+                    "restrict_users": True,
+                    "allowed_res_users_ids": [Command.set(self.cashbox_user.ids)],
+                    "allow_concurrent_sessions": True,
+                }
+            )
+        )
+
+    def test_desde_una_sucursal_solo_se_ven_las_sesiones_del_arbol(self):
+        """Dado un usuario parado en una sucursal, cuando se listan las sesiones
+        disponibles, entonces ve las de su sucursal y las de la empresa padre,
+        y no ve las de una sucursal hermana.
+
+        Cubre el comportamiento 23 del relevamiento oba-test de account_cashbox.
+        """
+        caja_padre = self._cashbox_en(self.company, "Caja del padre", self.journal_cash)
+        caja_sucursal = self._cashbox_en(self.branch, "Caja de la sucursal", self.journal_branch)
+        caja_hermana = self._cashbox_en(self.sibling, "Caja de la hermana", self.journal_sibling)
+
+        todas = self.company | self.branch | self.sibling
+        sesion_padre = self._create_session(caja_padre, name="Sesion padre", open_it=True, allowed_companies=todas)
+        sesion_sucursal = self._create_session(
+            caja_sucursal, name="Sesion sucursal", open_it=True, allowed_companies=todas
+        )
+        sesion_hermana = self._create_session(
+            caja_hermana, name="Sesion hermana", open_it=True, allowed_companies=todas
+        )
+
+        Session = self.env["account.cashbox.session"].with_user(self.cashbox_user).with_company(self.branch)
+        disponibles = Session.search(Session._get_available_domain(self.branch))
+        creadas_por_el_test = sesion_padre | sesion_sucursal | sesion_hermana
+
+        self.assertEqual(
+            disponibles & creadas_por_el_test,
+            sesion_padre | sesion_sucursal,
+            "Desde la sucursal las sesiones disponibles son %s" % (disponibles & creadas_por_el_test).mapped("name"),
+        )
+        self.assertNotIn(
+            sesion_hermana,
+            disponibles,
+            "Desde la sucursal se ofrece la sesión de una sucursal hermana: un cobro puede terminar imputado "
+            "a la caja de otra sucursal",
+        )
+
+    def test_el_pago_de_una_sucursal_cae_en_una_compania_del_arbol_del_diario(self):
+        """Dado una sucursal que cobra con un diario de la empresa padre, cuando se
+        crea el pago, entonces la compañía del pago pertenece al árbol del
+        diario.
+
+        Cubre el comportamiento 32 del relevamiento oba-test de account_cashbox.
+        """
+        caja_padre = self._cashbox_en(self.company, "Caja compartida", self.journal_cash)
+        sesion = self._create_session(
+            caja_padre,
+            name="Sesion compartida",
+            open_it=True,
+            allowed_companies=self.company | self.branch,
+        )
+
+        pago = (
+            self.env["account.payment"]
+            .with_user(self.cashbox_user)
+            .with_company(self.branch)
+            .create(
+                {
+                    "journal_id": self.journal_cash.id,
+                    "amount": 90.0,
+                    "payment_type": "inbound",
+                    "partner_type": "customer",
+                    "partner_id": self.partner.id,
+                    "cashbox_session_id": sesion.id,
+                }
+            )
+        )
+        # el pago se cobra con un diario del padre desde la sucursal: tiene que quedar colgado
+        # de una compañía del árbol de ese diario, no de una rama ajena
+        self.assertIn(
+            self.journal_cash.sudo().company_id,
+            pago.sudo().company_id.parent_ids,
+            "El pago quedó en la compañía %s, que no desciende de la del diario" % pago.sudo().company_id.name,
+        )

--- a/account_cashbox/tests/test_cash_control_closing.py
+++ b/account_cashbox/tests/test_cash_control_closing.py
@@ -1,0 +1,192 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.exceptions import UserError, ValidationError
+from odoo.tests import tagged
+
+from .common import CashboxCommon
+
+
+@tagged("post_install", "-at_install")
+class TestCashControlClosing(CashboxCommon):
+    def _caja_con_control(self, name, journal, **kwargs):
+        """Caja con control de apertura y cierre sobre `journal`.
+
+        Ojo con ``max_diff``: su default es 0, y el chequeo rechaza toda
+        diferencia mayor al tope. O sea que una caja recién creada **no puede
+        cerrar con ninguna diferencia** y el wizard de ajuste nunca llega a
+        abrirse. Los escenarios que van a buscar el ajuste declaran un tope
+        holgado; los que van a buscar el tope lo declaran chico.
+        """
+        kwargs.setdefault("max_diff", 100.0)
+        return self._create_cashbox(name, journal, cash_control_journal_ids=[(6, 0, journal.ids)], **kwargs)
+
+    def test_cierre_con_control_de_caja(self):
+        """Dado una sesión con diarios de control, cuando se la cierra contando la
+        plata, entonces el control exige el conteo, el desvío abre el ajuste, y
+        el ajuste deja un asiento sano.
+
+        Va en cadena porque es donde el estado tiene que sobrevivir a la
+        secuencia completa: control de cierre, ajuste, y vuelta a borrador que
+        deshace el asiento.
+
+        Cubre los comportamientos 9, 11, 12, 15 y 34 del relevamiento oba-test de
+        account_cashbox.
+        """
+        cashbox = self._caja_con_control("Control de caja", self.journal_cash)
+        session = self._create_session(cashbox, open_it=True)
+        self._create_payment(self.journal_cash, amount=200.0, session=session)
+        linea = session.line_ids
+
+        with self.subTest("pasar a control de cierre estampa la fecha de cierre"):
+            self.assertTrue(session.require_cash_control)
+            session.action_closing_control()
+            self.assertEqual(session.state, "closing_control")
+            self.assertTrue(session.closing_date)
+
+        with self.subTest("validar sin haber cargado el saldo real de un diario controlado se rechaza"):
+            with self.assertRaises(UserError):
+                session.action_account_cashbox_session_close()
+            self.assertEqual(session.state, "closing_control", "La sesión avanzó de estado pese al rechazo")
+
+        with self.subTest("con diferencia el cierre devuelve el wizard de ajuste en vez de cerrar"):
+            # se contaron 30 de más
+            linea.balance_end_real = 230.0
+            self.assertEqual(linea.balance_difference, 30.0)
+            action = session.action_account_cashbox_session_close()
+            self.assertEqual(action.get("res_model"), "account.cashbox.rounding.adjustment.wizard")
+            self.assertEqual(session.state, "closing_control", "La sesión cerró sin pasar por el ajuste")
+
+        with self.subTest("el ajuste crea un asiento contra la cuenta de ganancia del diario y cierra la sesión"):
+            wizard = self.env["account.cashbox.rounding.adjustment.wizard"].browse(action["res_id"])
+            wizard.action_create_journal_entries()
+            self.assertEqual(session.state, "closed")
+
+            asientos = self.env["account.move"].search([("cashbox_session_id", "=", session.id)])
+            self.assertEqual(
+                len(asientos),
+                1,
+                "El ajuste dejó %s asientos y la sesión tiene una sola línea con " "diferencia" % len(asientos),
+            )
+            self.assertEqual(asientos.state, "posted")
+            self.assert_move_sums_zero(asientos)
+            self.assert_no_automatic_balancing_line(asientos)
+            self.assert_no_zero_lines(asientos)
+            # se contó de más: entra plata a la cuenta del diario contra la cuenta de ganancia
+            ganancia = asientos.line_ids.filtered(lambda x: x.account_id == self.journal_cash.profit_account_id)
+            liquidez = asientos.line_ids.filtered(lambda x: x.account_id == self.journal_cash.default_account_id)
+            self.assertEqual(ganancia.credit, 30.0)
+            self.assertEqual(liquidez.debit, 30.0)
+
+        with self.subTest("volver la sesión a borrador borra el asiento de ajuste"):
+            session.action_account_cashbox_session_reset_to_draft()
+            self.assertEqual(session.state, "draft")
+            self.assertFalse(
+                asientos.exists(),
+                "La sesión volvió a borrador pero el asiento de ajuste quedó vivo: el próximo cierre sumaría "
+                "un segundo ajuste sobre la misma diferencia",
+            )
+
+    def test_ajuste_puede_cerrar_sin_generar_asientos(self):
+        """Dado una sesión con diferencia, cuando se elige cerrar sin asientos,
+        entonces la sesión queda cerrada y no se creó ningún asiento.
+
+        Cubre el comportamiento 36 del relevamiento oba-test de account_cashbox.
+        """
+        cashbox = self._caja_con_control("Cierre sin asientos", self.journal_cash)
+        session = self._create_session(cashbox, open_it=True)
+        self._create_payment(self.journal_cash, amount=100.0, session=session)
+        session.line_ids.balance_end_real = 90.0
+        session.action_closing_control()
+        action = session.action_account_cashbox_session_close()
+
+        wizard = self.env["account.cashbox.rounding.adjustment.wizard"].browse(action["res_id"])
+        wizard.action_close_without_entries()
+
+        self.assertEqual(session.state, "closed")
+        self.assertFalse(
+            self.env["account.move"].search([("cashbox_session_id", "=", session.id)]),
+            "Se eligió cerrar sin asientos y sin embargo quedó un asiento asociado a la sesión",
+        )
+
+    def test_tope_de_diferencia_en_moneda_de_la_compania(self):
+        """Dado una caja con diferencia máxima configurada, cuando la diferencia la
+        supera, entonces el cierre se rechaza.
+
+        Cubre el comportamiento 13 del relevamiento oba-test de account_cashbox.
+        """
+        cashbox = self._caja_con_control("Tope en la moneda de la compania", self.journal_cash, max_diff=10.0)
+        session = self._create_session(cashbox, open_it=True)
+        self._create_payment(self.journal_cash, amount=100.0, session=session)
+        session.action_closing_control()
+
+        with self.subTest("una diferencia dentro del tope no se rechaza"):
+            session.line_ids.balance_end_real = 105.0
+            action = session.action_account_cashbox_session_close()
+            self.assertEqual(action.get("res_model"), "account.cashbox.rounding.adjustment.wizard")
+
+        with self.subTest("una diferencia que supera el tope se rechaza"):
+            session.line_ids.balance_end_real = 130.0
+            with self.assertRaises(ValidationError):
+                session.action_account_cashbox_session_close()
+
+    def test_tope_de_diferencia_en_diario_en_moneda_extranjera(self):
+        """Dado un diario en moneda extranjera, cuando se compara la diferencia
+        contra el tope, entonces el tope se lleva a la moneda del diario.
+
+        El tope se configura en la moneda de la compañía (lo dice el help del
+        campo ``max_diff``) y la diferencia de la línea viene en la moneda del
+        diario. Con la cotización de la suite —1 de la compañía = 2 TCB— un tope
+        de 10 vale 20 TCB: una diferencia de 15 TCB entra y una de 25 TCB no.
+
+        Cubre los comportamientos 13 y 21 del relevamiento oba-test de
+        account_cashbox.
+        """
+        journal = self._create_journal("Test Cashbox TCB", "TCBF", "cash", currency=self.foreign_currency)
+        cashbox = self._caja_con_control("Tope en moneda", journal, max_diff=10.0)
+        session = self._create_session(cashbox, open_it=True)
+        self._create_payment(journal, amount=100.0, session=session, currency_id=self.foreign_currency.id)
+
+        linea = session.line_ids
+        self.assertEqual(linea.currency_id, self.foreign_currency, "La línea no tomó la moneda del diario")
+        self.assertEqual(linea.balance_end, 100.0, "El saldo de un diario con moneda propia no está en esa moneda")
+        session.action_closing_control()
+
+        with self.subTest("una diferencia de 15 TCB entra en un tope de 10 de la compañía (20 TCB)"):
+            linea.balance_end_real = 115.0
+            action = session.action_account_cashbox_session_close()
+            # hay diferencia, así que ofrece el ajuste: lo relevante es que no haya rechazado por el tope
+            self.assertEqual(action.get("res_model"), "account.cashbox.rounding.adjustment.wizard")
+
+        with self.subTest("una diferencia de 25 TCB supera ese mismo tope"):
+            linea.balance_end_real = 125.0
+            with self.assertRaises(ValidationError):
+                session.action_account_cashbox_session_close()
+
+    def test_ajuste_en_moneda_extranjera_usa_la_tasa_forzada(self):
+        """Dado un diario en moneda extranjera, cuando se fuerza la tasa en el
+        ajuste, entonces el asiento se valúa con esa tasa.
+
+        Cubre el comportamiento 35 del relevamiento oba-test de account_cashbox.
+        """
+        journal = self._create_journal("Test Cashbox TCB2", "TCBG", "cash", currency=self.foreign_currency)
+        cashbox = self._caja_con_control("Ajuste en moneda", journal)
+        session = self._create_session(cashbox, open_it=True)
+        self._create_payment(journal, amount=100.0, session=session, currency_id=self.foreign_currency.id)
+        session.line_ids.balance_end_real = 120.0
+        session.action_closing_control()
+        action = session.action_account_cashbox_session_close()
+
+        wizard = self.env["account.cashbox.rounding.adjustment.wizard"].browse(action["res_id"])
+        wizard.write({"force_rate": True, "forced_rate": 0.5})
+        wizard.action_create_journal_entries()
+
+        asiento = self.env["account.move"].search([("cashbox_session_id", "=", session.id)])
+        self.assertEqual(len(asiento), 1)
+        # 20 TCB de diferencia a la tasa forzada 0,5 => 10 en la moneda de la compañía
+        liquidez = asiento.line_ids.filtered(lambda x: x.account_id == journal.default_account_id)
+        self.assertEqual(liquidez.debit, 10.0)
+        self.assertEqual(liquidez.amount_currency, 20.0)
+        self.assert_move_sums_zero(asiento)
+        self.assert_no_zero_lines(asiento)

--- a/account_cashbox/tests/test_cashbox_invariants.py
+++ b/account_cashbox/tests/test_cashbox_invariants.py
@@ -1,0 +1,93 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import Command
+from odoo.tests import tagged
+
+from .common import CashboxCommon
+
+
+@tagged("post_install", "-at_install")
+class TestCashboxInvariants(CashboxCommon):
+    """La batería de invariantes tiene que fallar cuando corresponde fallar.
+
+    Es el test de la propia herramienta, y no es ceremonia: la batería la llaman
+    todas las suites de caja, así que un error acá deja la suite entera en verde
+    sin verificar nada. Por eso cada invariante se prueba en los dos sentidos:
+    pasa con la operación sana y **falla** con la operación que tiene que
+    detectar.
+
+    Ya pagamos ese costo una vez: ``assert_no_automatic_balancing_line`` estaba
+    escrita buscando la línea de relleno **por cuenta**, y
+    ``_get_automatic_balancing_account()`` devuelve la cuenta del diario cuando
+    el diario tiene una — o sea que daba positivo en todos los pagos de banco y
+    caja. Se detectó porque la invariante se probó contra una operación sana.
+    """
+
+    def test_cobertura_de_lineas_detecta_un_diario_que_no_es_de_caja(self):
+        cashbox = self._create_cashbox("Cobertura", self.journal_cash)
+        session = self._create_session(cashbox, open_it=True)
+
+        with self.subTest("con la sesión sana no molesta"):
+            self.assert_session_line_coverage(session)
+
+        with self.subTest("detecta una línea de un diario que no es de banco ni de caja"):
+            general = self._create_journal("Test Cashbox General", "TCBX", "general")
+            self.env["account.cashbox.session.line"].create(
+                {"cashbox_session_id": session.id, "journal_id": general.id}
+            )
+            with self.assertRaises(AssertionError):
+                self.assert_session_line_coverage(session)
+
+    def test_consistencia_de_saldos_detecta_un_pago_sin_linea(self):
+        cashbox = self._create_cashbox("Consistencia", self.journal_cash)
+        session = self._create_session(cashbox, open_it=True)
+        self._create_payment(self.journal_cash, amount=100.0, session=session)
+
+        with self.subTest("con la sesión sana no molesta"):
+            self.assert_session_balances_consistent(session)
+
+        with self.subTest("detecta un pago en un diario que la sesión no controla"):
+            # el importe de este pago no entra en ningún saldo de la sesión: al cerrar,
+            # esa plata simplemente no se cuenta y nada falla
+            huerfano = self._create_payment(self.journal_bank, amount=40.0, session=False)
+            huerfano.cashbox_session_id = session
+            with self.assertRaises(AssertionError):
+                self.assert_session_balances_consistent(session)
+
+    def test_la_bateria_de_asientos_detecta_la_linea_de_relleno(self):
+        """La línea de relleno se busca por nombre, que es como la identifica Odoo.
+
+        El caso sano es el que importa acá: un pago en un diario de caja tiene su
+        línea de liquidez en ``journal.default_account_id``, que es justo lo que
+        devuelve ``_get_automatic_balancing_account()``. Buscar por cuenta daría
+        positivo siempre.
+        """
+        cashbox = self._create_cashbox("Relleno", self.journal_cash)
+        session = self._create_session(cashbox, open_it=True)
+        pago = self._create_payment(self.journal_cash, amount=100.0, session=session)
+
+        with self.subTest("un pago normal de caja no tiene línea de relleno"):
+            self.assert_payment_invariants(pago)
+
+        with self.subTest("detecta la línea que agrega Odoo cuando el asiento no cierra solo"):
+            move = pago.move_id
+            move.button_draft()
+            cuenta = self.journal_cash.profit_account_id or self.journal_cash.default_account_id
+            move.write(
+                {
+                    "line_ids": [
+                        Command.create(
+                            {
+                                "name": self.env._("Automatic Balancing Line"),
+                                "account_id": cuenta.id,
+                                "debit": 0.0,
+                                "credit": 0.0,
+                            }
+                        )
+                    ]
+                }
+            )
+            with self.assertRaises(AssertionError):
+                self.assert_no_automatic_balancing_line(move)

--- a/account_cashbox/tests/test_cashbox_security.py
+++ b/account_cashbox/tests/test_cashbox_security.py
@@ -1,0 +1,129 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.exceptions import AccessError, UserError, ValidationError
+from odoo.tests import tagged
+
+from .common import CashboxCommon
+
+
+@tagged("post_install", "-at_install")
+class TestCashboxSecurity(CashboxCommon):
+    def _assert_bloqueado_por_el_modulo(self, accion):
+        """El bloqueo lo pone el módulo, no el ACL.
+
+        ``AccessError`` hereda de ``UserError``, así que un ``assertRaises
+        (UserError)`` pelado acepta las dos cosas indistintamente y no
+        distingue "el módulo lo frenó" de "el usuario no tenía permiso de
+        escritura igual". Esa laxitud deja pasar el caso en que alguien saca la
+        verificación del módulo: el test sigue verde porque el ACL tapa el
+        agujero, hasta que a alguien le dan permiso de escritura.
+        """
+        with self.assertRaises(UserError) as capturado:
+            accion()
+        self.assertNotIsInstance(
+            capturado.exception,
+            AccessError,
+            "El intento lo frenó el control de acceso genérico y no la verificación de la caja: "
+            "el mensaje fue %s" % capturado.exception,
+        )
+
+    def test_usuario_de_solo_lectura_ve_pero_no_opera(self):
+        """Dado un usuario habilitado solo para ver los pagos de una caja, cuando
+        intenta operarla, entonces el sistema lo bloquea; y solo ve las sesiones
+        de esa caja.
+
+        Es un **control positivo**: lo que se verifica es que el sistema
+        *bloquee*. Sin esto, una suite deja pasar el arreglo que bloquea de más
+        —"lo arreglé" puede significar "lo apagué"— y también el que no bloquea
+        nada, que es el estado en el que estaba este módulo.
+
+        Cubre los comportamientos 17 y 39 del relevamiento oba-test de
+        account_cashbox.
+        """
+        caja_visible = self._create_cashbox("Caja del viewer", self.journal_cash)
+        caja_visible.allowed_users_view_payments = [(6, 0, self.viewer_user.ids)]
+        caja_ajena = self._create_cashbox("Caja ajena", self.journal_bank)
+
+        sesion_visible = self._create_session(caja_visible, open_it=True)
+        sesion_ajena = self._create_session(caja_ajena, open_it=True)
+
+        with self.subTest("el usuario de solo-lectura ve las sesiones de su caja y no ve las de otra caja"):
+            visibles = (
+                self.env["account.cashbox.session"]
+                .with_user(self.viewer_user)
+                .search([("id", "in", (sesion_visible | sesion_ajena).ids)])
+            )
+            # igualdad exacta contra los registros que creó el test: nunca "hay al menos una"
+            self.assertEqual(
+                visibles,
+                sesion_visible,
+                "El usuario de solo-lectura ve %s y solo debería ver la sesión de su caja" % visibles.mapped("name"),
+            )
+
+        with self.subTest("el usuario de solo-lectura no puede abrir una sesión"):
+            # en otra caja: caja_visible no permite concurrentes y ya tiene su sesión abierta
+            otra_caja = self._create_cashbox("Caja del viewer 2", self.journal_cash)
+            otra_caja.allowed_users_view_payments = [(6, 0, self.viewer_user.ids)]
+            en_borrador = self._create_session(otra_caja, open_it=False)
+            self._assert_bloqueado_por_el_modulo(
+                en_borrador.with_user(self.viewer_user).action_account_cashbox_session_open
+            )
+
+        with self.subTest("el usuario de solo-lectura no puede pasar a control de cierre ni cerrar"):
+            self._assert_bloqueado_por_el_modulo(sesion_visible.with_user(self.viewer_user).action_closing_control)
+            self._assert_bloqueado_por_el_modulo(
+                sesion_visible.with_user(self.viewer_user).action_account_cashbox_session_close
+            )
+
+        with self.subTest("el usuario de solo-lectura no puede escribir la sesión"):
+            with self.assertRaises(AccessError):
+                sesion_visible.with_user(self.viewer_user).write({"name": "Renombrada por el viewer"})
+
+    def test_configuracion_de_la_caja_se_protege(self):
+        """Dado una caja configurada, cuando se la modifica de formas que dejarían
+        datos inconsistentes, entonces el sistema las rechaza.
+
+        Cubre los comportamientos 1, 2 y 3 del relevamiento oba-test de
+        account_cashbox.
+        """
+        cashbox = self._create_cashbox(
+            "Configuración protegida",
+            self.journal_cash | self.journal_bank,
+            cash_control_journal_ids=[(6, 0, self.journal_cash.ids)],
+        )
+
+        with self.subTest("no se saca de la caja un diario que tiene control de apertura y cierre"):
+            with self.assertRaises(UserError):
+                cashbox.journal_ids = [(6, 0, self.journal_bank.ids)]
+
+        with self.subTest("desmarcar restringir usuarios vacía la lista de usuarios permitidos"):
+            self.assertTrue(cashbox.allowed_res_users_ids)
+            cashbox.restrict_users = False
+            self.assertFalse(
+                cashbox.allowed_res_users_ids,
+                "La caja dejó de restringir usuarios pero conservó la lista de permitidos",
+            )
+
+        with self.subTest("no se borra una caja que tiene sesiones"):
+            self._create_session(cashbox)
+            with self.assertRaises(UserError):
+                cashbox.unlink()
+
+    def test_la_sesion_no_acepta_usuarios_ajenos_a_la_caja(self):
+        """Dado una caja que restringe usuarios, cuando se asigna a la sesión un
+        usuario que no está permitido, entonces se rechaza.
+
+        Cubre el comportamiento 18 del relevamiento oba-test de account_cashbox.
+        La validación existía escrita pero estaba anidada dentro de
+        ``_compute_line_ids``, así que el ORM nunca la registraba: se definía una
+        función local en cada iteración del compute y se descartaba.
+        """
+        ajeno = self._create_user("cashbox_intruso", "Cashbox Intruso")
+        cashbox = self._create_cashbox("Con usuarios restringidos", self.journal_cash)
+        self.assertNotIn(ajeno, cashbox.allowed_res_users_ids)
+
+        session = self._create_session(cashbox)
+        with self.assertRaises(ValidationError):
+            session.write({"user_ids": [(4, ajeno.id)]})

--- a/account_cashbox/tests/test_internal_transfer_batch.py
+++ b/account_cashbox/tests/test_internal_transfer_batch.py
@@ -1,0 +1,117 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.tests import tagged
+
+from .common import CashboxCommon
+
+
+@tagged("post_install", "-at_install")
+class TestInternalTransferBatch(CashboxCommon):
+    """Transferencias internas entre sesiones de caja, en los bordes que faltaban.
+
+    El camino feliz de una transferencia con sesión destino ya está cubierto por
+    ``test_internal_transfer_cashbox_session``. Acá van los dos casos que esa
+    suite no puede detectar: un lote donde cada transferencia va a una sesión
+    destino **distinta** (la suite actual manda las tres a la misma, así que un
+    cruce entre pagos del lote pasaría en verde), y el onchange que limpia la
+    sesión destino cuando deja de ser válida.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.journal_origen = cls._create_journal("Test Transfer Origen", "TTRO", "cash")
+        cls.journal_destino_a = cls._create_journal("Test Transfer Destino A", "TTRA", "cash")
+        cls.journal_destino_b = cls._create_journal("Test Transfer Destino B", "TTRB", "cash")
+
+    def setUp(self):
+        super().setUp()
+        self.caja_origen = self._create_cashbox("Transfer origen", self.journal_origen)
+        self.caja_a = self._create_cashbox("Transfer destino A", self.journal_destino_a)
+        self.caja_b = self._create_cashbox("Transfer destino B", self.journal_destino_b)
+        self.sesion_origen = self._create_session(self.caja_origen, open_it=True)
+        self.sesion_a = self._create_session(self.caja_a, open_it=True)
+        self.sesion_b = self._create_session(self.caja_b, open_it=True)
+
+    def _transferencia(self, destino_journal, destino_sesion, amount):
+        return self._create_payment(
+            self.journal_origen,
+            amount=amount,
+            session=self.sesion_origen,
+            post=False,
+            is_internal_transfer=True,
+            destination_journal_id=destino_journal.id,
+            destination_cashbox_session_id=destino_sesion.id,
+        )
+
+    def test_un_lote_manda_cada_pareado_a_su_propia_sesion_destino(self):
+        """Dado un lote de transferencias internas a sesiones destino distintas,
+        cuando se postean juntas, entonces cada pago pareado cae en la sesión
+        que le corresponde.
+
+        Los importes son distintos entre sí a propósito: con importes iguales un
+        cruce entre pagos del lote sería indistinguible del resultado correcto.
+
+        Cubre el comportamiento 30c del relevamiento oba-test de account_cashbox.
+        """
+        esperado = {
+            self._transferencia(self.journal_destino_a, self.sesion_a, 100.0): self.sesion_a,
+            self._transferencia(self.journal_destino_b, self.sesion_b, 200.0): self.sesion_b,
+            self._transferencia(self.journal_destino_a, self.sesion_a, 300.0): self.sesion_a,
+        }
+        pagos = self.env["account.payment"].browse([p.id for p in esperado])
+        pagos.action_post()
+
+        for pago, sesion_destino in esperado.items():
+            pareado = pago.paired_internal_transfer_payment_id
+            self.assertTrue(pareado, "La transferencia de %s no generó su pago pareado" % pago.amount)
+            self.assertEqual(
+                pareado.cashbox_session_id,
+                sesion_destino,
+                "El pareado de la transferencia de %s cayó en la sesión %s y la transferencia declaraba %s"
+                % (pago.amount, pareado.cashbox_session_id.name, sesion_destino.name),
+            )
+            self.assertFalse(
+                pareado.destination_cashbox_session_id,
+                "El pago pareado quedó con sesión destino propia: encadenaría otra transferencia",
+            )
+            self.assert_payment_invariants(pago)
+            self.assert_payment_invariants(pareado)
+
+        self.assert_cashbox_invariants(self.sesion_a)
+        self.assert_cashbox_invariants(self.sesion_b)
+
+    def test_cambiar_el_diario_destino_limpia_la_sesion_que_dejo_de_valer(self):
+        """Dado una transferencia con sesión destino elegida, cuando se cambia el
+        diario destino por otro que esa sesión no controla, entonces la sesión
+        destino se limpia.
+
+        Sin esto la transferencia se postea contra una sesión que no maneja el
+        diario al que entra la plata, y el importe queda fuera de todos los
+        saldos de esa sesión.
+
+        Cubre el comportamiento 31 del relevamiento oba-test de account_cashbox.
+        """
+        pago = self._transferencia(self.journal_destino_a, self.sesion_a, 150.0)
+        self.assertEqual(pago.destination_cashbox_session_id, self.sesion_a)
+
+        with self.subTest("cambiar a un diario que la sesión destino no controla la limpia"):
+            pago.destination_journal_id = self.journal_destino_b
+            pago._onchange_destination_journal_id()
+            self.assertFalse(
+                pago.destination_cashbox_session_id,
+                "La sesión destino sobrevivió al cambio de diario y ya no controla ese diario",
+            )
+
+        with self.subTest("volver a un diario que sí controla y elegir su sesión la conserva"):
+            pago.destination_journal_id = self.journal_destino_a
+            pago.destination_cashbox_session_id = self.sesion_a
+            pago._onchange_destination_journal_id()
+            self.assertEqual(pago.destination_cashbox_session_id, self.sesion_a)
+
+        with self.subTest("sin diario destino no queda sesión destino"):
+            pago.destination_journal_id = False
+            pago._onchange_destination_journal_id()
+            self.assertFalse(pago.destination_cashbox_session_id)

--- a/account_cashbox/tests/test_payment_binding.py
+++ b/account_cashbox/tests/test_payment_binding.py
@@ -1,0 +1,197 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import Command
+from odoo.exceptions import UserError, ValidationError
+from odoo.tests import Form, tagged
+
+from .common import CashboxCommon
+
+
+@tagged("post_install", "-at_install")
+class TestPaymentBinding(CashboxCommon):
+    """Enganche entre el pago y la sesión de caja.
+
+    Todos los pagos se crean con ``cashbox_user``: el dominio de sesiones
+    disponibles se evalúa contra el usuario en curso, así que crear como
+    superusuario mediría otra cosa. Y todas las cajas de la suite restringen
+    usuarios, así que las sesiones que la base ya tuviera abiertas no entran en
+    el dominio de este usuario — la aislación es por construcción, no por
+    asserts flojos.
+    """
+
+    def _pago_desde_formulario(self, journal, amount=100.0):
+        """Carga un pago como lo carga el usuario, por el formulario.
+
+        Va por ``Form`` y no por ``create()`` a propósito: la asignación
+        automática de la sesión **solo ocurre por el formulario**. En un
+        ``create()`` programático el campo queda vacío, porque se computa antes
+        de que esté seteada la compañía del pago y el dominio de sesiones
+        disponibles sale vacío. Está reportado como hallazgo del relevamiento;
+        el test no lo blinda ni lo tapa: verifica el camino del usuario, que es
+        el que tiene comportamiento definido.
+        """
+        form = Form(self.env["account.payment"].with_user(self.cashbox_user))
+        form.partner_id = self.partner
+        form.journal_id = journal
+        form.amount = amount
+        return form
+
+    def test_el_pago_toma_la_sesion_disponible(self):
+        """Dado un pago nuevo, cuando hay una, varias o ninguna sesión disponible,
+        entonces toma la única, la de la caja por defecto del usuario, o ninguna.
+
+        Cubre el comportamiento 22 del relevamiento oba-test de account_cashbox.
+        """
+        caja_a = self._create_cashbox("Binding A", self.journal_cash)
+        sesion_a = self._create_session(caja_a, open_it=True)
+
+        with self.subTest("con una sola sesión disponible el pago la toma solo"):
+            self.assertEqual(self._pago_desde_formulario(self.journal_cash).cashbox_session_id, sesion_a)
+
+        caja_b = self._create_cashbox("Binding B", self.journal_cash)
+        sesion_b = self._create_session(caja_b, open_it=True)
+
+        with self.subTest("con dos sesiones disponibles el pago toma la de la caja por defecto del usuario"):
+            self.cashbox_user.default_cashbox_id = caja_b
+            self.assertEqual(
+                self._pago_desde_formulario(self.journal_cash).cashbox_session_id,
+                sesion_b,
+                "Con dos sesiones disponibles el pago no cayó en la sesión de la caja por defecto del usuario",
+            )
+
+        with self.subTest("sin ninguna sesión disponible el pago queda sin sesión"):
+            self.cashbox_user.default_cashbox_id = False
+            for sesion in (sesion_a, sesion_b):
+                sesion.action_account_cashbox_session_close()
+            self.assertFalse(self._pago_desde_formulario(self.journal_cash).cashbox_session_id)
+
+    def test_el_usuario_obligado_a_usar_sesion_no_postea_sin_sesion(self):
+        """Dado un usuario obligado a operar con sesión de caja, cuando postea un
+        pago sin sesión abierta, entonces se rechaza.
+
+        Cubre el comportamiento 24 del relevamiento oba-test de account_cashbox.
+        """
+        self.cashbox_user.requiere_account_cashbox_session = True
+        pago = self._create_payment(self.journal_cash, post=False)
+        self.assertFalse(pago.cashbox_session_id, "El escenario declara que no hay ninguna sesión abierta")
+        with self.assertRaises(UserError):
+            pago.with_user(self.cashbox_user).action_post()
+
+    def test_no_se_postea_ni_se_cancela_contra_una_sesion_que_no_esta_abierta(self):
+        """Dado una sesión que no está abierta, cuando se postea o se cancela un
+        pago suyo, entonces se rechaza.
+
+        Son los dos bordes del mismo mecanismo —la sesión como ventana temporal
+        de lo que se puede tocar— y por eso van juntos.
+
+        Cubre los comportamientos 25 y 26 del relevamiento oba-test de
+        account_cashbox.
+        """
+        cashbox = self._create_cashbox("Ventana de la sesión", self.journal_cash)
+        session = self._create_session(cashbox)
+
+        with self.subTest("no se postea un pago sobre una sesión que sigue en borrador"):
+            pago = self._create_payment(self.journal_cash, session=session, post=False)
+            with self.assertRaises(UserError):
+                pago.with_user(self.cashbox_user).action_post()
+
+        with self.subTest("no se cancela un pago de una sesión ya cerrada"):
+            session.action_account_cashbox_session_open()
+            posteado = self._create_payment(self.journal_cash, amount=50.0, session=session)
+            session.action_account_cashbox_session_close()
+            self.assertEqual(session.state, "closed")
+            with self.assertRaises(UserError):
+                posteado.action_cancel()
+
+    def test_los_diarios_del_pago_se_limitan_a_los_de_la_sesion(self):
+        """Dado una sesión vieja y una caja a la que después le agregaron un diario,
+        cuando se listan los diarios disponibles del pago, entonces salen los de
+        las **líneas de la sesión**, no los de la caja.
+
+        Ese es el borde que el propio código declara en su comentario: la sesión
+        conserva los diarios con los que nació. Con una caja que nunca cambió,
+        las dos listas coinciden y el test no verificaría nada.
+
+        Cubre el comportamiento 27 del relevamiento oba-test de account_cashbox.
+        """
+        cashbox = self._create_cashbox("Diarios de la sesión", self.journal_cash)
+        session = self._create_session(cashbox, open_it=True)
+        self.assertEqual(session.line_ids.mapped("journal_id"), self.journal_cash)
+
+        # la caja cambia después de abierta la sesión: la sesión no se entera, y está bien
+        cashbox.journal_ids = [Command.set((self.journal_cash | self.journal_bank).ids)]
+
+        pago = self._create_payment(self.journal_cash, session=session, post=False)
+        self.assertIn(self.journal_cash, pago.available_journal_ids)
+        self.assertNotIn(
+            self.journal_bank,
+            pago.available_journal_ids,
+            "El pago ofrece un diario que se agregó a la caja después de abierta la sesión",
+        )
+
+    def test_la_moneda_del_pago_debe_ser_la_del_diario(self):
+        """Dado un diario con moneda propia y una sesión, cuando el pago va en otra
+        moneda, entonces se rechaza.
+
+        Cubre el comportamiento 29 del relevamiento oba-test de account_cashbox.
+        """
+        journal = self._create_journal("Test Cashbox TCB3", "TCBH", "cash", currency=self.foreign_currency)
+        cashbox = self._create_cashbox("Moneda del diario", journal)
+        session = self._create_session(cashbox, open_it=True)
+
+        with self.assertRaises(ValidationError):
+            self._create_payment(journal, session=session, post=False, currency_id=self.currency.id)
+
+    def test_importar_pagos_los_ata_a_la_sesion_y_deja_nota(self):
+        """Dado pagos sueltos, cuando se los importa a una sesión, entonces quedan
+        atados a ella y la sesión deja constancia en el chatter.
+
+        Cubre el comportamiento 33 del relevamiento oba-test de account_cashbox.
+        """
+        cashbox = self._create_cashbox("Importar pagos", self.journal_cash)
+        session = self._create_session(cashbox, open_it=True)
+        suelto = self._create_payment(self.journal_cash, amount=70.0, session=False, post=False)
+        self.assertFalse(suelto.cashbox_session_id)
+
+        mensajes_antes = len(session.message_ids)
+        wizard = self.env["account.cashbox.payment.import"].create(
+            {"cashbox_session_id": session.id, "payment_ids": [Command.set(suelto.ids)]}
+        )
+        wizard.action_import_payment()
+
+        self.assertEqual(suelto.cashbox_session_id, session)
+        self.assertEqual(
+            len(session.message_ids), mensajes_antes + 1, "La importación no dejó constancia en el chatter"
+        )
+        self.assertIn(self.journal_cash.display_name, session.message_ids[0].body)
+
+    def test_el_wizard_de_registro_propaga_la_sesion(self):
+        """Dado el wizard de registro de pagos con una sesión elegida, cuando se
+        registra el pago, entonces el pago creado sale con esa sesión.
+
+        Es el camino que usan los módulos que siguen registrando pagos por el
+        wizard estándar (gastos, por ejemplo), no por el flujo propio de caja.
+
+        Cubre el comportamiento 37 del relevamiento oba-test de account_cashbox.
+        """
+        cashbox = self._create_cashbox("Wizard de registro", self.journal_cash)
+        session = self._create_session(cashbox, open_it=True)
+        invoice = self._create_invoice(amount=120.0)
+
+        wizard = (
+            self.env["account.payment.register"]
+            .with_user(self.cashbox_user)
+            .with_context(active_model="account.move", active_ids=invoice.ids)
+            .create({"journal_id": self.journal_cash.id, "cashbox_session_id": session.id})
+        )
+        pagos = wizard._create_payments()
+
+        self.assertEqual(len(pagos), 1)
+        self.assertEqual(
+            pagos.cashbox_session_id,
+            session,
+            "El pago creado por el wizard de registro no se enganchó a la sesión elegida en el wizard",
+        )
+        self.assert_cashbox_invariants(session)

--- a/account_cashbox/tests/test_session_concurrency.py
+++ b/account_cashbox/tests/test_session_concurrency.py
@@ -1,0 +1,73 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+
+from .common import CashboxCommon
+
+
+@tagged("post_install", "-at_install")
+class TestSessionConcurrency(CashboxCommon):
+    def test_unicidad_y_arrastre_de_saldo(self):
+        """Dado una caja con o sin sesiones concurrentes, cuando se abre la sesión
+        siguiente, entonces la unicidad y el arrastre del saldo inicial se
+        comportan según ese setting.
+
+        Va parametrizado y no en dos archivos porque es **el mismo mecanismo en
+        sus dos configuraciones**: duplicarlo duplicaría el fixture y el
+        mantenimiento sin agregar una verificación nueva.
+
+        El arrastre es lo que hace que la plata que quedó en la caja al cerrar
+        anoche aparezca como saldo inicial esta mañana. Cubre los
+        comportamientos 4, 6, 6b y 7 del relevamiento oba-test de
+        account_cashbox.
+        """
+        for concurrentes in (False, True):
+            with self.subTest("caja con sesiones concurrentes" if concurrentes else "caja sin sesiones concurrentes"):
+                cashbox = self._create_cashbox(
+                    "Arrastre %s" % concurrentes,
+                    self.journal_cash,
+                    cash_control_journal_ids=[(6, 0, self.journal_cash.ids)],
+                    allow_concurrent_sessions=concurrentes,
+                )
+
+                primera = self._create_session(cashbox, open_it=True)
+                self._create_payment(self.journal_cash, amount=100.0, session=primera)
+                linea = primera.line_ids
+                self.assertEqual(linea.balance_start, 0.0, "La primera sesión de la caja arrancó con saldo inicial")
+                self.assertEqual(linea.balance_end, 100.0)
+
+                # se cuenta la plata y coincide: cierra sin pasar por el ajuste
+                linea.balance_end_real = 100.0
+                primera.action_closing_control()
+                primera.action_account_cashbox_session_close()
+                self.assertEqual(primera.state, "closed")
+
+                segunda = self._create_session(cashbox)
+                arrastre = 0.0 if concurrentes else 100.0
+                self.assertEqual(
+                    segunda.line_ids.balance_start,
+                    arrastre,
+                    "La sesión siguiente arrancó con saldo inicial %s y la caja %s sesiones concurrentes"
+                    % (segunda.line_ids.balance_start, "permite" if concurrentes else "no permite"),
+                )
+                self.assert_cashbox_invariants(segunda)
+
+                segunda.action_account_cashbox_session_open()
+                if concurrentes:
+                    tercera = self._create_session(cashbox, name="Tercera concurrente", open_it=True)
+                    self.assertEqual(
+                        cashbox.current_concurrent_session_ids,
+                        segunda | tercera,
+                        "La caja con sesiones concurrentes no lista las dos sesiones abiertas",
+                    )
+                else:
+                    with self.assertRaises(UserError):
+                        self._create_session(cashbox, open_it=True)
+                    self.assertEqual(
+                        cashbox.current_session_id,
+                        segunda,
+                        "La sesión actual de la caja no es la única que quedó abierta",
+                    )

--- a/account_cashbox/tests/test_session_lifecycle.py
+++ b/account_cashbox/tests/test_session_lifecycle.py
@@ -1,0 +1,87 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+
+from .common import CashboxCommon
+
+
+@tagged("post_install", "-at_install")
+class TestSessionLifecycle(CashboxCommon):
+    def test_session_lifecycle(self):
+        """Dado una caja sin control de caja, cuando se recorre el ciclo de vida
+        completo de una sesión, entonces cada paso deja el estado, las fechas y
+        los saldos que declara.
+
+        Va en cadena y no suelto porque lo que hay que verificar no es cada paso
+        aislado sino que el estado **sobreviva a la secuencia**: la fecha de
+        apertura que no se repisa al reabrir, y el cierre que estampa la fecha
+        aun sin diarios de control.
+
+        Cubre los comportamientos 5, 8, 10, 16 y 19 del relevamiento oba-test de
+        account_cashbox.
+        """
+        cashbox = self._create_cashbox("Ciclo de vida", self.journal_cash | self.journal_bank)
+        session = self._create_session(cashbox)
+
+        with self.subTest("crear la sesión la numera con la secuencia de la caja y arma una línea por diario"):
+            self.assertTrue(
+                session.name.startswith(cashbox.sequence_id.prefix),
+                "La sesión se llama %s y la secuencia de la caja tiene prefijo %s"
+                % (session.name, cashbox.sequence_id.prefix),
+            )
+            self.assertEqual(session.state, "draft")
+            self.assertEqual(session.line_ids.mapped("journal_id"), self.journal_cash | self.journal_bank)
+            self.assertFalse(session.opening_date)
+            self.assertFalse(session.closing_date)
+            self.assert_cashbox_invariants(session)
+
+        with self.subTest("abrirla la pasa a abierta y estampa la fecha de apertura"):
+            session.with_user(self.cashbox_user).action_account_cashbox_session_open()
+            self.assertEqual(session.state, "opened")
+            self.assertTrue(session.opening_date)
+            primera_apertura = session.opening_date
+
+        with self.subTest("un pago posteado suma al saldo final de la línea de su diario, y solo de ese"):
+            payment = self._create_payment(self.journal_cash, amount=150.0, session=session)
+            linea_cash = session.line_ids.filtered(lambda line: line.journal_id == self.journal_cash)
+            linea_bank = session.line_ids.filtered(lambda line: line.journal_id == self.journal_bank)
+            self.assertEqual(linea_cash.amount, 150.0)
+            self.assertEqual(linea_cash.balance_end, 150.0)
+            self.assertEqual(linea_bank.amount, 0.0, "El pago del diario de caja movió el saldo del diario de banco")
+            self.assert_payment_invariants(payment)
+            self.assert_cashbox_invariants(session)
+
+        with self.subTest("cerrarla sin diarios de control igual estampa la fecha de cierre"):
+            self.assertFalse(session.require_cash_control)
+            session.with_user(self.cashbox_user).action_account_cashbox_session_close()
+            self.assertEqual(session.state, "closed")
+            self.assertTrue(
+                session.closing_date,
+                "La sesión cerró sin estampar la fecha de cierre: sin diarios de control nadie pasa por el "
+                "control de cierre, que es donde la otra rama la estampa",
+            )
+
+        with self.subTest("volverla a borrador y reabrirla no repisa la fecha de apertura original"):
+            session.action_account_cashbox_session_reset_to_draft()
+            self.assertEqual(session.state, "draft")
+            session.with_user(self.cashbox_user).action_account_cashbox_session_open()
+            self.assertEqual(session.state, "opened")
+            self.assertEqual(
+                session.opening_date,
+                primera_apertura,
+                "Reabrir la sesión repisó la fecha de apertura original",
+            )
+            self.assert_cashbox_invariants(session)
+
+        with self.subTest("una sesión que no está en borrador no se puede borrar"):
+            with self.assertRaises(UserError):
+                session.unlink()
+
+        with self.subTest("una sesión en borrador sí se puede borrar"):
+            # en otra caja: la de arriba tiene una sesión abierta y no permite concurrentes
+            borrable = self._create_session(self._create_cashbox("Borrable", self.journal_cash))
+            borrable.unlink()
+            self.assertFalse(borrable.exists())


### PR DESCRIPTION
Part of the Robustez & Calidad guild work (task 67106). Independent from #1152, which covers `account_payment_pro` on the same task.

## What this does

`account_cashbox` had 5 tests covering a single mechanism (internal transfers between sessions). Everything else was unverified: the session lifecycle, the opening-balance carry-over between sessions, the cash-control closing and the rounding adjustment, the payment/session binding, and the security checks.

The suite now covers the module's behaviours **grouped by mechanism**, not one test per method: 39 relevant behaviours became 9 tests. Mirrored cases (cashbox with and without concurrent sessions) are one parametrised test; the lifecycle is one chain with a `subTest` per step, so a failure still names the step in business language.

## Invariants battery

`tests/invariants.py` holds the checks that must hold after **any** operation, so they run everywhere instead of only where someone remembered them: the entry balances, Odoo did not complete it with an automatic balancing line, no zero lines, multi-currency entries close in both currencies, and — specific to this module — every payment of a session has a control line for its journal, and the balances match their parts.

That last one is the interesting one: a payment whose session has no line for its journal **disappears from every balance**. Nothing fails, nothing is logged; the money simply is not counted at closing.

The battery has its own tests, in both directions: each invariant is checked against a sound operation (it must not complain) and against the defective one it exists to catch (it must complain). That paid off immediately — see the first note below.

## Two fixes the suite surfaced

Both in `models/account_cashbox_session.py`:

- **`_check_user_ids_allowed` was dead code.** It was nested inside `_compute_line_ids`, so the ORM never registered it: a local function was defined on each compute iteration and thrown away. Sessions accepted users not allowed on the cashbox. Moved to class level.
- **`max_diff` was converted in the wrong direction.** The field is documented in company currency, but it was converted *from* the journal currency *to* the company one, while the difference it is compared against is expressed in the journal currency. On a foreign-currency journal the cap was off by the exchange rate. Now converted company → journal, with explicit company and date.

## Test plan

```
odoo-bin -d <db> -u account_cashbox --test-tags /account_cashbox --stop-after-init

account_cashbox: 49 tests 11.50s 10958 queries
0 failed, 0 error(s) of 29 tests
```

No warnings emitted during the run.

**Every test was demonstrated failing.** For each one the protected behaviour was broken surgically and the run was checked to fail on the matching assert, with a message that explains what was expected; then the code was restored and the suite verified green again. Reverting either of the two fixes above turns its test red, so both are covered.

## Notes for reviewers

- The battery is duplicated on purpose. The shared cobros/pagos battery is being written in `account_ux` on another branch and repo; copying it here keeps this PR unblocked. The module docstring says so, and the duplicate half is deleted when that one lands.
- While writing this, `assert_no_automatic_balancing_line` was found to be wrong as originally drafted: it looked for the filler line **by account**, and `_get_automatic_balancing_account()` returns the journal's account when it has one — which is exactly where the legitimate liquidity line of any bank or cash payment lands, so it reported a false positive on every payment. Odoo itself identifies that line **by name** in `_sync_unbalanced_lines`, and that is what this copy does.
- No existing test was modified or removed. Several are worth revisiting (one asserts the value it just wrote, another skips itself when the database lacks two journals, a batch test sends all its transfers to the same destination session so it cannot detect a cross-over) but that is a separate call and a separate PR.
- Some behaviours are deliberately left without a test rather than freezing current behaviour as expected, most notably that `cashbox_session_id` is not assigned on a programmatic `create()` — it works through the form, and on posting only for users flagged as requiring a session. Writing a test for the broken path would defend the bug.

Internal task: /odoo/project.task/67106