### PR TITLE
[FIX] account_cashbox: follow shared_to_branches becoming a scope

### DIFF
--- a/account_cashbox/models/account_payment.py
+++ b/account_cashbox/models/account_payment.py
@@ -53,7 +53,7 @@ class AccountPayment(models.Model):
 
     @api.depends("journal_id")
     def _compute_company_id(self):
-        # journal_id puede pertenecer a la empresa padre (shared_to_branches=True) y el usuario
+        # journal_id puede pertenecer a la empresa padre (compartido a sucursales) y el usuario
         # de sucursal no tiene acceso de lectura a ese res.company (res_company_rule_employee).
         # Usamos sudo() para evaluar la jerarquía sin disparar AccessError.
         for payment in self:

--- a/account_cashbox/views/account_payment.xml
+++ b/account_cashbox/views/account_payment.xml
@@ -21,7 +21,7 @@
             <field name="destination_journal_id" position="after">
                 <field
                     name="destination_cashbox_session_id"
-                    domain="[('state', '=', 'opened'), ('company_id', 'parent_of', company_id), '|', ('company_id', '=', company_id), ('cashbox_id.journal_ids.shared_to_branches', '=', True), ('cashbox_id.journal_ids', '=', destination_journal_id), '|', ('user_ids', '=', uid), ('user_ids', '=', False)]"
+                    domain="[('state', '=', 'opened'), ('company_id', 'parent_of', company_id), '|', ('company_id', '=', company_id), ('cashbox_id.journal_ids.shared_to_branches', 'in', ['all', 'legal_entity']), ('cashbox_id.journal_ids', '=', destination_journal_id), '|', ('user_ids', '=', uid), ('user_ids', '=', False)]"
                     required="requiere_account_cashbox_session and state == 'draft' and payment_type == 'transfer'"
                     readonly = "state != 'draft'"
                     invisible = "not is_internal_transfer or not destination_journal_id or (paired_internal_transfer_payment_id and not destination_cashbox_session_id)"


### PR DESCRIPTION
Follows `shared_to_branches` becoming a selection in ingadhoc/account-financial-tools#1021 (all branches / same legal entity / not shared) instead of a boolean.

The domain of the destination cashbox session filters the sessions of the parent company by whether its journals are shared to branches. Compared against `True` it now matches nothing, so a branch would silently stop being able to pick the sessions of its parent's cashboxes. It compares against the two values that mean shared instead.

The comment in `_compute_company_id` that spelled the condition as `shared_to_branches=True` was reworded for the same reason.

Same branch name as the other three PRs of this change, so runbot builds them together.

## Test plan

On a parent with branches, from a branch: an internal transfer whose destination journal belongs to the parent still offers the parent's open cashbox sessions in `destination_cashbox_session_id`, as long as the journal is shared (all branches, or same legal entity when the branch qualifies). A journal that is not shared offers none.
