### PR TITLE
[FIX] account_cashbox: follow shared_to_branches becoming a scope

### DIFF
--- a/account_cashbox/models/account_payment.py
+++ b/account_cashbox/models/account_payment.py
@@ -53,7 +53,7 @@ class AccountPayment(models.Model):
 
     @api.depends("journal_id")
     def _compute_company_id(self):
-        # journal_id puede pertenecer a la empresa padre (shared_to_branches=True) y el usuario
+        # journal_id puede pertenecer a la empresa padre (compartido a sucursales) y el usuario
         # de sucursal no tiene acceso de lectura a ese res.company (res_company_rule_employee).
         # Usamos sudo() para evaluar la jerarquía sin disparar AccessError.
         for payment in self:

--- a/account_cashbox/views/account_payment.xml
+++ b/account_cashbox/views/account_payment.xml
@@ -21,7 +21,7 @@
             <field name="destination_journal_id" position="after">
                 <field
                     name="destination_cashbox_session_id"
-                    domain="[('state', '=', 'opened'), ('company_id', 'parent_of', company_id), '|', ('company_id', '=', company_id), ('cashbox_id.journal_ids.shared_to_branches', '=', True), ('cashbox_id.journal_ids', '=', destination_journal_id), '|', ('user_ids', '=', uid), ('user_ids', '=', False)]"
+                    domain="[('state', '=', 'opened'), ('company_id', 'parent_of', company_id), '|', ('company_id', '=', company_id), ('cashbox_id.journal_ids.shared_to_branches', 'in', ['all', 'legal_entity']), ('cashbox_id.journal_ids', '=', destination_journal_id), '|', ('user_ids', '=', uid), ('user_ids', '=', False)]"
                     required="requiere_account_cashbox_session and state == 'draft' and payment_type == 'transfer'"
                     readonly = "state != 'draft'"
                     invisible = "not is_internal_transfer or not destination_journal_id or (paired_internal_transfer_payment_id and not destination_cashbox_session_id)"

--- a/account_payment_pro/README.md
+++ b/account_payment_pro/README.md
@@ -13,6 +13,7 @@ This module is the foundation for managing Argentine withholdings — install `l
 - **Editable exchange rates:** `accounting_rate` (A↔C) and `counterpart_rate` (A↔B) are stored and user-editable; the UI shows rates in the most readable direction automatically.
 - **Multi-currency internal transfers:** supports transfers between journals in different currencies (ARS→USD, USD→EUR, etc.) with proper bridge-account reconciliation.
 - **Pay Now on invoices:** instant payment creation from the invoice form.
+- **Debt of the whole legal entity:** the debt offered to be paid is the one of every company that is the same legal entity as the payment's, limited to the companies the user has selected — so a branch sees the debt of its parent and the other way round, instead of only its own. Companies of another legal entity are never listed, and the payment stays in the company where it was made.
 
 ## Dependencies
 

--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -1165,6 +1165,27 @@ class AccountPayment(models.Model):
 
         return records
 
+    def _get_to_pay_companies(self):
+        """Las compañías cuya deuda puede pagar este pago: su entidad fiscal, acotada a lo
+        que el usuario tiene seleccionado.
+
+        La deuda de una entidad fiscal se cobra desde cualquiera de sus compañías, así que
+        el recibo tiene que listarla toda y no solo la de la compañía del pago —que era lo
+        que hacía, y por eso una sucursal no veía la deuda de su padre ni al revés—. Se
+        acota a ``env.companies`` porque el criterio acordado es "toda la deuda compatible
+        con las compañías que el usuario tiene seleccionadas, ni más ni menos": lo que el
+        usuario no tildó no entra.
+
+        El pago sigue quedando en la compañía donde se hizo, aunque la deuda sea de otra
+        sucursal de la entidad; lo que lo permite es el ``_check_company_domain`` de
+        ``account.move.line`` en ``account_ux``, que acepta la entidad fiscal completa.
+        """
+        self.ensure_one()
+        if not self.company_id:
+            return self.env["res.company"]
+        legal_entity = self.company_id._get_legal_entity_companies()
+        return (legal_entity & self.env.companies) or self.company_id
+
     def _get_to_pay_move_lines_domain(self):
         self.ensure_one()
         # Cuando se llama desde action_add_all (manual), permitir líneas sin partner
@@ -1174,7 +1195,7 @@ class AccountPayment(models.Model):
 
         domain = [
             ("partner_id", "=", self.partner_id.commercial_partner_id.id),
-            ("company_id", "=", self.company_id.id),
+            ("company_id", "in", self._get_to_pay_companies().ids),
             ("move_id.state", "=", "posted"),
             ("account_id.reconcile", "=", True),
             ("reconciled", "=", False),

--- a/account_payment_pro/tests/__init__.py
+++ b/account_payment_pro/tests/__init__.py
@@ -14,3 +14,4 @@ from . import (
     test_reset_cycle,
     test_write_off_and_rounding,
 )
+from . import test_receipt_debt_legal_entity

--- a/account_payment_pro/tests/test_account_paymet_pro_unit_test.py
+++ b/account_payment_pro/tests/test_account_paymet_pro_unit_test.py
@@ -360,6 +360,14 @@ class TestAccountPaymentProUnitTest(common.TransactionCase):
         branch_journal = self.env["account.journal"].create(
             {"name": "Branch Sale", "type": "sale", "company_id": branch.id}
         )
+        # El pago va en un diario de banco de la sucursal, y no en el de la padre: el de la
+        # padre solo sirve si esta compartido a sucursales, y eso es un valor almacenado que
+        # se calculo cuando se creo el diario. En una base creada sin --test-enable los
+        # diarios de banco quedan sin compartir, y el chequeo de compañias rechazaba el pago
+        # por un motivo que no tiene nada que ver con lo que este test verifica.
+        branch_bank_journal = self.env["account.journal"].create(
+            {"name": "Branch Bank", "code": "BBWT", "type": "bank", "company_id": branch.id}
+        )
         parent_tax = self.env["account.tax"].create(
             {
                 "name": "Parent Tax 21%",
@@ -378,7 +386,7 @@ class TestAccountPaymentProUnitTest(common.TransactionCase):
                 "payment_type": "inbound",
                 "partner_type": "customer",
                 "partner_id": self.partner_ri.id,
-                "journal_id": self.company_bank_journal.id,
+                "journal_id": branch_bank_journal.id,
                 "date": self.today,
                 "company_id": branch.id,
             }

--- a/account_payment_pro/tests/test_receipt_debt_legal_entity.py
+++ b/account_payment_pro/tests/test_receipt_debt_legal_entity.py
@@ -1,0 +1,157 @@
+# © ADHOC SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import Command
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestReceiptDebtLegalEntity(AccountTestInvoicingCommon):
+    """El recibo lista la deuda de toda la entidad fiscal, acotada a lo seleccionado.
+
+    Con stores toda la deuda vivía en una sola compañía y el recibo la listaba entera.
+    Branches parte la compañía, y el recibo se partía con ella: filtraba por la compañía
+    del pago, así que una sucursal no veía la deuda de su padre ni al revés, sin ningún
+    aviso — el operador veía al cliente sin deuda.
+
+    Ahora el filtro es la entidad fiscal intersecada con las compañías que el usuario
+    tiene seleccionadas, y el pago sigue quedando en la compañía donde se hizo.
+    """
+
+    PARENT_VAT = "30111111118"
+    OTHER_VAT = "30222222226"
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.parent = cls.company_data["company"]
+        cls.parent_invoice = cls.init_invoice("out_invoice", amounts=[100.0], post=True, company=cls.parent)
+        cls.partner = cls.parent_invoice.partner_id
+
+        cls.parent.country_id = False
+        cls.parent.vat = cls.PARENT_VAT
+        cls.same_entity = cls.env["res.company"].create(
+            {"name": "Sucursal mismo CUIT", "parent_id": cls.parent.id, "vat": cls.PARENT_VAT}
+        )
+        cls.other_entity = cls.env["res.company"].create(
+            {"name": "Sucursal otro CUIT", "parent_id": cls.parent.id, "vat": cls.OTHER_VAT}
+        )
+        cls.income = cls.env["account.account"].search(
+            [("company_ids", "in", cls.parent.id), ("account_type", "=", "income")], limit=1
+        )
+        # Cuenta corriente propia en cada sucursal, que es el escenario de cuentas
+        # corrientes independientes por sucursal, y una factura abierta en cada una.
+        cls.same_entity_invoice = cls._invoice_in_branch(cls.same_entity, "01")
+        cls.other_entity_invoice = cls._invoice_in_branch(cls.other_entity, "02")
+
+    @classmethod
+    def _invoice_in_branch(cls, company, suffix):
+        receivable = cls.env["account.account"].create(
+            {
+                "name": "Deudores %s" % company.name,
+                "code": "ZZ%s" % suffix,
+                "account_type": "asset_receivable",
+                "reconcile": True,
+                "company_ids": [Command.set(company.ids)],
+            }
+        )
+        cls.partner.with_company(company).property_account_receivable_id = receivable
+        journal = cls.env["account.journal"].create(
+            {"name": "Ventas %s" % company.name, "code": "ZV%s" % suffix, "type": "sale", "company_id": company.id}
+        )
+        invoice = (
+            cls.env["account.move"]
+            .with_company(company)
+            .create(
+                {
+                    "move_type": "out_invoice",
+                    "partner_id": cls.partner.id,
+                    "journal_id": journal.id,
+                    "company_id": company.id,
+                    "invoice_line_ids": [
+                        Command.create(
+                            {"name": "x", "quantity": 1, "price_unit": 100, "tax_ids": [], "account_id": cls.income.id}
+                        )
+                    ],
+                }
+            )
+        )
+        invoice.action_post()
+        return invoice
+
+    def _debt_listed(self, company, selected):
+        payment = (
+            self.env["account.payment"]
+            .with_context(allowed_company_ids=selected.ids)
+            .new(
+                {
+                    "partner_id": self.partner.id,
+                    "partner_type": "customer",
+                    "payment_type": "inbound",
+                    "company_id": company.id,
+                }
+            )
+        )
+        return self.env["account.move.line"].search(payment._get_to_pay_move_lines_domain())
+
+    def test_the_receipt_lists_the_debt_of_the_whole_legal_entity(self):
+        """Desde la sucursal se ve la deuda del padre, que es lo que se había perdido."""
+        every_company = self.parent + self.same_entity + self.other_entity
+
+        listed = self._debt_listed(self.same_entity, every_company)
+
+        self.assertEqual(listed.company_id, self.parent + self.same_entity)
+
+    def test_it_lists_the_same_debt_from_the_parent(self):
+        """Y al revés: la padre cobra la deuda de su sucursal."""
+        every_company = self.parent + self.same_entity + self.other_entity
+
+        listed = self._debt_listed(self.parent, every_company)
+
+        self.assertEqual(listed.company_id, self.parent + self.same_entity)
+
+    def test_the_debt_of_another_legal_entity_is_never_listed(self):
+        """La garantía que se conserva: otra entidad fiscal no entra ni tildándola."""
+        every_company = self.parent + self.same_entity + self.other_entity
+
+        listed = self._debt_listed(self.parent, every_company)
+
+        self.assertNotIn(self.other_entity, listed.company_id)
+
+    def test_a_company_the_user_did_not_select_is_not_listed(self):
+        """ "Ni más ni menos que las seleccionadas": sin tildar la sucursal, su deuda no va."""
+        listed = self._debt_listed(self.parent, self.parent)
+
+        self.assertEqual(listed.company_id, self.parent)
+
+    def test_the_payment_keeps_the_company_where_it_was_made(self):
+        """Aunque pague deuda de otra sucursal de la entidad, el pago es de esa compañía.
+
+        Es lo que el ``_check_company_domain`` de ``account.move.line`` en ``account_ux``
+        habilita: sin eso, el m2m rechazaría el apunte del padre y este create fallaría.
+        """
+        parent_debt = self.parent_invoice.line_ids.filtered(
+            lambda line: line.account_id.account_type == "asset_receivable"
+        )
+        journal = self.env["account.journal"].create(
+            {"name": "Banco sucursal", "code": "ZZB", "type": "bank", "company_id": self.same_entity.id}
+        )
+
+        payment = (
+            self.env["account.payment"]
+            .with_context(allowed_company_ids=(self.parent + self.same_entity).ids)
+            .create(
+                {
+                    "partner_id": self.partner.id,
+                    "partner_type": "customer",
+                    "payment_type": "inbound",
+                    "company_id": self.same_entity.id,
+                    "journal_id": journal.id,
+                    "amount": 100.0,
+                    "to_pay_move_line_ids": [Command.set(parent_debt.ids)],
+                }
+            )
+        )
+
+        self.assertEqual(payment.company_id, self.same_entity)
+        self.assertEqual(payment.to_pay_move_line_ids.company_id, self.parent)


### PR DESCRIPTION
Follows `shared_to_branches` becoming a selection in ingadhoc/account-financial-tools#1019 (all branches / same legal entity / not shared) instead of a boolean.

The domain of the destination cashbox session filters the sessions of the parent company by whether its journals are shared to branches. Compared against `True` it now matches nothing, so a branch would silently stop being able to pick the sessions of its parent's cashboxes. It compares against the two values that mean shared instead.

The comment in `_compute_company_id` that spelled the condition as `shared_to_branches=True` was reworded for the same reason.

Same commit as #1183, moved to the branch name the rest of the milestone uses so runbot builds every layer in a single base. #1183 is closed in favour of this one.

## Test plan

On a parent with branches, from a branch: an internal transfer whose destination journal belongs to the parent still offers the parent's open cashbox sessions in `destination_cashbox_session_id`, as long as the journal is shared (all branches, or same legal entity when the branch qualifies). A journal that is not shared offers none.

Tasks: https://www.adhoc.inc/odoo/project.task/71641 (the scope) and https://www.adhoc.inc/odoo/project.task/72204 (the milestone)

---

# Second commit — the receipt offers the debt of the whole legal entity

The debt a receipt offers was filtered by `("company_id", "=", self.company_id.id)`: the payment's company alone. So a branch never saw the debt of its parent, nor the parent the debt of its branch — silently, with no error. The operator saw a customer with no debt and had no way to tell they owed in another branch.

Measured before, on a parent and a branch of the same legal entity, each with its own receivable account for the same customer and open debt in both, with **both companies selected**:

```
recibo en YourCompany  -> lista 1 línea(s) de ['YourCompany']
recibo en ZZ Sucursal  -> lista 1 línea(s) de ['ZZ Sucursal']
```

And after:

```
recibo en YourCompany  -> 2 línea(s) de ['YourCompany', 'ZZ Sucursal']
recibo en ZZ Sucursal  -> 2 línea(s) de ['YourCompany', 'ZZ Sucursal']
```

The filter is now the companies of the payment's legal entity intersected with `env.companies`, which is the criterion agreed for this: all the compatible debt of the selected companies, no more and no less. A company of another legal entity is never offered, even when selected. The payment **stays in the company where it was made**, whichever branch of the entity the debt belongs to; what makes that possible is the `_check_company_domain` of `account.move.line` in ingadhoc/account-financial-tools#1019.

Worth stating because the task assumed otherwise: **the receivable accounts have nothing to do with it.** The domain filters by account type and reconcilability, never by a specific account, so giving each branch its own current account does not change what gets listed. What used to hide the debt was the company filter, not the account.

### Test plan of the second commit

Five tests in `tests/test_receipt_debt_legal_entity.py`, over a parent, a same-Tax-ID branch and a different-Tax-ID one, each with its own receivable account and an open invoice: the receipt lists the entity's debt from the branch, the same from the parent, another legal entity is never listed, a company the user did not select is not listed, and — end to end — a payment created in the branch holds a line of its parent and keeps its own company.

```
odoo -d <db> -u account_ux,account_payment_pro --test-enable --test-tags "/account_ux,/account_payment_pro"

account_payment_pro: 29 tests 9.25s 10661 queries
```

Mutation check: with the company filter put back, the two listing tests fail; with the `check_company` override of #1019 disabled, the end-to-end test errors with the company inconsistency `UserError`.

# Third commit — a test that depended on how the journals of the database were computed

`TestAccountPaymentProUnitTest.test_change_product_includes_parent_company_taxes` was red on this database, and red with this branch's changes stashed too. It builds its payment in a branch but with the **bank journal of the parent**, and a branch may only use that journal when it is shared to branches.

That is a stored value, computed when the journal was created, and `account_ux._compute_shared_to_branches` shares *everything* only while running with `--test-enable`:

```python
# In case of test environment (but not demo data loading), share all journals to branches
if tools.config["test_enable"] and not self.env.context.get("demo"):
    self.shared_to_branches = "all"
```

So on a build whose journals were created with tests enabled the test is green, and on any database created without them the bank journals end up unshared and the company check refuses the payment — failing for a reason that has nothing to do with what the test verifies, which is that the invoice wizard offers the taxes of the parent company to a branch.

The test now creates its own bank journal in the branch. Same class of fragility as the export-buttons test in ingadhoc/odoo-argentina-ee#1132: an assertion resting on a value that another module happened to leave in the database.

Worth a separate look, and not touched here: that `test_enable` branch in the compute predates this work (it is in `19.0` as well), and it means no test can exercise the *unshared* path through the computed default — the very behaviour the scope of `shared_to_branches` governs.

```
odoo -d <db> -u account_payment_pro --test-enable --test-tags "/account_payment_pro"

account_payment_pro: 29 tests 14.30s 10799 queries
0 failed, 0 error(s) of 15 tests
```

Tasks: https://www.adhoc.inc/odoo/project.task/72168 (the receipt debt) and https://www.adhoc.inc/odoo/project.task/71641 (the scope)

