### PR TITLE
[FIX] l10n_latam_check_ux: look up the debit journal entry within the company

### DIFF
--- a/l10n_latam_check_ux/wizards/account_check_action_wizard.py
+++ b/l10n_latam_check_ux/wizards/account_check_action_wizard.py
@@ -48,8 +48,15 @@ class AccountCheckActionWizard(models.TransientModel):
                     .create(new_mv_line_dicts)
                 )
                 wizard.reconcile()
+                # El label repite el número de cheque, que puede existir en más de una
+                # sucursal: sin el filtro de compañía el link podría apuntar al asiento de otra.
                 debit_move = self.env["account.move"].search(
-                    [("line_ids.name", "=", label), ("date", "=", self.date)], limit=1
+                    [
+                        ("line_ids.name", "=", label),
+                        ("date", "=", self.date),
+                        ("company_id", "=", check.company_id.id),
+                    ],
+                    limit=1,
                 )
             else:
                 amount = abs(sum(check.outstanding_line_id.mapped("balance")))


### PR DESCRIPTION
Parte del review de multicompañía / branches de `l10n_latam_check_ux` (tarea 72543, subtarea de la 72037).

### Qué corrige

La búsqueda del asiento de débito por label + fecha podía traer el asiento de otra sucursal que hubiera debitado el mismo día un cheque con el mismo número. Se agrega el filtro de compañía.

`wizards/account_check_action_wizard.py`