### PR TITLE
[FIX] l10n_latam_check_ux: partner check credit over the company hierarchy

### DIFF
--- a/l10n_latam_check_ux/models/res_partner.py
+++ b/l10n_latam_check_ux/models/res_partner.py
@@ -11,21 +11,27 @@ class ResPartner(models.Model):
     def _credit_debit_get(self):
         super()._credit_debit_get()
         for partner in self.filtered("add_check_credit"):
-            partner_checks = self.env["l10n_latam.check"].search(
-                [
-                    # Partner actual
-                    ("partner_id", "=", partner.id),
-                    # Filtro por empresa actual
-                    ("company_id", "=", self.env.company.id),
-                    # Filtro On-Hand
-                    (
-                        "current_journal_id.inbound_payment_method_line_ids.payment_method_id.code",
-                        "=",
-                        "in_third_party_checks",
-                    ),
-                    # Cuya fecha de pago sea mayor a la de hoy
-                    ("payment_date", ">", fields.Date.context_today(self)),
-                ]
+            # sudo + child_of para alinearnos con el _credit_debit_get de core, que agrega los
+            # apuntes de toda la jerarquía de compañías (branches) con bypass_access.
+            partner_checks = (
+                self.env["l10n_latam.check"]
+                .sudo()
+                .search(
+                    [
+                        # Partner actual
+                        ("partner_id", "=", partner.id),
+                        # Filtro por la compañía activa y sus sucursales
+                        ("company_id", "child_of", self.env.company.root_id.id),
+                        # Filtro On-Hand
+                        (
+                            "current_journal_id.inbound_payment_method_line_ids.payment_method_id.code",
+                            "=",
+                            "in_third_party_checks",
+                        ),
+                        # Cuya fecha de pago sea mayor a la de hoy
+                        ("payment_date", ">", fields.Date.context_today(self)),
+                    ]
+                )
             )
 
             partner.credit += sum(partner_checks.mapped("amount"))

--- a/l10n_latam_check_ux/tests/test_check_transfers.py
+++ b/l10n_latam_check_ux/tests/test_check_transfers.py
@@ -152,6 +152,23 @@ class TestL10nLatamCheckUxTransfers(AccountTestInvoicingCommon):
         payment.action_post()
         return payment.l10n_latam_new_check_ids
 
+    def _create_branch(self, name="Branch", parent=None):
+        """Sucursal que comparte el plan de cuentas de su padre.
+
+        Las propiedades company dependent del partner hay que setearlas para la sucursal
+        para poder postear pagos en ella.
+        """
+        parent = parent or self.company
+        branch = self.env["res.company"].create({"name": name, "parent_id": parent.id})
+        self.partner_a.with_company(branch).write(
+            {
+                "property_account_receivable_id": self.company_data["default_account_receivable"].id,
+                "property_account_payable_id": self.company_data["default_account_payable"].id,
+            }
+        )
+        branch.transfer_account_id = self.company.transfer_account_id
+        return branch
+
     def test_deposit_third_party_check_to_bank(self):
         check = self._create_third_party_check(self.third_party_check_journal, "UX-DEP-0001")
         bank_journal = self.company_bank_journal
@@ -173,16 +190,7 @@ class TestL10nLatamCheckUxTransfers(AccountTestInvoicingCommon):
         Las operaciones de la sucursal de origen tienen que seguir visibles en el historial del
         cheque después de transferirlo a un diario de la compañía padre.
         """
-        branch = self.env["res.company"].create({"name": "Branch", "parent_id": self.company.id})
-        # the branch shares the parent chart of accounts, but the company dependent properties of
-        # the partner have to be set for it so the receipt can be posted
-        self.partner_a.with_company(branch).write(
-            {
-                "property_account_receivable_id": self.company_data["default_account_receivable"].id,
-                "property_account_payable_id": self.company_data["default_account_payable"].id,
-            }
-        )
-        branch.transfer_account_id = self.company.transfer_account_id
+        branch = self._create_branch()
         self.assertTrue(branch.transfer_account_id, "An internal transfer account is required to run this test")
         branch_journal = self._create_check_journal("Branch Third Party Checks", "BTPC", company=branch)
         check = self._create_third_party_check(branch_journal, "UX-BRANCH-0001")
@@ -303,3 +311,21 @@ class TestL10nLatamCheckUxTransfers(AccountTestInvoicingCommon):
                     "amount": 200.0,
                 }
             )
+
+    def test_partner_check_credit_includes_branch_checks(self):
+        """El crédito por cheques tiene que abarcar el árbol de compañías, como el de core.
+
+        `_credit_debit_get` de core agrega los apuntes con `child_of` sobre la raíz, así que
+        sumar los cheques de una sola compañía deja el total inconsistente: la casa central ve
+        las facturas de la sucursal pero no sus cheques.
+        """
+        branch = self._create_branch()
+        branch_journal = self._create_check_journal("Branch Third Party Checks", "BTPC1", company=branch)
+        self._create_third_party_check(branch_journal, "UX-CREDIT-0001")
+
+        partner_from_parent = self.partner_a.with_company(self.company)
+        partner_from_parent.add_check_credit = False
+        credit_without_checks = partner_from_parent.credit
+        partner_from_parent.add_check_credit = True
+
+        self.assertEqual(partner_from_parent.credit - credit_without_checks, 100.0)


### PR DESCRIPTION
Parte del review de multicompañía / branches de `l10n_latam_check_ux` (tarea 72538, subtarea de la 72037).

### Qué corrige

El crédito por cheques del partner se sumaba solo con la compañía activa, mientras el `_credit_debit_get` de core agrega los apuntes con `child_of` sobre la raíz y `bypass_access`: parado en la casa central se veían las facturas de la sucursal pero no sus cheques, y los cheques de una compañía del árbol que el usuario no tenía habilitada se descartaban en silencio. Ahora usa `child_of` sobre `root_id` + `sudo`.

`models/res_partner.py`

### Tests

`tests/test_check_transfers.py::test_partner_check_credit_includes_branch_checks`, verificado en rojo sin el fix y en verde con él.