### PR TITLE
[FIX] l10n_latam_check_ux: mass transfer main company from the root company

### DIFF
--- a/l10n_ar_payment_bundle/tests/__init__.py
+++ b/l10n_ar_payment_bundle/tests/__init__.py
@@ -1,3 +1,4 @@
 from . import test_payment_bundle_multimoneda
 from . import test_bundle_reconcile
 from . import test_bundle_journal_suspense
+from . import test_mass_transfer_domain

--- a/l10n_ar_payment_bundle/tests/test_mass_transfer_domain.py
+++ b/l10n_ar_payment_bundle/tests/test_mass_transfer_domain.py
@@ -1,0 +1,111 @@
+# © 2026 ADHOC SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import Command
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestMassTransferDestinationDomain(TransactionCase):
+    """El dominio de destination_journal_id tiene que alcanzar toda la jerarquia de compañias.
+
+    l10n_ar_payment_bundle redefine destination_journal_id con su propio dominio dinamico (para
+    excluir los diarios de bundle) armado con company_id = company_id, pisando el que
+    l10n_latam_check_ux corrige sobre este mismo campo (main_company_id, resuelto hasta la raiz
+    del arbol). Con una jerarquia de mas de dos niveles, el desplegable quedaba vacio pese a que
+    main_company_id ya apuntaba a la raiz.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.root = cls.env.company
+        cls.branch = cls.env["res.company"].create({"name": "Branch", "parent_id": cls.root.id})
+        cls.sub_branch = cls.env["res.company"].create({"name": "Sub branch", "parent_id": cls.branch.id})
+
+        cls.root_bank_journal = cls.env["account.journal"].create(
+            {
+                "name": "Root Bank",
+                "type": "bank",
+                "code": "RBNK",
+                "company_id": cls.root.id,
+            }
+        )
+
+        # branches share the root company's chart of accounts, so the account is looked up there
+        check_account = cls.env["account.account"].search(
+            [("company_ids", "in", cls.root.id), ("account_type", "=", "asset_current")], limit=1
+        )
+        cls.sub_branch_check_journal = cls.env["account.journal"].create(
+            {
+                "name": "Sub Branch Checks",
+                "type": "cash",
+                "code": "SBCHK",
+                "company_id": cls.sub_branch.id,
+                "default_account_id": check_account.id,
+            }
+        )
+        methods = cls.env["account.payment.method"].search(
+            [("code", "in", ("new_third_party_checks", "in_third_party_checks", "out_third_party_checks"))]
+        )
+        for method in methods:
+            field = (
+                "inbound_payment_method_line_ids"
+                if method.payment_type == "inbound"
+                else "outbound_payment_method_line_ids"
+            )
+            cls.sub_branch_check_journal.write(
+                {field: [Command.create({"payment_method_id": method.id, "payment_account_id": check_account.id})]}
+            )
+
+        cls.partner = cls.env["res.partner"].create({"name": "Sub Branch Customer"})
+        cls.partner.with_company(cls.sub_branch).write(
+            {
+                "property_account_receivable_id": check_account.id,
+            }
+        )
+        new_check_method_line = cls.sub_branch_check_journal.inbound_payment_method_line_ids.filtered(
+            lambda line: line.code == "new_third_party_checks"
+        )
+        payment = (
+            cls.env["account.payment"]
+            .with_company(cls.sub_branch)
+            .create(
+                {
+                    "payment_type": "inbound",
+                    "partner_type": "customer",
+                    "partner_id": cls.partner.id,
+                    "journal_id": cls.sub_branch_check_journal.id,
+                    "payment_method_line_id": new_check_method_line.id,
+                    "amount": 1000.0,
+                    "l10n_latam_new_check_ids": [
+                        Command.create({"name": "00000001", "payment_date": "2099-01-01", "amount": 1000.0})
+                    ],
+                }
+            )
+        )
+        payment.action_post()
+        cls.check = payment.l10n_latam_new_check_ids
+
+    def test_destination_journal_domain_reaches_the_root_company(self):
+        wizard = (
+            self.env["l10n_latam.payment.mass.transfer"]
+            .with_context(
+                allowed_company_ids=[self.sub_branch.id, self.branch.id, self.root.id],
+                active_model="l10n_latam.check",
+                active_ids=self.check.ids,
+            )
+            .create({})
+        )
+
+        if "main_company_id" not in wizard._fields:
+            self.skipTest("l10n_latam_check_ux is not installed")
+
+        self.assertEqual(wizard.main_company_id, self.root)
+        reachable = self.env["account.journal"].search(wizard.destination_journal_domain)
+        self.assertIn(
+            self.root_bank_journal,
+            reachable,
+            "the root company's bank journal should be a valid destination",
+        )

--- a/l10n_ar_payment_bundle/wizard/l10n_latam_payment_mass_transfer.py
+++ b/l10n_ar_payment_bundle/wizard/l10n_latam_payment_mass_transfer.py
@@ -15,12 +15,18 @@ class L10nLatamPaymentMassTransfer(models.TransientModel):
 
     @api.depends("journal_id", "company_id")
     def _compute_destination_journal_domain(self):
-        """Exclude bundle journals from destination journal selection."""
+        """Exclude bundle journals from destination journal selection.
+
+        `main_company_id` (l10n_latam_check_ux) already resolves the root of the company
+        hierarchy so branches with more than two levels reach the whole tree; fall back to
+        `company_id` when that module isn't installed.
+        """
         for rec in self:
+            main_company = getattr(rec, "main_company_id", False) or rec.company_id
             base_domain = [
                 ("type", "in", ("bank", "cash")),
                 ("id", "!=", rec.journal_id.id),
-                ("company_id", "=", rec.company_id.id),
+                ("company_id", "child_of", main_company.id),
             ]
 
             # Exclude both inbound and outbound bundle journals

--- a/l10n_latam_check_ux/tests/test_check_transfers.py
+++ b/l10n_latam_check_ux/tests/test_check_transfers.py
@@ -152,6 +152,23 @@ class TestL10nLatamCheckUxTransfers(AccountTestInvoicingCommon):
         payment.action_post()
         return payment.l10n_latam_new_check_ids
 
+    def _create_branch(self, name="Branch", parent=None):
+        """Sucursal que comparte el plan de cuentas de su padre.
+
+        Las propiedades company dependent del partner hay que setearlas para la sucursal
+        para poder postear pagos en ella.
+        """
+        parent = parent or self.company
+        branch = self.env["res.company"].create({"name": name, "parent_id": parent.id})
+        self.partner_a.with_company(branch).write(
+            {
+                "property_account_receivable_id": self.company_data["default_account_receivable"].id,
+                "property_account_payable_id": self.company_data["default_account_payable"].id,
+            }
+        )
+        branch.transfer_account_id = self.company.transfer_account_id
+        return branch
+
     def test_deposit_third_party_check_to_bank(self):
         check = self._create_third_party_check(self.third_party_check_journal, "UX-DEP-0001")
         bank_journal = self.company_bank_journal
@@ -303,3 +320,22 @@ class TestL10nLatamCheckUxTransfers(AccountTestInvoicingCommon):
                     "amount": 200.0,
                 }
             )
+
+    def test_mass_transfer_destination_domain_reaches_the_root_company(self):
+        """El dominio del diario destino se arma sobre la raíz, no sobre el padre inmediato.
+
+        Con una jerarquía de más de dos niveles, `parent_id` se queda en la compañía
+        intermedia y deja afuera del dominio a la casa central y a las otras ramas.
+        """
+        branch = self._create_branch()
+        sub_branch = self._create_branch(name="Sub branch", parent=branch)
+        sub_branch_journal = self._create_check_journal("Sub Branch Checks", "SBC", company=sub_branch)
+        check = self._create_third_party_check(sub_branch_journal, "UX-ROOT-0001")
+
+        wizard = (
+            self.env["l10n_latam.payment.mass.transfer"]
+            .with_context(active_model="l10n_latam.check", active_ids=check.ids)
+            .create({})
+        )
+
+        self.assertEqual(wizard.main_company_id, self.company)

--- a/l10n_latam_check_ux/tests/test_check_transfers.py
+++ b/l10n_latam_check_ux/tests/test_check_transfers.py
@@ -339,3 +339,13 @@ class TestL10nLatamCheckUxTransfers(AccountTestInvoicingCommon):
         )
 
         self.assertEqual(wizard.main_company_id, self.company)
+
+    def test_mass_transfer_view_exposes_the_fields_of_the_destination_domain(self):
+        """El desplegable del diario destino queda vacío si la vista no trae `main_company_id`.
+
+        El dominio de `destination_journal_id` lo lee, y el cliente web evalúa los dominios solo
+        con los campos que la vista carga: sin el campo, `main_company_id` es False, el `child_of`
+        no matchea ninguna compañía y el usuario no puede elegir ningún diario.
+        """
+        view = self.env["l10n_latam.payment.mass.transfer"].get_view()
+        self.assertIn("main_company_id", view["models"]["l10n_latam.payment.mass.transfer"])

--- a/l10n_latam_check_ux/wizards/l10n_latam_payment_mass_transfer.py
+++ b/l10n_latam_check_ux/wizards/l10n_latam_payment_mass_transfer.py
@@ -25,7 +25,9 @@ class L10nLatamPaymentMassTransfer(models.TransientModel):
     @api.depends("company_id")
     def _compute_main_company(self):
         for rec in self:
-            rec.main_company_id = rec.company_id.parent_id or rec.company_id
+            # root_id and not parent_id: with a hierarchy deeper than two levels, parent_id
+            # stops at the intermediate company and leaves the rest of the tree out.
+            rec.main_company_id = rec.company_id.root_id
 
     def _create_payments(self):
         if self.destination_journal_id.company_id != self.journal_id.company_id:

--- a/l10n_latam_check_ux/wizards/l10n_latam_payment_mass_transfer.xml
+++ b/l10n_latam_check_ux/wizards/l10n_latam_payment_mass_transfer.xml
@@ -8,6 +8,9 @@
             <field name="destination_journal_id" position="after">
                 <field name="split_payment"/>
                 <field name="company_id"/>
+                <!-- the domain of destination_journal_id reads main_company_id: without the field in
+                     the view the client evaluates it as False and the dropdown lists nothing -->
+                <field name="main_company_id" invisible="1"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Parte del review de multicompañía / branches de `l10n_latam_check_ux` (tarea 72539, subtarea de la 72037).

### Qué corrige

`main_company_id` de la transferencia masiva subía un solo nivel (`parent_id`): con jerarquías de más de dos niveles el `child_of` del dominio nunca llegaba a la raíz y dejaba afuera a la casa central y a las otras ramas. Ahora usa `root_id`, como ya hace `models/l10n_latam_check.py`.

Va además el campo en la vista: el cliente web evalúa los dominios solo con los campos que la vista carga, así que sin `main_company_id` el desplegable del diario destino queda vacío.

`wizards/l10n_latam_payment_mass_transfer.py`, `wizards/l10n_latam_payment_mass_transfer.xml`

### El mismo bug, un nivel más abajo (l10n_ar_payment_bundle)

Verificando el fix en un runbot real con jerarquía de tres niveles, el desplegable seguía vacío pese a que `main_company_id` ya apuntaba a la raíz. Causa: `l10n_ar_payment_bundle` redefine el mismo campo `destination_journal_id` con su propio dominio dinámico (`destination_journal_domain`, para excluir los diarios de bundle), armado con `company_id = company_id` — pisa por completo el domain que este PR corrige, sin pasar nunca por `main_company_id`.

Se agrega el mismo `child_of` ahí, con fallback a `company_id` si `l10n_latam_check_ux` no está instalado (este módulo no depende de él).

`l10n_ar_payment_bundle/wizards/l10n_latam_payment_mass_transfer.py`

### Fuera de alcance

El dominio del diario destino sigue ofreciendo diarios que después hacen fallar la validación de la transferencia. Es una decisión de producto (cerrar el dominio a la propia compañía o sacar el `ValidationError`) y no se toca acá.

### Tests

Verificados en rojo sin el fix y en verde con él:

- `l10n_latam_check_ux/tests/test_check_transfers.py::test_mass_transfer_destination_domain_reaches_the_root_company`
- `l10n_latam_check_ux/tests/test_check_transfers.py::test_mass_transfer_view_exposes_the_fields_of_the_destination_domain`
- `l10n_ar_payment_bundle/tests/test_mass_transfer_domain.py::test_destination_journal_domain_reaches_the_root_company`