### PR TITLE
[FIX] l10n_latam_check_ux: filter the checks to date report by company

### DIFF
--- a/l10n_latam_check_ux/reports/report_checks_to_date.xml
+++ b/l10n_latam_check_ux/reports/report_checks_to_date.xml
@@ -6,8 +6,12 @@
     <t t-set="company" t-value="env.company"/>
         <t t-call="web.internal_layout">
             <h3 class="text-center">Listado de cheques pendientes al <span t-field="docs.to_date"/></h3>
+            <t t-set="report_companies" t-value="docs._get_report_companies()"/>
+            <div>
+                Compañía: <span t-out="', '.join(report_companies.mapped('name'))"/>
+            </div>
             <t t-if="docs.journal_id">
-                Diario: <span t-esc="docs.env['account.journal'].browse(docs.journal_id.id).name"/>
+                Diario: <span t-out="docs.journal_id.name"/>
             </t>
             <div class="page">
                 <t t-if="docs._get_checks_handed(docs.journal_id.id, docs.to_date)">
@@ -20,6 +24,7 @@
                                 <th class="text-left">Fecha contable</th>
                                 <th class="text-left">Fecha de pago</th>
                                 <th class="text-left">Empresa</th>
+                                <th t-if="len(report_companies) > 1" class="text-left">Compañía</th>
                                 <th class="text-left">Importe</th>
                             </tr>
                         </thead>
@@ -38,6 +43,9 @@
                                 </td>
                                 <td>
                                     <span t-out="tcheck.partner_id.name" />
+                                </td>
+                                <td t-if="len(report_companies) > 1">
+                                    <span t-out="tcheck.company_id.name"/>
                                 </td>
                                 <td>
                                     <span t-out="tcheck.amount"  t-options='{"widget": "monetary", "display_currency": tcheck.currency_id}'/>
@@ -66,6 +74,7 @@
                                 <th class="text-left">Fecha contable</th>
                                 <th class="text-left">Fecha de pago</th>
                                 <th class="text-left">Cuit</th>
+                                <th t-if="len(report_companies) > 1" class="text-left">Compañía</th>
                                 <th class="text-left">Importe</th>
                             </tr>
                         </thead>
@@ -84,6 +93,9 @@
                                 </td>
                                 <td>
                                     <span t-out="tcheck.issuer_vat" />
+                                </td>
+                                <td t-if="len(report_companies) > 1">
+                                    <span t-out="tcheck.company_id.name"/>
                                 </td>
                                 <td>
                                     <span t-out="tcheck.amount"  t-options='{"widget": "monetary", "display_currency": tcheck.currency_id}'/>

--- a/l10n_latam_check_ux/wizards/checks_to_date_report.py
+++ b/l10n_latam_check_ux/wizards/checks_to_date_report.py
@@ -10,20 +10,43 @@ class AccountCheckToDateReportWizard(models.TransientModel):
     _name = "account.check.to_date.report.wizard"
     _description = "account.check.to_date.report.wizard"
 
+    company_id = fields.Many2one(
+        "res.company",
+        string="Compañía",
+        compute="_compute_company_id",
+        help="Compañía activa. El reporte incluye sus sucursales habilitadas.",
+    )
     journal_id = fields.Many2one(
         "account.journal",
         string="Diario",
-        domain=[
-            "|",
-            ("outbound_payment_method_line_ids.code", "=", "check_printing"),
-            ("inbound_payment_method_line_ids.code", "=", "in_third_party_checks"),
-        ],
+        domain="""[
+            '&',
+            ('company_id', 'child_of', company_id),
+            '|',
+            ('outbound_payment_method_line_ids.code', '=', 'check_printing'),
+            ('inbound_payment_method_line_ids.code', '=', 'in_third_party_checks'),
+        ]""",
     )
     to_date = fields.Date(
         "Hasta Fecha",
         required=True,
         default=fields.Date.today,
     )
+
+    @api.depends_context("company")
+    def _compute_company_id(self):
+        for rec in self:
+            rec.company_id = self.env.company
+
+    @api.model
+    def _get_report_companies(self):
+        """Compañías que abarca el reporte: la activa más sus sucursales habilitadas.
+
+        Sin esto las queries crudas de abajo no filtran por compañía y el único corte
+        efectivo termina siendo la record rule del cheque, que abarca todas las compañías
+        habilitadas — incluso las de otro grupo económico.
+        """
+        return self.env.company._accessible_branches()
 
     def action_confirm(self):
         self.ensure_one()
@@ -68,6 +91,7 @@ class AccountCheckToDateReportWizard(models.TransientModel):
                         WHERE
                         apm.code = 'own_checks'
                         AND ap_move.date <= %(to_date)s
+                        AND ap_move.company_id = ANY(%(company_ids)s)
                         AND ap.state not in ('canceled', 'draft')
                         AND c.issue_state != 'voided'
                         ORDER BY c.id, ap_move.date desc
@@ -106,6 +130,7 @@ class AccountCheckToDateReportWizard(models.TransientModel):
                 ;
             """,
             to_date=to_date,
+            company_ids=self._get_report_companies().ids,
         )
         self.env.cr.execute(query)
         res = self.env.cr.fetchall()
@@ -205,6 +230,7 @@ class AccountCheckToDateReportWizard(models.TransientModel):
                 )
             )
             AND ap_move.date <= %s
+            AND ap_move.company_id = ANY(%s)
             UNION ALL
             SELECT c.id AS check_id, ap_move.date AS operation_date, apm.code AS operation_code
             FROM l10n_latam_check c
@@ -217,9 +243,11 @@ class AccountCheckToDateReportWizard(models.TransientModel):
                 apm.code in ('new_third_party_checks','in_third_party_checks')
                 AND c.current_journal_id IS NOT NULL
                 AND rel.check_id IS NULL
-                AND ap_move.date <= %s;
+                AND ap_move.date <= %s
+                AND ap_move.company_id = ANY(%s);
         """
-        self.env.cr.execute(query, (to_date, to_date, to_date))
+        company_ids = self._get_report_companies().ids
+        self.env.cr.execute(query, (to_date, to_date, company_ids, to_date, company_ids))
         res = self.env.cr.fetchall()
         check_ids = [x[0] for x in res]
         checks = self.env["l10n_latam.check"].search([("id", "in", check_ids)])

--- a/l10n_latam_check_ux/wizards/checks_to_date_view.xml
+++ b/l10n_latam_check_ux/wizards/checks_to_date_view.xml
@@ -6,6 +6,7 @@
             <field name="arch" type="xml">
                 <form string="Cheques a Fecha">
                     <group>
+                        <field name="company_id" invisible="1"/>
                         <field name="to_date"/>
                         <field name="journal_id"/>
                     </group>


### PR DESCRIPTION
Parte del review de multicompañía / branches de `l10n_latam_check_ux` (tarea 72541, subtarea de la 72037).

### Qué corrige

El reporte "Cheques a fecha" no filtraba por compañía en ninguna de sus dos queries crudas: el único corte efectivo era la record rule del cheque, que abarca todas las compañías habilitadas —incluso de otro grupo económico— mientras el encabezado del PDF mostraba solo la compañía activa. Ahora las queries filtran por las sucursales accesibles de la compañía activa, el dominio del diario también, y el PDF informa las compañías incluidas, con columna por cheque cuando hay más de una.

`wizards/checks_to_date_report.py`, `wizards/checks_to_date_view.xml`, `reports/report_checks_to_date.xml`