### PR TITLE
[FIX] account_payment_pro: counterpart nominal when debt is reconcile…

### DIFF
--- a/account_payment_pro/__manifest__.py
+++ b/account_payment_pro/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Account Payment Super Power",
-    "version": "19.0.2.11.0",
+    "version": "19.0.2.11.1",
     "category": "Payment",
     "website": "www.adhoc.com.ar",
     "author": "ADHOC SA",

--- a/account_payment_pro/models/account_payment.py
+++ b/account_payment_pro/models/account_payment.py
@@ -766,10 +766,27 @@ class AccountPayment(models.Model):
                 if self.write_off_amount and self.destination_currency_id == self.counterpart_currency_id:
                     counterpart_amt += abs(self.write_off_amount)
                 counterpart_lines[0]["amount_currency"] = cp_sign * counterpart_amt
+        elif self.destination_currency_id == self.company_currency_id and self.counterpart_currency_id != (
+            self.company_currency_id
+        ):
+            # A == B1 ≠ C con B2 == C (reconcile_on_company_currency): la moneda ya es la
+            # correcta (B1, igual que A), pero el nominal que trae base Odoo no sirve, porque
+            # suma el amount_currency del write-off — que va en B2 == C — contra el de
+            # liquidez, que va en A. Mezcla monedas y puede salir con el signo opuesto al
+            # balance recalculado arriba, que revienta contra
+            # _check_amount_currency_balance_sign (ticket 126046).
+            # Se recalcula entero (no como delta sobre el nominal del core, que acá viene
+            # contaminado) desde payment_total — que está en B2 == C — llevado a B1 con el
+            # accounting_rate del propio pago, el mismo que usa la línea de liquidez, para no
+            # introducir una cotización distinta a la de la operación.
+            cp_sign = -1 if counterpart_lines[0]["balance"] < 0 else 1
+            counterpart_amt = abs(self.counterpart_currency_id.round(self.payment_total * self.accounting_rate))
+            counterpart_lines[0]["amount_currency"] = cp_sign * counterpart_amt
         elif write_off_line_vals:
             # A == B1 y la moneda ya es correcta: el core armó el nominal sin ver el write-off,
             # así que hay que sumárselo para que la contrapartida cubra el total de la deuda.
             counterpart_lines[0]["amount_currency"] -= sum(line["amount_currency"] for line in write_off_line_vals)
+        # Si A == B1 == B2 y sin write-off: la moneda ya es correcta (A), solo el balance cambió
 
         # Cualquiera de las ramas anteriores puede dejar la contrapartida en moneda de
         # compañía, y ahí el nominal y el balance son la misma cifra por definición: tiene

--- a/account_payment_pro/tests/test_payment_multimoneda.py
+++ b/account_payment_pro/tests/test_payment_multimoneda.py
@@ -766,6 +766,102 @@ class TestPaymentMultimoneda(TestArCommon):
         finally:
             self.company.reconcile_on_company_currency = False
 
+    def test_caso9_spec_b1_forzada_usd(self):
+        """Caso 9 de la spec · USD / USD / ARS / ARS  ("Pago USD de Deuda ARS")
+
+        Deuda contable en ARS (cuenta sin moneda), pago en USD, y el usuario fuerza el
+        apunte AP/AR a USD. Es la combinación que la spec numera 9 y que DESIGN.md
+        transcribe como "USD / B1=USD / B2=ARS"; el test_caso9_pago_usd_deuda_ars
+        implementado cubre otra (ahí B1 queda en ARS por default), así que este
+        escenario no estaba cubierto.
+
+        Sin write-off el nominal de la contrapartida coincide con el monto del pago, de
+        modo que este caso pasa con o sin el fix de _prepare_move_lines_per_type: cubre
+        la spec, no la regresión. La regresión la cubre el test de acá abajo.
+        """
+        self.company.reconcile_on_company_currency = True
+        self.account_receivable.currency_id = False
+        try:
+            expected_debt_ars = 1_000 / self._get_rate(self.ars, self.usd)  # 1 000 USD → 1 200 000 ARS
+            invoice = self._create_invoice(expected_debt_ars, self.ars)
+            payment = self._create_payment(
+                self.bank_usd,
+                amount=1_000,
+                to_pay_move_line_ids=[Command.set(self._get_debt_lines(invoice).ids)],
+            )
+            # Con el flag el default de B1 es C: el usuario la fuerza a USD desde la vista
+            payment.counterpart_currency_id = self.usd
+
+            self._assert_currencies(payment, A=self.usd, B1=self.usd, B2=self.ars, C=self.ars)
+
+            payment.action_post()
+
+            self._assert_move_lines(
+                payment,
+                {
+                    "liquidity": {"currency": self.usd, "amt_currency": 1_000, "balance": expected_debt_ars},
+                    "counterpart": {"currency": self.usd, "amt_currency": -1_000, "balance": -expected_debt_ars},
+                },
+            )
+            self.assertIn(invoice.payment_state, ["paid", "in_payment"])
+        finally:
+            self.company.reconcile_on_company_currency = False
+
+    def test_caso9_spec_b1_forzada_usd_con_write_off(self):
+        """Caso 9 de la spec + write-off · USD / USD / ARS / ARS
+
+        Igual que el test de arriba pero con ajuste. La spec no especifica el asiento de
+        los casos con reconcile (la columna "Detalle Técnico" está vacía en las filas
+        8/9/10) y no trae ningún ejemplo con write-off, así que el asiento esperado sigue
+        el patrón de los casos sin reconcile: importe en B1, balance en C.
+
+        Es el caso que rompía. La contrapartida se queda en B1 (DESIGN.md §Journal entry
+        generation) y lo que hay que recalcular es el nominal: el que trae base Odoo suma
+        el amount_currency del write-off (que va en B2 == C) contra el de liquidez (que va
+        en A), y sale con el signo opuesto al balance, que revienta contra
+        _check_amount_currency_balance_sign (ticket 126046).
+        """
+        self.company.reconcile_on_company_currency = True
+        self.account_receivable.currency_id = False
+        try:
+            invoice = self._create_invoice(117_600, self.ars)
+            debt_lines = self._get_debt_lines(invoice)
+            payment = self._create_payment(
+                self.bank_usd,
+                amount=99,
+                to_pay_move_line_ids=[Command.set(debt_lines.ids)],
+                write_off_type_id=self.write_off_type.id,
+                write_off_amount=-1_200,
+            )
+            # Con el flag el default de B1 es C: el usuario la fuerza a USD desde la vista
+            payment.counterpart_currency_id = self.usd
+
+            self._assert_currencies(payment, A=self.usd, B1=self.usd, B2=self.ars, C=self.ars)
+
+            expected_liq_balance = 99 / self._get_rate(self.ars, self.usd)  # 99 USD → 118 800 ARS
+            # Balance de contrapartida: -118 800 - (-1 200) = -117 600 ARS
+            # Nominal en B1 (USD): payment_total (117 600 ARS) * accounting_rate = 98 USD
+            expected_cp_balance = -(expected_liq_balance + (-1_200))
+            expected_cp_amount = expected_cp_balance * payment.accounting_rate
+
+            payment.action_post()
+
+            self._assert_move_lines(
+                payment,
+                {
+                    "liquidity": {"currency": self.usd, "amt_currency": 99, "balance": expected_liq_balance},
+                    "counterpart": {
+                        "currency": self.usd,
+                        "amt_currency": expected_cp_amount,
+                        "balance": expected_cp_balance,
+                    },
+                    "write_off": {"currency": self.ars, "amt_currency": -1_200, "balance": -1_200},
+                },
+            )
+            self.assertIn(invoice.payment_state, ["paid", "in_payment"])
+        finally:
+            self.company.reconcile_on_company_currency = False
+
     # ==================================================================
     # TESTS DE MECÁNICA INTERNA
     # ==================================================================


### PR DESCRIPTION
…d in company currency

With reconcile_on_company_currency the write-off line is built in B2 (which equals the company currency) while the liquidity line is built in A. When A == B1 and B1 != company currency, base Odoo derives the counterpart nominal by summing amount_currency across those two different currencies, so it can come out with the opposite sign of the balance recomputed afterwards and the entry is rejected by _check_amount_currency_balance_sign.

Recompute the counterpart nominal in full for that combination, from payment_total (expressed in B2) converted to B1 with the payment's own accounting_rate, the same rate the liquidity line uses. The counterpart line stays in B1, as specified.

Adds the spec's case 9 (foreign currency journal, B1 forced to that currency, debt in company currency) and its write-off variant, which is the one that reproduced the failure.