### PR TITLE
[FIX] account_payment_pro_receiptbook: avoid MemoryError in migration

### DIFF
--- a/account_payment_pro_receiptbook/migrations/19.0.2.4.0/post-migration.py
+++ b/account_payment_pro_receiptbook/migrations/19.0.2.4.0/post-migration.py
@@ -14,6 +14,14 @@ receiptbook + prefijo, así que los valores guardados pueden estar desactualizad
 Barremos *todos* los asientos con ``receiptbook_id`` (sin filtro de fecha: la
 condición es exacta y una ventana temporal solo dejaría asientos viejos mal
 marcados) y reaplicamos la detección. Idempotente.
+
+El barrido se hace en SQL y no con ``_update_receiptbook_made_sequence_gap()``.
+``made_sequence_gap`` es un boolean plano de housekeeping (sin tracking, sin
+inverse, sin depends), pero asignarlo por ORM dispara ``account.move.write()``
+y con él el override de Purchase, que hace
+``move.mapped('line_ids.purchase_line_id.order_id')`` por cada asiento. Sobre un
+recordset del tamaño de toda la tabla eso materializa en memoria los ids de
+todas las ``account.move.line`` de la base y termina en ``MemoryError``.
 """
 
 import logging
@@ -22,15 +30,52 @@ from odoo import SUPERUSER_ID, api
 
 _logger = logging.getLogger(__name__)
 
+# Un asiento hace hueco cuando falta el número inmediatamente anterior dentro
+# del mismo receiptbook + prefijo. Los no posteados que ya tomaron número se
+# marcan siempre. El LEFT JOIN busca ese predecesor sin filtrar por estado (un
+# asiento cancelado igual ocupa el número).
+_RECOMPUTE_MADE_SEQUENCE_GAP = """
+    WITH rb AS (
+        SELECT id,
+               receiptbook_id,
+               COALESCE(sequence_prefix, '') AS prefix,
+               COALESCE(sequence_number, 0) AS sequence_number,
+               state
+          FROM account_move
+         WHERE receiptbook_id IS NOT NULL
+    ),
+    computed AS (
+        SELECT DISTINCT
+               m.id,
+               CASE
+                   WHEN m.sequence_number <> 0 AND m.state <> 'posted' THEN TRUE
+                   WHEN m.sequence_number > 1 AND p.id IS NULL THEN TRUE
+                   ELSE FALSE
+               END AS made_gap
+          FROM rb m
+          LEFT JOIN rb p
+                 ON p.receiptbook_id = m.receiptbook_id
+                AND p.prefix = m.prefix
+                AND p.sequence_number = m.sequence_number - 1
+    )
+    UPDATE account_move am
+       SET made_sequence_gap = c.made_gap
+      FROM computed c
+     WHERE am.id = c.id
+       AND am.made_sequence_gap IS DISTINCT FROM c.made_gap
+"""
+
 
 def migrate(cr, version):
     _logger.info("Running post-migration %s: recompute made_sequence_gap on receiptbook moves", version)
 
     env = api.Environment(cr, SUPERUSER_ID, {})
+    # ``receiptbook_id`` es related stored y ``sequence_prefix`` / ``sequence_number``
+    # son computados stored: puede haber recomputes pendientes que el SQL no vería.
+    env.flush_all()
 
-    moves = env["account.move"].with_context(active_test=False).search([("receiptbook_id", "!=", False)])
-    _logger.info("Recomputando made_sequence_gap en %d asientos de receiptbook", len(moves))
+    cr.execute(_RECOMPUTE_MADE_SEQUENCE_GAP)
+    _logger.info("made_sequence_gap actualizado en %d asientos de receiptbook", cr.rowcount)
 
-    if moves:
-        moves._update_receiptbook_made_sequence_gap()
-        env.flush_all()
+    # Pisamos columnas por fuera del ORM.
+    env.invalidate_all()


### PR DESCRIPTION
## Problema

La post-migration `19.0.2.4.0` aborta con `MemoryError` durante una actualización 17 → 19 sobre una base con volumen alto de recibos.

El script barre todos los asientos con `receiptbook_id` y llama a `_update_receiptbook_made_sequence_gap()`, que asigna `made_sequence_gap` registro por registro. Cada asignación es un `write()` sobre `account.move`, y con él corre el override de Purchase:

```python
# addons/purchase/models/account_invoice.py
old_purchases = [move.mapped('line_ids.purchase_line_id.order_id') for move in self]
```

El `mapped` arrastra el prefetch set completo. El recordset que devuelve `line_ids` lleva como `_prefetch_ids` un iterador sobre las líneas de todos los asientos prefetcheados, así que al pedir `purchase_line_id` el `expand_ids()` / `tools.misc.unique()` materializa en memoria los ids de todas las `account.move.line` de la base. Ahí explota:

```
File "odoo/tools/misc.py", line 1225, in unique
    seen.add(e)
MemoryError
```

Batchear no alcanza: mientras el barrido pase por `write()`, cada lote sigue pagando el override.

## Solución

`made_sequence_gap` es un boolean plano de housekeeping — sin tracking, sin inverse, sin depends. El barrido masivo pasa a un único `UPDATE` en SQL:

- `LEFT JOIN` sobre el mismo subconjunto (asientos con `receiptbook_id`) buscando el número inmediatamente anterior dentro del mismo receiptbook + prefijo. Un solo scan y un hash join, sin subconsulta correlacionada.
- `WHERE ... IS DISTINCT FROM` para escribir solo las filas cuyo valor cambia.
- `COALESCE` en prefijo y número, para que un `NULL` no deje el flag en `NULL`.
- `DISTINCT` para el caso de números duplicados dentro del mismo receiptbook + prefijo.
- `flush_all()` antes y `invalidate_all()` después, porque se leen y pisan columnas por fuera del ORM.

El método `_update_receiptbook_made_sequence_gap()` no se toca en este PR: sigue siendo el camino de runtime.

## Test plan

Paridad y idempotencia verificadas sobre una tabla `account_move` sintética en postgres (46 asientos: secuencia continua, huecos reales, estados `posted` / `draft` / `cancel`, dos prefijos en un mismo talonario, número 0, duplicados exactos, prefijo y número `NULL`, más asientos sin receiptbook como control), comparando el resultado del SQL contra una reimplementación de la lógica Python anterior:

```
asientos con receiptbook: 41 | sin receiptbook: 5
marcados con hueco (Python): 11 | (SQL): 11
PARIDAD OK: SQL == Python en los 41 asientos de receiptbook
segunda corrida (idempotencia): UPDATE 0
```

Los asientos sin `receiptbook_id` quedan intactos.

Pendiente de mi lado: correr el upgrade 17 → 19 completo sobre un dump de volumen real y un `EXPLAIN (ANALYZE, BUFFERS)` del `UPDATE`. Ojo que `receiptbook_id` no tiene índice — el filtro resuelve por seq scan; si en una base grande el plan no rinde, se puede sumar un índice parcial temporal dentro de la propia migración.

Ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/126129