### PR TITLE
[FIX] l10n_latam_check_ux: recompute issue_state of the whole hierarchy

### DIFF
--- a/l10n_latam_check_ux/models/account_account.py
+++ b/l10n_latam_check_ux/models/account_account.py
@@ -7,10 +7,17 @@ class AccountAccount(models.Model):
     def write(self, vals):
         res = super().write(vals)
         if "reconcile" in vals:
-            checks = self.env["l10n_latam.check"].search(
-                [
-                    ("outstanding_line_id.account_id", "in", self.ids),
-                ]
+            # sudo: the account is shared across the whole company hierarchy, so the stored
+            # issue_state of checks living in branches the user has not enabled must be
+            # recomputed as well.
+            checks = (
+                self.env["l10n_latam.check"]
+                .sudo()
+                .search(
+                    [
+                        ("outstanding_line_id.account_id", "in", self.ids),
+                    ]
+                )
             )
             checks._compute_issue_state()
         return res


### PR DESCRIPTION
Parte del review de multicompañía / branches de `l10n_latam_check_ux` (tarea 72542, subtarea de la 72037).

### Qué corrige

Al tocar "Permitir conciliación" en una cuenta compartida por el árbol de compañías, el recálculo del `issue_state` almacenado se salteaba los cheques de las branches que el usuario no tenía habilitadas y los dejaba desincronizados. Ahora el `search` es `sudo`: es un recálculo técnico, no una consulta del usuario.

`models/account_account.py`