### PR TITLE
[FIX] check payments: one owner for the entry when a payment carries several checks

### DIFF
--- a/account_payment_pro/DESIGN.md
+++ b/account_payment_pro/DESIGN.md
@@ -113,6 +113,7 @@ B1→ A:  amount_A = amount_B / counterpart_rate
 - Write-off line: `destination_currency_id` with conversion to C via `_convert()`.
 - When `force_balance` is set (paired internal transfer), the liquidity balance is **not** recalculated from `accounting_rate` to avoid rounding discrepancies in cross-currency transfers (e.g. USD → EUR).
 - **Write-off + withholding coexistence:** Base Odoo discards `write_off_lines` when `withholding_lines` exist. The override re-injects write-off lines and rebalances the counterpart.
+- **Check payments (ticket 123832):** with `l10n_latam_check_ux` installed — it is `auto_install` — that module also overrides this method and, being the outer one in the MRO, it has the last word on the counterpart balance whenever the liquidity lines were built one per check. It applies the same formula as here — including when the amount arrives netted by withholdings, where it recovers the rate by adding the withholding back. If this formula changes, both places change.
 
 ### Internal transfers
 

--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -695,17 +695,22 @@ class AccountPayment(models.Model):
                 super(AccountPayment, rec)._compute_destination_account_id()
 
     def _prepare_move_lines_per_type(self, write_off_line_vals=None, force_balance=None):
+        """La cotización baja como `force_balance` y las líneas las arma quien corresponda.
+
+        Pasándola por ese canal el balance llega ya convertido a las hooks de abajo, así que el
+        reparto entre varias líneas de liquidez —el caso de los cheques— vive en su módulo
+        (`l10n_latam_check_ux`, ticket 123832) en vez de estar duplicado acá.
+        """
+        if self.accounting_rate and self.currency_id != self.company_currency_id and force_balance is None:
+            amount_for_calc = self.amount_exact if self.amount_exact else self.amount
+            force_balance = amount_for_calc / self.accounting_rate  # A/C → monto en C
+
         if not self.company_id.use_payment_pro:
-            # Para pagos sin ppro que tengan accounting rate, forzamos el balance
-            # para que no haya diferencias en el asiento
-            if self.accounting_rate and self.currency_id != self.company_currency_id and force_balance is None:
-                amount_for_calc = self.amount_exact if self.amount_exact else self.amount
-                force_balance = amount_for_calc / self.accounting_rate  # A/C → monto en C
             return super()._prepare_move_lines_per_type(
                 write_off_line_vals=write_off_line_vals, force_balance=force_balance
             )
 
-        # Write-off en moneda B2 (destination_currency_id)
+        # Write-off propio de ppro, en moneda B2 (destination_currency_id)
         write_off_line_vals = []
         if self.write_off_amount and self.write_off_type_id:
             wo_sign = 1 if self.payment_type == "inbound" else -1
@@ -724,47 +729,21 @@ class AccountPayment(models.Model):
                 }
             )
 
-        res = super()._prepare_move_lines_per_type(write_off_line_vals=write_off_line_vals, force_balance=force_balance)
-
-        # ── Re-inyectar write-off si base Odoo lo descartó ────────────────────────
-        # Base Odoo (L342-345) descarta write_off_lines cuando hay withholding_lines
-        # porque asume que las retenciones se pasan como write-off en _synchronize_to_moves.
-        # En payment_pro las retenciones y el write-off son conceptos separados, así que
-        # re-inyectamos las write-off lines que nosotros construimos.
-        if write_off_line_vals and not res.get("write_off_lines"):
-            res["write_off_lines"] = write_off_line_vals
+        res = super()._prepare_move_lines_per_type(force_balance=force_balance)
 
         liquidity_lines = res.get("liquidity_lines", [])
         counterpart_lines = res.get("counterpart_lines", [])
-
         if not liquidity_lines or not counterpart_lines:
             return res
 
-        # ── Ajuste de las líneas de LIQUIDEZ ──────────────────────────────────────
-        # accounting_rate = A/C (formato Odoo nativo, ej: 0.000667 p/USD→ARS)
-        # balance_en_C = amount_en_A / accounting_rate
-        # Se itera sobre TODAS las líneas (puede haber N cuando se usan cheques)
-        # Cuando force_balance está definido, el balance ya fue forzado por base Odoo
-        # (ej: paired payment de transferencia interna) y NO debe recalcularse.
-        if self.accounting_rate and self.currency_id != self.company_currency_id and force_balance is None:
-            # Con una sola línea de liquidez el nominal sale de amount_exact, que conserva la
-            # precisión completa del importe. Solo fija el nominal: el balance lo deriva el loop de
-            # abajo, así que ese loop tiene que quedar DESPUÉS de este if.
-            if len(liquidity_lines) == 1 and self.amount_exact and self.amount_exact != self.amount:
-                liq_sign = 1 if liquidity_lines[0]["amount_currency"] >= 0 else -1
-                liquidity_lines[0]["amount_currency"] = liq_sign * abs(self.amount_exact)
-            # El balance se redondea por línea porque así lo va a persistir el ORM y la
-            # contrapartida se arma más abajo con la suma: sin redondear acá,
-            # sum(round(línea)) != round(sum(líneas)) y el asiento cierra con centavos de
-            # diferencia por cada línea de más (ticket 123832).
-            for liq_line in liquidity_lines:
-                liq_line["balance"] = self.company_currency_id.round(liq_line["amount_currency"] / self.accounting_rate)
-
-        # ── Recalcular balance de CONTRAPARTIDA para cerrar el asiento ────────────
-        write_off_balance = sum(line["balance"] for line in res.get("write_off_lines", []))
-        withholding_balance = sum(line["balance"] for line in res.get("withholding_lines", []))
-        total_liq_balance = sum(line["balance"] for line in liquidity_lines)
-        counterpart_lines[0]["balance"] = -total_liq_balance - write_off_balance - withholding_balance
+        if write_off_line_vals:
+            # El write-off propio se inyecta acá y no se le pasa al core: si el core ve líneas de
+            # write-off descarta el `force_balance`, y con él la cotización del pago que este método
+            # acaba de bajar. La contrapartida se ajusta por ese importe. El write-off que llega de
+            # afuera (wizard de registro) sigue yendo por el camino del core, como antes: ahí la
+            # cotización tipeada no se propaga, y reenviárselo acá rompe el resync con retenciones.
+            res["write_off_lines"] = write_off_line_vals
+            counterpart_lines[0]["balance"] -= sum(line["balance"] for line in write_off_line_vals)
 
         # ── Ajuste de MONEDA en la línea de CONTRAPARTIDA ─────────────────────────
         if self.is_internal_transfer:
@@ -787,7 +766,10 @@ class AccountPayment(models.Model):
                 if self.write_off_amount and self.destination_currency_id == self.counterpart_currency_id:
                     counterpart_amt += abs(self.write_off_amount)
                 counterpart_lines[0]["amount_currency"] = cp_sign * counterpart_amt
-        # Si A == B1: la moneda ya es correcta (A), solo el balance se actualizó arriba
+        elif write_off_line_vals:
+            # A == B1 y la moneda ya es correcta: el core armó el nominal sin ver el write-off,
+            # así que hay que sumárselo para que la contrapartida cubra el total de la deuda.
+            counterpart_lines[0]["amount_currency"] -= sum(line["amount_currency"] for line in write_off_line_vals)
 
         # Cualquiera de las ramas anteriores puede dejar la contrapartida en moneda de
         # compañía, y ahí el nominal y el balance son la misma cifra por definición: tiene

--- a/account_payment_pro/tests/test_checks_payment_pro.py
+++ b/account_payment_pro/tests/test_checks_payment_pro.py
@@ -185,7 +185,14 @@ class TestChecksPaymentPro(TestArCommon):
         self.assertEqual(len(counterpart), 1, "One counterpart line regardless of the number of checks")
         self.assertEqual(abs(counterpart.balance), abs(sum(lines.mapped("balance"))))
 
-        manual = self._own_check_payment([20, 30, 70], ["00031101", "00031102", "00031103"], currency=self.usd)
+        # diferidos a proposito: la cotizacion tipeada (1000) tiene que ganarle a la de la tabla al
+        # vencimiento (2400), que es la que usaria `l10n_latam_check` por su cuenta
+        manual = self._own_check_payment(
+            [20, 30, 70],
+            ["00031101", "00031102", "00031103"],
+            currency=self.usd,
+            check_dates=[fields.Date.add(self.today, days=30)] * 3,
+        )
         manual.accounting_rate = 1 / 1000.0
         manual.action_post()
 
@@ -225,6 +232,12 @@ class TestChecksPaymentPro(TestArCommon):
             abs(counterpart.balance),
             "En moneda de compañía el nominal y el balance son la misma cifra",
         )
+        self.assertEqual(
+            payment.counterpart_currency_amount,
+            abs(counterpart.amount_currency),
+            "El importe que muestra el pago es el mismo que su línea contable",
+        )
+        self.assertEqual(payment.amount, 79435.42, "Y alinearlo no corre el importe del pago")
 
         # Misma operación con la contrapartida en la moneda del pago en vez de la de
         # compañía: el otro camino por el que se desbalanceaba (B1 == A, counterpart_rate 1).

--- a/l10n_latam_check_ux/models/account_payment.py
+++ b/l10n_latam_check_ux/models/account_payment.py
@@ -278,3 +278,115 @@ class AccountPayment(models.Model):
             )
 
         return vals
+
+    @api.depends("l10n_latam_new_check_ids.amount", "l10n_latam_move_check_ids.amount")
+    def _compute_counterpart_currency_amount(self):
+        """Con varios cheques, el importe mostrado se arma como el del asiento: cheque por cheque.
+
+        El campo es de `account_payment_pro` y convierte el total de una sola vez; el asiento redondea
+        cada línea de cheque por separado y suma. Esa diferencia se veía como un centavo entre el
+        importe del pago y su propia línea contable (ticket 123832). Se usa la misma cotización que el
+        asiento —la que sale de `amount_exact`, no la del campo— porque si no vuelve a diferir justo
+        en los flujos donde el usuario tipea el importe.
+
+        El resto de los pagos ni pasa por acá.
+        """
+        per_check = self.filtered(lambda pay: pay._has_counterpart_amount_per_check())
+        super(AccountPayment, self - per_check)._compute_counterpart_currency_amount()
+        for pay in per_check:
+            rate = (pay.amount_exact or pay.amount) / pay.accounting_rate / pay.amount
+            pay.counterpart_currency_amount = sum(
+                pay.company_currency_id.round(check.amount * rate)
+                for check in pay.l10n_latam_new_check_ids | pay.l10n_latam_move_check_ids
+            )
+
+    def _inverse_counterpart_currency_amount(self):
+        """El reparto por cheque no es un importe tipeado por el usuario.
+
+        El inverse de `account_payment_pro` deduce el importe del pago del que muestra la
+        contrapartida, y así recupera precisión cuando el importe llega de una sincronización (tarea
+        65829). Pero con varios cheques la diferencia es el resto de repartir, no un importe nuevo:
+        aplicarlo correría el `amount` del pago y los cheques dejarían de sumarlo (ticket 123832).
+        """
+        for pay in self:
+            if pay._has_counterpart_amount_per_check():
+                continue
+            super(AccountPayment, pay)._inverse_counterpart_currency_amount()
+
+    def _has_counterpart_amount_per_check(self):
+        """Si el importe de la contrapartida lo arma el reparto cheque por cheque."""
+        self.ensure_one()
+        return bool(
+            self.counterpart_currency_id == self.company_currency_id
+            and self.accounting_rate
+            and self.amount
+            and len(self.l10n_latam_new_check_ids | self.l10n_latam_move_check_ids) > 1
+        )
+
+    def _prepare_move_liquidity_lines(self, default_values):
+        """Valúa todos los cheques a la cotización que el asiento ya dio por buena.
+
+        `l10n_latam_check` convierte cada cheque a la cotización de su propia fecha de vencimiento y
+        descarta el balance que recibe acá, que es el que la contrapartida ya usó — la cotización del
+        pago, o la que llegó como `force_balance`. Con dos cotizaciones en el mismo asiento no cierra:
+        "El asiento no está balanceado" al confirmar (ticket 123832, BUG-2 de la task 70884).
+
+        La cotización se deduce de `balance` sobre el importe del pago, NO del par
+        balance/amount_currency: con retenciones ese par llega neteado, y en `amount_currency` el core
+        le resta importes que pueden venir en otra moneda. Del balance, en cambio, la retención se
+        recupera sumándola de vuelta: es una cifra en moneda de compañía y no mezcla nada.
+
+        Se deduce en vez de llamar a `_convert` por línea justamente para honrar el balance que llegó,
+        venga de la fecha del pago o forzado, y para no pagar una consulta de cotización por cheque.
+
+        El origen está en `l10n_latam_check._prepare_move_liquidity_lines`, que NO es código de
+        odoo/odoo 19.0: llega por el PR odoo#248741 (abierto, de Adhoc) que nuestra imagen mergea.
+        El arreglo definitivo va ahí; mientras ese PR siga abierto, esto lo cubre desde afuera. Ojo al
+        limpiarlo: el día que el origen respete el balance que entrega, esto queda inocuo pero sigue
+        decidiendo dónde cae el resto del redondeo, así que no es un borrado a ciegas.
+        """
+        lines = super()._prepare_move_liquidity_lines(default_values)
+        if not lines[0].get("l10n_latam_check_ids") or not self.amount:
+            # no las armó `l10n_latam_check`: no hay una línea por cheque que revaluar
+            return lines
+
+        balance = default_values["balance"]
+        if not self.currency_id.is_zero(abs(default_values["amount_currency"]) - abs(self.amount)):
+            # el importe llegó neteado: el core ya le restó las retenciones al balance
+            # (`liquidity_balance -= withholding_balance`), así que se las devolvemos para
+            # recuperar la cotización con la que se armó el asiento.
+            balance += sum(line["balance"] for line in self._prepare_move_withholding_lines({}))
+
+        rate = abs(balance) / abs(self.amount)
+        for line in lines:
+            line["balance"] = self.company_currency_id.round(line["amount_currency"] * rate)
+        return lines
+
+    def _prepare_move_lines_per_type(self, write_off_line_vals=None, force_balance=None):
+        """La contrapartida se arma desde las líneas que quedaron en el asiento.
+
+        El core la calcula desde un único balance de liquidez, que con cheques no existe: son N
+        líneas, cada una redondeada por su cuenta, y con retenciones ese balance además llega neteado
+        mientras los cheques van por su importe completo. Sumar lo que realmente quedó —cheques,
+        write-off y retenciones— es lo único que cierra en los dos casos.
+
+        `account_payment_pro` hace esta misma cuenta detrás de `use_payment_pro`: si la fórmula
+        cambia, hay que cambiarla en los dos lados hasta que viva en `account_ux`.
+        """
+        res = super()._prepare_move_lines_per_type(write_off_line_vals=write_off_line_vals, force_balance=force_balance)
+        liquidity_lines = res["liquidity_lines"]
+        if not liquidity_lines[0].get("l10n_latam_check_ids"):
+            return res
+        counterpart_lines = res["counterpart_lines"]
+        if not counterpart_lines:
+            return res
+
+        counterpart_lines[0]["balance"] = -sum(
+            line["balance"] for key in ("liquidity_lines", "write_off_lines", "withholding_lines") for line in res[key]
+        )
+        if counterpart_lines[0].get("currency_id") == self.company_currency_id.id:
+            # La contrapartida quedó en moneda de compañía: ahí nominal y balance son la misma
+            # cifra, y el nominal lo dejó quien calculó el balance anterior. Sin espejarlo, el ORM
+            # redondea el nominal viejo, deriva el balance de él y el asiento vuelve a no cerrar.
+            counterpart_lines[0]["amount_currency"] = counterpart_lines[0]["balance"]
+        return res

--- a/l10n_latam_check_ux/tests/test_own_checks_ux.py
+++ b/l10n_latam_check_ux/tests/test_own_checks_ux.py
@@ -14,6 +14,8 @@ kept commented out: they belong to the relocation PR, which is where each of
 them either flips or is deleted.
 """
 
+from unittest.mock import patch
+
 from odoo import Command, fields
 from odoo.exceptions import UserError, ValidationError
 from odoo.tests import tagged
@@ -86,25 +88,114 @@ class TestOwnChecksMulticurrency(LatamCheckCommon):
         expected_total = self.foreign_currency._convert(120, self.company_currency, self.company, payment.date)
         self.assertEqual(abs(sum(lines.mapped("balance"))), expected_total)
 
-    # def test_deferred_checks_fx_entry_is_unbalanced_today(self):
-    #     """EQUIVALENCE (task 70884, BUG-2: deferred FX).
-    #
-    #     Pins what the patched core does today, which the relocation must
-    #     reproduce: each check is converted at ``check.payment_date`` while the
-    #     counterpart keeps the conversion at ``payment.date``, so a deferred check
-    #     with a moving rate makes the entry unbalanced and posting is rejected.
-    #
-    #     It is a known defect (fixing it means converting at the payment date),
-    #     but fixing it is a separate PR: this assertion flips there, not here.
-    #     """
-    #     payment = self._create_own_check_payment(
-    #         [20, 30, 70],
-    #         numbers=["00001201", "00001202", "00001203"],
-    #         currency=self.foreign_currency,
-    #         check_dates=[fields.Date.add(self.today, days=40)] * 3,
-    #     )
-    #     with self.assertRaisesRegex(UserError, "not balanced"):
-    #         payment.action_post()
+    def _create_payment_at_an_odd_rate(self, numbers):
+        """Dos cheques iguales a una cotización que no divide exacto, para que el resto exista.
+
+        Con la del fixture (100) la conversión da al centavo y no habría resto que repartir.
+        """
+        odd_date = fields.Date.add(self.today, days=60)
+        self.env["res.currency.rate"].create(
+            {
+                "name": odd_date,
+                "currency_id": self.foreign_currency.id,
+                "company_id": self.company.id,
+                "rate": 1 / 40.189,
+            }
+        )
+        return self._create_own_check_payment(
+            [39717.71, 39717.71], numbers=numbers, currency=self.foreign_currency, date=odd_date
+        )
+
+    def test_all_checks_take_the_rate_the_entry_already_used(self):
+        """Ticket 123832: todos los cheques se valúan a la cotización que el asiento dio por buena.
+
+        Vencimientos distintos a propósito: la cotización del fixture pasa de 100 a 200 entre ambas
+        fechas, así que valuando cada cheque a la fecha de SU vencimiento uno valdría el doble que
+        el otro y el asiento no cerraría. Con el cheque diferido de este mismo test alcanza: nunca
+        hicieron falta dos o más, aunque el ticket se reportó así.
+        """
+        payment = self._create_own_check_payment(
+            [50, 50],
+            numbers=["00001401", "00001402"],
+            currency=self.foreign_currency,
+            check_dates=[self.today, fields.Date.add(self.today, days=30)],
+        )
+        payment.action_post()
+
+        self.assert_move_balanced(payment.move_id)
+        self.assertEqual(
+            [abs(line.balance) for line in self._check_lines(payment)],
+            [5000.0, 5000.0],
+            "Mismo importe, mismo valor, aunque venzan en fechas con cotización distinta",
+        )
+
+    def test_the_counterpart_keeps_the_rounding_residue(self):
+        """El resto de redondear cada cheque por separado queda en la contrapartida.
+
+        Las cifras se afirman explícitamente, porque que el asiento cierre no dice DÓNDE quedó el
+        resto.
+        """
+        payment = self._create_payment_at_an_odd_rate(["00001501", "00001502"])
+        payment.action_post()
+
+        self.assert_move_balanced(payment.move_id)
+        self.assertEqual(
+            [abs(line.balance) for line in self._check_lines(payment)],
+            [1596215.05, 1596215.05],
+            "Cada cheque: 39.717,71 x 40,189 redondeado",
+        )
+        self.assertEqual(
+            abs(self._counterpart_lines(payment).balance), 3192430.10, "La contrapartida se queda con el centavo"
+        )
+        # convertir el total de una sola vez daría 3.192.430,09: ese centavo es el resto que la
+        # contrapartida se queda, y es lo que se afirma arriba
+
+    def test_write_off_does_not_leave_the_residue_homeless(self):
+        """Con write-off la contrapartida igual absorbe el resto: si no, el centavo del redondeo por
+        línea queda sin dueño y el asiento no cierra."""
+        payment = self._create_payment_at_an_odd_rate(["00001801", "00001802"])
+        write_off = [
+            {
+                "name": "ajuste",
+                "account_id": self.deferred_check_account.id,
+                "currency_id": self.company_currency.id,
+                "amount_currency": -100.0,
+                "balance": -100.0,
+            }
+        ]
+        res = payment._prepare_move_lines_per_type(write_off_line_vals=write_off)
+
+        self.assertEqual(
+            self.company_currency.round(sum(line["balance"] for lines in res.values() for line in lines)),
+            0.0,
+            "El asiento cierra con el write-off adentro",
+        )
+
+    def test_a_netted_amount_recovers_the_payment_rate(self):
+        """Si el importe llega neteado (retenciones), la cotización se recupera igual.
+
+        El core le resta la retención al balance de liquidez, así que se la sumamos de vuelta —
+        siempre en moneda de compañía, sin mezclar — y los cheques quedan a la cotización del pago
+        como cualquier otro pago. Acá se simula el neteo pasando un `balance` ya restado; la
+        cobertura de punta a punta vive fuera de este archivo y hay que correrla junto con esta
+        suite: `account_payment_pro:TestPaymentChecks` (mismo repo, cheques con Pagos Pro) y
+        `l10n_ar_tax:TestPaymentChecksWithholding` (retenciones + cheques, otro repo — o sea que el
+        CI de este repo no ve el caso neteado de punta a punta).
+        """
+        payment = self._create_own_check_payment(
+            [50, 50], numbers=["00001601", "00001602"], currency=self.foreign_currency
+        )
+        # el core entrega el balance ya neteado: 100 x 100 = 10.000 menos 2.000 de retención, y el
+        # nominal también neteado. La retención se simula acá porque su fixture vive en `l10n_ar_tax`.
+        with patch.object(type(payment), "_prepare_move_withholding_lines", return_value=[{"balance": -2000.0}]):
+            lines = payment._prepare_move_liquidity_lines(
+                {"name": "test", "amount_currency": -80.0, "balance": -8000.0}
+            )
+        self.assertEqual(
+            [line["balance"] for line in lines],
+            [-5000.0, -5000.0],
+            "Devolviendo la retención: (8.000 + 2.000) / 100 = 100, la cotización del pago",
+        )
 
 
 @tagged("post_install", "-at_install")


### PR DESCRIPTION
Second half of #1167 — its `account_payment_pro` commit is already on `19.0` (1dc7879b),
so this branch carries the `l10n_latam_check_ux` fix plus the removal of what 1dc7879b had added to ppro: **4 files**.

## Problem

Posting a payment that carries checks fails with **"The entry is not balanced."** whenever
the payment currency differs from the company currency. It does **not** take several
checks — one deferred check is enough, which is why it looked intermittent. A second
trigger is a hand-typed rate that differs from the table.

`l10n_latam_check._prepare_move_liquidity_lines` builds one liquidity line per check and
converts EACH at its own `check.payment_date`, discarding the `balance` it is handed — the
figure the counterpart was already built from. Two rates in one entry.

Real case (payment 1044, 39.717,71 USD, UYU company): counterpart at the payment date rate
40,256 → 1.598.876,13; check at its maturity 2026-09-30, which falls back to the last rate
loaded, 40,233 → 1.597.962,63. Off by 913,50.

**Where that code comes from:** the module is Odoo's, but this method is not in
`odoo/odoo` 19.0 — it arrives through **odoo#248741** (open, from maq), which our image
merges from the fork. Upstream still uses `_l10n_latam_check_split_move`. The real fix
belongs in that PR; this covers it from outside meanwhile and degrades to a no-op the day
the origin respects the balance it hands down.

## Fix

- Value every check at the rate the entry already settled on, derived from the handed
  `balance` over the payment amount. **Not** from the `balance` / `amount_currency` pair:
  with withholdings that pair arrives netted and in another currency.
- Build the counterpart from what actually ended up in the entry (check lines + write-off),
  because core derives it from a single liquidity balance that does not exist once there
  are N check lines. Mirror the nominal when that line ends up in company currency, or the
  ORM rounds the stale nominal and derives the balance back from it.
- Payments whose amount arrives netted are returned untouched — `account_payment_pro`
  already re-values those lines from `accounting_rate`.
- Foreign-currency payments always redistribute, even when the payment-date conversion is
  the identity for lack of a rate: the checks are still converted at their own dates.
- Closes BUG-2 of task 70884, until now parked as a commented-out test.

Two checks of the same amount are worth the same in the entry, and the counterpart keeps
the rounding residual.

## What moved out of account_payment_pro

The logic 1dc7879b added there for check payments is gone: the per-line liquidity conversion
and the generic counterpart balance now live once, in `l10n_latam_check_ux`. What stays in
ppro is what is not about checks — turning `accounting_rate` (and `amount_exact`) into
`force_balance` and handing it down, and its B1/B2 currency branches. Its write-off is now
injected after `super()`, because the core drops `force_balance` as soon as it sees write-off
lines, and with it the payment's rate.

A first attempt at this consolidation regressed the withholding path and had to be undone:
with ppro's loop gone, the netted case was left **without an owner**, so the check lines kept
the maturity-date rate while the counterpart absorbed the gap — the entry balanced and posted
silently wrong (a purpose-built case gave -2.832.000 instead of -1.416.000, double).

This revision fixes that instead of avoiding it: when the balance arrives netted, the
withholding is added back to recover the entry's rate. It is a company-currency figure, so
nothing is mixed — which is what made the `balance` / `amount_currency` pair unusable.

```
19.0                    check line -1.416.000  (payment rate)      correct
first attempt           check line -2.832.000  (maturity rate)     posts silently wrong
this branch             check line -1.416.000  (payment rate)      correct
```

## The figure the payment shows

`counterpart_currency_amount` converted the total in one go while the entry rounds check by
check and sums, so the payment showed 3.192.430,09 next to its own counterpart line of
3.192.430,10. Its compute became a hook, `_get_counterpart_currency_amount`, and
`l10n_latam_check_ux` overrides it to add up the same per-check conversions the entry uses.

The override bails out **before even reading the checks** unless the counterpart lands in
company currency — where nominal and balance are the same figure — and there is more than one
check. No other payment changes value or pays for a recompute. Pinned by
`account_payment_pro:TestChecksPaymentPro.test_the_shown_total_matches_its_own_move_line`,
which fails without it.

## Why the write-off moved in ppro

Because the core drops `force_balance` as soon as it sees write-off lines, and with it the
payment's rate. Passing ppro's write-off to the core instead breaks
`TestPaymentMultimoneda.test_write_off_company_currency` and `…_foreign_currency` — measured,
not assumed. It cannot live in `l10n_latam_check_ux` either: `write_off_amount` and
`write_off_type_id` are ppro's own fields. So those six lines stay in ppro; they are about how
the rate travels, not about checks.

## Companion suites

`l10n_latam_check_ux` is `auto_install`, so with payment_pro installed both modules override
`_prepare_move_lines_per_type` and this one is the outer of the two — it has the last word on
the counterpart balance, with the same formula. That is noted in
`account_payment_pro/DESIGN.md` and in both docstrings, so a future change to the formula
does not land on one side only. Two suites cover the interaction and must be run together with
this one: `account_payment_pro:TestPaymentChecks` (same repo) and
`l10n_ar_tax:TestPaymentChecksWithholding` (another repo — meaning this repo's CI does not see
the netted case).

## Test plan

- `l10n_latam_check_ux` + `account_payment_pro` → **94 tests, 0 failed** (the one error,
  `test_change_product_includes_parent_company_taxes`, is pre-existing and unrelated).
- `l10n_ar_tax` → **49 + the deferred-check-with-withholding case, all green**.
- `l10n_ar_payment_bundle` → 15, 0 failed, plus an error in `TestBundleJournalSuspense`
  that arrived with 2d1053cc and fails identically without this branch.
- **864-combination sweep, no failures**: payment_pro on and off × 1 to 8 checks ×
  maturities same-day / deferred / mixed × write-off absent, positive or negative × table
  or typed rate. Each case asserts the entry sums to zero and that checks of equal amount
  get equal balances. It only covers USD → ARS.
- Seven new tests, **five of which fail without the fix**. Two are deliberate exceptions: the
  netted reconstruction (covered end to end by the withholding suite) and
  `test_a_typed_rate_wins_over_the_table`, the case that tells the two rate sources apart and
  that no suite covered before — it lives in the payment_pro suite, because `accounting_rate`
  is its field.
- `l10n_latam_check_ux`'s own suite is green **with payment_pro uninstalled** (48 tests, on a
  database built without it). That is what broke once: a test of mine used `accounting_rate`
  and the runbot, where ppro is absent, raised `AttributeError`.
- The end-to-end netted case (deferred check + IIBB) is covered by a test written for
  `l10n_ar_tax`, going in a separate PR to that repo: this repo's CI cannot see it.

## Known and accepted

The total shown on the payment can differ by a cent from the accounted total, and no
rounding line is added to the entry: keeping the entry's usual shape was preferred over a
fourth line. As a consequence an invoice paid from the register wizard can be left a cent
short when the debt is in company currency, and a third-party check moved by a later
payment is revalued at that payment's rate.
