### PR TITLE
[FIX] payment_retry: do not hide the payment button on pending transactions

### DIFF
--- a/payment_retry/__manifest__.py
+++ b/payment_retry/__manifest__.py
@@ -3,7 +3,7 @@
     "author": "ADHOC SA",
     "website": "https://www.adhoc.inc",
     "category": "Payment",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.1.0",
     "depends": ["account_payment"],
     "license": "LGPL-3",
     "images": [],
@@ -12,5 +12,6 @@
         "security/ir.model.access.csv",
         "data/ir_cron.xml",
         "wizards/payment_transaction_retry.xml",
+        "wizards/electronic_payment_pending_confirm.xml",
     ],
 }

--- a/payment_retry/i18n/es.po
+++ b/payment_retry/i18n/es.po
@@ -1,10 +1,10 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # 	* payment_retry
-# 
+#
 # Translators:
 # ADHOC - Bot <transbot@adhoc.com.ar>, 2025
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0+e\n"
@@ -12,14 +12,12 @@ msgstr ""
 "POT-Creation-Date: 2025-11-19 12:55+0000\n"
 "PO-Revision-Date: 2025-12-26 17:10+0000\n"
 "Last-Translator: carla spiaggi <sca@adhoc.inc>\n"
-"Language-Team: Spanish <https://translation.dev-adhoc.com/projects/"
-"account-payment-19-0/account-payment-19-0-payment_retry/es/>\n"
+"Language-Team: Spanish <https://translation.dev-adhoc.com/projects/account-payment-19-0/account-payment-19-0-payment_retry/es/>\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ((n != 0 && n % 1000000 == 0)"
-" ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ((n != 0 && n % 1000000 == 0) ? 1 : 2);\n"
 "X-Generator: Weblate 5.10.4\n"
 
 #. module: payment_retry
@@ -74,12 +72,14 @@ msgid "Create payments without check"
 msgstr "Crear pagos sin verificación"
 
 #. module: payment_retry
+#: model:ir.model.fields,field_description:payment_retry.field_electronic_payment_pending_confirm__create_uid
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction_retry__create_uid
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction_retry_lines__create_uid
 msgid "Created by"
 msgstr "Creado por"
 
 #. module: payment_retry
+#: model:ir.model.fields,field_description:payment_retry.field_electronic_payment_pending_confirm__create_date
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction_retry__create_date
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction_retry_lines__create_date
 msgid "Created on"
@@ -91,12 +91,14 @@ msgid "Currency"
 msgstr "Moneda"
 
 #. module: payment_retry
+#: model_terms:ir.ui.view,arch_db:payment_retry.electronic_payment_pending_confirm_view_form
 #: model_terms:ir.ui.view,arch_db:payment_retry.payment_transaction_retry_view_form
 msgid "Discard"
 msgstr "Descartar"
 
 #. module: payment_retry
 #: model:ir.model.fields,field_description:payment_retry.field_account_move__display_name
+#: model:ir.model.fields,field_description:payment_retry.field_electronic_payment_pending_confirm__display_name
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction__display_name
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction_retry__display_name
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction_retry_lines__display_name
@@ -104,7 +106,6 @@ msgid "Display Name"
 msgstr "Nombre a Mostrar"
 
 #. module: payment_retry
-#: model:ir.model.fields.selection,name:payment_retry.selection__account_move__payment_state__electronic_pending
 #: model:ir.model.fields.selection,name:payment_retry.selection__account_move__status_in_payment__electronic_pending
 msgid "Electronic payment"
 msgstr "Pago Electrónico"
@@ -122,6 +123,7 @@ msgstr "Error al enviar solicitud tx id %i: %s"
 
 #. module: payment_retry
 #: model:ir.model.fields,field_description:payment_retry.field_account_move__id
+#: model:ir.model.fields,field_description:payment_retry.field_electronic_payment_pending_confirm__id
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction__id
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction_retry__id
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction_retry_lines__id
@@ -135,8 +137,8 @@ msgid ""
 " se realizará de forma asincrónica y puede llegar a demorar el envío de los "
 "pagos"
 msgstr ""
-"IMPORTANTE! Tener en cuenta que está generando más de 20 transacciones, esto "
-"se realizará de forma asincrónica y puede llegar a demorar el envío de los "
+"IMPORTANTE! Tener en cuenta que está generando más de 20 transacciones, esto"
+" se realizará de forma asincrónica y puede llegar a demorar el envío de los "
 "pagos"
 
 #. module: payment_retry
@@ -150,12 +152,14 @@ msgid "Journal Entry"
 msgstr "Asiento Contable"
 
 #. module: payment_retry
+#: model:ir.model.fields,field_description:payment_retry.field_electronic_payment_pending_confirm__write_uid
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction_retry__write_uid
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction_retry_lines__write_uid
 msgid "Last Updated by"
 msgstr "Última modificación por"
 
 #. module: payment_retry
+#: model:ir.model.fields,field_description:payment_retry.field_electronic_payment_pending_confirm__write_date
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction_retry__write_date
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction_retry_lines__write_date
 msgid "Last Updated on"
@@ -186,12 +190,6 @@ msgstr "Contacto"
 #: code:addons/payment_retry/wizards/payment_transaction_retry.py:0
 msgid "Partner(s) should have an email address."
 msgstr "Los contactos deben tener una dirección de correo electrónico."
-
-#. module: payment_retry
-#: model:ir.model.fields,field_description:payment_retry.field_account_bank_statement_line__payment_state
-#: model:ir.model.fields,field_description:payment_retry.field_account_move__payment_state
-msgid "Payment Status"
-msgstr "Estado de pago"
 
 #. module: payment_retry
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction_retry_lines__payment_token_id
@@ -281,3 +279,59 @@ msgstr "Líneas de reintento de transacción de pago"
 #: model_terms:ir.ui.view,arch_db:payment_retry.payment_transaction_retry_view_form
 msgid "retry"
 msgstr "Reintentar"
+
+#. module: payment_retry
+#: model:ir.model,name:payment_retry.model_electronic_payment_pending_confirm
+msgid "Confirm a manual payment while an electronic payment is on course"
+msgstr "Confirmar un pago manual mientras hay un pago electrónico en curso"
+
+#. module: payment_retry
+#: code:addons/payment_retry/models/account_move.py:0
+#: model_terms:ir.ui.view,arch_db:payment_retry.electronic_payment_pending_confirm_view_form
+msgid "Electronic payment on course"
+msgstr "Pago electrónico en curso"
+
+#. module: payment_retry
+#: model:ir.model.fields,field_description:payment_retry.field_account_bank_statement_line__has_pending_transaction
+#: model:ir.model.fields,field_description:payment_retry.field_account_move__has_pending_transaction
+msgid "Has Pending Transaction"
+msgstr "Tiene una transacción pendiente"
+
+#. module: payment_retry
+#: model:ir.model.fields,field_description:payment_retry.field_electronic_payment_pending_confirm__move_ids
+msgid "Move"
+msgstr "Asiento"
+
+#. module: payment_retry
+#: model_terms:ir.ui.view,arch_db:payment_retry.electronic_payment_pending_confirm_view_form
+msgid "Register payment anyway"
+msgstr "Registrar el pago de todas formas"
+
+#. module: payment_retry
+#: model:ir.model.fields,help:payment_retry.field_account_bank_statement_line__has_pending_transaction
+#: model:ir.model.fields,help:payment_retry.field_account_move__has_pending_transaction
+msgid ""
+"Technical field to know if there is an electronic payment on course for this"
+" invoice."
+msgstr ""
+"Campo técnico para saber si hay un pago electrónico en curso para esta "
+"factura."
+
+#. module: payment_retry
+#: code:addons/payment_retry/wizards/electronic_payment_pending_confirm.py:0
+msgid ""
+"The payment is being registered manually while the electronic payment %s is "
+"still on course."
+msgstr ""
+"El pago se está registrando manualmente mientras el pago electrónico %s "
+"sigue en curso."
+
+#. module: payment_retry
+#: model_terms:ir.ui.view,arch_db:payment_retry.electronic_payment_pending_confirm_view_form
+msgid ""
+"There is an electronic payment on course for this invoice. If the customer ends up\n"
+"                        paying it online, that payment will be registered too and the invoice will be paid twice."
+msgstr ""
+"Existe un pago electrónico en curso para esta factura. Si el cliente "
+"finalmente lo paga en línea, ese pago también se registrará y la factura "
+"quedará pagada dos veces."

--- a/payment_retry/i18n/payment_retry.pot
+++ b/payment_retry/i18n/payment_retry.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-21 10:25+0000\n"
-"PO-Revision-Date: 2025-11-21 10:25+0000\n"
+"POT-Creation-Date: 2026-08-26 12:30+0000\n"
+"PO-Revision-Date: 2026-08-26 12:30+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -57,6 +57,11 @@ msgid "Company"
 msgstr ""
 
 #. module: payment_retry
+#: model:ir.model,name:payment_retry.model_electronic_payment_pending_confirm
+msgid "Confirm a manual payment while an electronic payment is on course"
+msgstr ""
+
+#. module: payment_retry
 #: model_terms:ir.ui.view,arch_db:payment_retry.payment_transaction_retry_view_form
 msgid "Create payments"
 msgstr ""
@@ -67,12 +72,14 @@ msgid "Create payments without check"
 msgstr ""
 
 #. module: payment_retry
+#: model:ir.model.fields,field_description:payment_retry.field_electronic_payment_pending_confirm__create_uid
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction_retry__create_uid
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction_retry_lines__create_uid
 msgid "Created by"
 msgstr ""
 
 #. module: payment_retry
+#: model:ir.model.fields,field_description:payment_retry.field_electronic_payment_pending_confirm__create_date
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction_retry__create_date
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction_retry_lines__create_date
 msgid "Created on"
@@ -84,12 +91,14 @@ msgid "Currency"
 msgstr ""
 
 #. module: payment_retry
+#: model_terms:ir.ui.view,arch_db:payment_retry.electronic_payment_pending_confirm_view_form
 #: model_terms:ir.ui.view,arch_db:payment_retry.payment_transaction_retry_view_form
 msgid "Discard"
 msgstr ""
 
 #. module: payment_retry
 #: model:ir.model.fields,field_description:payment_retry.field_account_move__display_name
+#: model:ir.model.fields,field_description:payment_retry.field_electronic_payment_pending_confirm__display_name
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction__display_name
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction_retry__display_name
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction_retry_lines__display_name
@@ -97,9 +106,15 @@ msgid "Display Name"
 msgstr ""
 
 #. module: payment_retry
-#: model:ir.model.fields.selection,name:payment_retry.selection__account_move__payment_state__electronic_pending
 #: model:ir.model.fields.selection,name:payment_retry.selection__account_move__status_in_payment__electronic_pending
 msgid "Electronic payment"
+msgstr ""
+
+#. module: payment_retry
+#. odoo-python
+#: code:addons/payment_retry/models/account_move.py:0
+#: model_terms:ir.ui.view,arch_db:payment_retry.electronic_payment_pending_confirm_view_form
+msgid "Electronic payment on course"
 msgstr ""
 
 #. module: payment_retry
@@ -114,7 +129,14 @@ msgid "Error al enviar request tx id %i: %s"
 msgstr ""
 
 #. module: payment_retry
+#: model:ir.model.fields,field_description:payment_retry.field_account_bank_statement_line__has_pending_transaction
+#: model:ir.model.fields,field_description:payment_retry.field_account_move__has_pending_transaction
+msgid "Has Pending Transaction"
+msgstr ""
+
+#. module: payment_retry
 #: model:ir.model.fields,field_description:payment_retry.field_account_move__id
+#: model:ir.model.fields,field_description:payment_retry.field_electronic_payment_pending_confirm__id
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction__id
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction_retry__id
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction_retry_lines__id
@@ -140,12 +162,14 @@ msgid "Journal Entry"
 msgstr ""
 
 #. module: payment_retry
+#: model:ir.model.fields,field_description:payment_retry.field_electronic_payment_pending_confirm__write_uid
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction_retry__write_uid
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction_retry_lines__write_uid
 msgid "Last Updated by"
 msgstr ""
 
 #. module: payment_retry
+#: model:ir.model.fields,field_description:payment_retry.field_electronic_payment_pending_confirm__write_date
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction_retry__write_date
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction_retry_lines__write_date
 msgid "Last Updated on"
@@ -167,6 +191,11 @@ msgid "Message"
 msgstr ""
 
 #. module: payment_retry
+#: model:ir.model.fields,field_description:payment_retry.field_electronic_payment_pending_confirm__move_ids
+msgid "Move"
+msgstr ""
+
+#. module: payment_retry
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction_retry_lines__partner_id
 msgid "Partner"
 msgstr ""
@@ -175,12 +204,6 @@ msgstr ""
 #. odoo-python
 #: code:addons/payment_retry/wizards/payment_transaction_retry.py:0
 msgid "Partner(s) should have an email address."
-msgstr ""
-
-#. module: payment_retry
-#: model:ir.model.fields,field_description:payment_retry.field_account_bank_statement_line__payment_state
-#: model:ir.model.fields,field_description:payment_retry.field_account_move__payment_state
-msgid "Payment Status"
 msgstr ""
 
 #. module: payment_retry
@@ -205,6 +228,11 @@ msgid "Percentage:"
 msgstr ""
 
 #. module: payment_retry
+#: model_terms:ir.ui.view,arch_db:payment_retry.electronic_payment_pending_confirm_view_form
+msgid "Register payment anyway"
+msgstr ""
+
+#. module: payment_retry
 #: model:ir.model.fields,field_description:payment_retry.field_payment_transaction_retry_lines__retry_id
 msgid "Retry"
 msgstr ""
@@ -224,6 +252,29 @@ msgstr ""
 #: model:ir.model.fields,field_description:payment_retry.field_account_bank_statement_line__status_in_payment
 #: model:ir.model.fields,field_description:payment_retry.field_account_move__status_in_payment
 msgid "Status In Payment"
+msgstr ""
+
+#. module: payment_retry
+#: model:ir.model.fields,help:payment_retry.field_account_bank_statement_line__has_pending_transaction
+#: model:ir.model.fields,help:payment_retry.field_account_move__has_pending_transaction
+msgid ""
+"Technical field to know if there is an electronic payment on course for this"
+" invoice."
+msgstr ""
+
+#. module: payment_retry
+#. odoo-python
+#: code:addons/payment_retry/wizards/electronic_payment_pending_confirm.py:0
+msgid ""
+"The payment is being registered manually while the electronic payment %s is "
+"still on course."
+msgstr ""
+
+#. module: payment_retry
+#: model_terms:ir.ui.view,arch_db:payment_retry.electronic_payment_pending_confirm_view_form
+msgid ""
+"There is an electronic payment on course for this invoice. If the customer ends up\n"
+"                        paying it online, that payment will be registered too and the invoice will be paid twice."
 msgstr ""
 
 #. module: payment_retry

--- a/payment_retry/migrations/19.0.1.1.0/pre-migration.py
+++ b/payment_retry/migrations/19.0.1.1.0/pre-migration.py
@@ -1,0 +1,5 @@
+def migrate(cr, version):
+    """The 'electronic_pending' value is no longer added to account.move payment_state,
+    it is only exposed on status_in_payment. Restore the real payment state on the
+    invoices that were stamped with it, otherwise they keep an orphan value."""
+    cr.execute("UPDATE account_move SET payment_state = 'not_paid' WHERE payment_state = 'electronic_pending'")

--- a/payment_retry/models/account_move.py
+++ b/payment_retry/models/account_move.py
@@ -1,26 +1,57 @@
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 
 
 class AccountMove(models.Model):
     _inherit = "account.move"
-    payment_state = fields.Selection(
-        selection_add=[("electronic_pending", "Electronic payment")], ondelete={"electronic_pending": "cascade"}
-    )
+
     status_in_payment = fields.Selection(
         selection_add=[("electronic_pending", "Electronic payment")], ondelete={"electronic_pending": "cascade"}
     )
+    has_pending_transaction = fields.Boolean(
+        compute="_compute_has_pending_transaction",
+        help="Technical field to know if there is an electronic payment on course for this invoice.",
+    )
+
+    def _get_pending_transactions(self):
+        """Return the electronic payments on course, the ones that could still pay these invoices.
+
+        Payment transactions are only readable by settings users, hence the sudo.
+        """
+        return self.sudo().transaction_ids.filtered(lambda tx: tx.state in ("pending", "authorized"))
 
     @api.depends("transaction_ids.state")
-    def _compute_payment_state(self):
-        super()._compute_payment_state()
+    def _compute_has_pending_transaction(self):
+        for rec in self:
+            rec.has_pending_transaction = bool(rec._get_pending_transactions())
+
+    @api.depends("has_pending_transaction", "payment_state", "state", "is_move_sent")
+    def _compute_status_in_payment(self):
+        super()._compute_status_in_payment()
         for rec in self.filtered(
-            lambda x: x.payment_state == "not_paid"
-            and {"pending", "authorized"}.intersection(set(x.transaction_ids.mapped("state")))
+            lambda x: x.has_pending_transaction and x.state == "posted" and x.payment_state == "not_paid"
         ):
-            rec.payment_state = "electronic_pending"
+            rec.status_in_payment = "electronic_pending"
+
+    def action_force_register_payment(self):
+        """Warn before registering a payment by hand when an electronic payment is on course:
+        if the customer also pays it online, the invoice ends up being paid twice.
+
+        The check goes here and not on action_register_payment because that one only validates and
+        delegates here, and because some modules point the invoice button straight to this method.
+        """
+        if self.env.context.get("skip_electronic_pending_check") or not self.filtered("has_pending_transaction"):
+            return super().action_force_register_payment()
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Electronic payment on course"),
+            "res_model": "electronic.payment.pending.confirm",
+            "view_mode": "form",
+            "target": "new",
+            "context": {"default_move_ids": self.ids},
+        }
 
     def _has_to_be_paid(self):
         self.ensure_one()
-        if self.transaction_ids.filtered(lambda tx: tx.state in ("electronic_pending")):
+        if self.has_pending_transaction:
             return False
         return super()._has_to_be_paid()

--- a/payment_retry/security/ir.model.access.csv
+++ b/payment_retry/security/ir.model.access.csv
@@ -1,3 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 payment_retry.payment_retry_line, transaction retry line,payment_retry.model_payment_transaction_retry_lines,account.group_account_invoice,1,1,1,1
 payment_retry.payment_retry,payment transaction retry,payment_retry.model_payment_transaction_retry,account.group_account_invoice,1,1,1,1
+payment_retry.electronic_payment_pending_confirm,electronic payment pending confirm,payment_retry.model_electronic_payment_pending_confirm,account.group_account_invoice,1,1,1,1

--- a/payment_retry/tests/__init__.py
+++ b/payment_retry/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_electronic_pending

--- a/payment_retry/tests/test_electronic_pending.py
+++ b/payment_retry/tests/test_electronic_pending.py
@@ -1,0 +1,111 @@
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestElectronicPending(AccountTestInvoicingCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.provider = cls.env.ref("payment.payment_provider_adyen").sudo()
+        cls.payment_method = cls.provider.with_context(active_test=False).payment_method_ids[:1]
+
+    def _create_invoice(self):
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.partner_a.id,
+                "invoice_date": "2026-08-10",
+                "invoice_line_ids": [
+                    (0, 0, {"name": "test", "quantity": 1, "price_unit": 1000.0, "tax_ids": []}),
+                ],
+            }
+        )
+        invoice.action_post()
+        return invoice
+
+    def _create_transaction(self, invoice, state="pending"):
+        transaction = (
+            self.env["payment.transaction"]
+            .sudo()
+            .create(
+                {
+                    "provider_id": self.provider.id,
+                    "payment_method_id": self.payment_method.id,
+                    "partner_id": invoice.partner_id.id,
+                    "amount": invoice.amount_total,
+                    "currency_id": invoice.currency_id.id,
+                    "reference": "test-%s" % invoice.id,
+                    "operation": "online_redirect",
+                    "invoice_ids": [(6, 0, invoice.ids)],
+                }
+            )
+        )
+        transaction.state = state
+        invoice.invalidate_recordset()
+        return transaction
+
+    def test_01_pending_transaction_keeps_invoice_payable(self):
+        """An invoice with a pending online transaction must still be payable by hand."""
+        invoice = self._create_invoice()
+        self._create_transaction(invoice)
+        # the payment state is not overridden, so the "Pay" button and the outstanding
+        # widget of the invoice form keep working
+        self.assertEqual(invoice.payment_state, "not_paid")
+        self.assertEqual(invoice.status_in_payment, "electronic_pending")
+        self.assertTrue(invoice.has_pending_transaction)
+        # but the invoice is not offered for payment on the portal, to avoid paying it twice
+        self.assertFalse(invoice._has_to_be_paid())
+
+    def test_02_register_payment_on_pending_transaction(self):
+        """Registering the payment by hand while the transaction is pending pays the invoice."""
+        invoice = self._create_invoice()
+        self._create_transaction(invoice)
+        # both entry points of the "Pay" button ask for confirmation first: the core one and the
+        # one some modules bind the button to directly
+        for method in ("action_register_payment", "action_force_register_payment"):
+            action = getattr(invoice, method)()
+            self.assertEqual(action["res_model"], "electronic.payment.pending.confirm", method)
+        wizard = self.env["electronic.payment.pending.confirm"].create({"move_ids": invoice.ids})
+        messages_before = len(invoice.message_ids)
+        action = wizard.action_confirm()
+        # confirming leaves a note in the chatter and opens the payment wizard
+        self.assertEqual(action["res_model"], "account.payment.register")
+        self.assertEqual(len(invoice.message_ids), messages_before + 1)
+        self.env["account.payment.register"].with_context(active_model="account.move", active_ids=invoice.ids).create(
+            {}
+        ).action_create_payments()
+        invoice.invalidate_recordset()
+        # 'in_payment' when the payment journal has an outstanding account set, 'paid' otherwise
+        self.assertIn(invoice.payment_state, ("paid", "in_payment"))
+        self.assertEqual(invoice.amount_residual, 0.0)
+
+    def test_03_authorized_transaction(self):
+        """An authorized transaction is also considered on course."""
+        invoice = self._create_invoice()
+        transaction = self._create_transaction(invoice)
+        # bypass the ORM: the demo providers do not support manual capture
+        self.env.cr.execute("UPDATE payment_transaction SET state = 'authorized' WHERE id = %s", (transaction.id,))
+        transaction.invalidate_recordset()
+        invoice.invalidate_recordset()
+        self.assertTrue(invoice.has_pending_transaction)
+        self.assertEqual(invoice.status_in_payment, "electronic_pending")
+        self.assertFalse(invoice._has_to_be_paid())
+
+    def test_04_cancelled_transaction_releases_the_invoice(self):
+        """A cancelled or expired transaction leaves no trace on the invoice."""
+        invoice = self._create_invoice()
+        transaction = self._create_transaction(invoice)
+        transaction.state = "cancel"
+        invoice.invalidate_recordset()
+        self.assertFalse(invoice.has_pending_transaction)
+        self.assertEqual(invoice.payment_state, "not_paid")
+        self.assertNotEqual(invoice.status_in_payment, "electronic_pending")
+        self.assertTrue(invoice._has_to_be_paid())
+
+    def test_05_no_warning_without_pending_transaction(self):
+        """Without an electronic payment on course, the "Pay" button goes straight to the wizard."""
+        invoice = self._create_invoice()
+        for method in ("action_register_payment", "action_force_register_payment"):
+            action = getattr(invoice, method)()
+            self.assertEqual(action["res_model"], "account.payment.register", method)

--- a/payment_retry/wizards/__init__.py
+++ b/payment_retry/wizards/__init__.py
@@ -1,1 +1,2 @@
 from . import payment_transaction_retry
+from . import electronic_payment_pending_confirm

--- a/payment_retry/wizards/electronic_payment_pending_confirm.py
+++ b/payment_retry/wizards/electronic_payment_pending_confirm.py
@@ -1,0 +1,20 @@
+from odoo import _, fields, models
+
+
+class ElectronicPaymentPendingConfirm(models.TransientModel):
+    _name = "electronic.payment.pending.confirm"
+    _description = "Confirm a manual payment while an electronic payment is on course"
+
+    move_ids = fields.Many2many("account.move", required=True)
+
+    def action_confirm(self):
+        self.ensure_one()
+        for move in self.move_ids:
+            move.message_post(
+                body=_(
+                    "The payment is being registered manually while the electronic payment %s is still on course.",
+                    ", ".join(move._get_pending_transactions().mapped("reference")),
+                ),
+                subtype_xmlid="mail.mt_note",
+            )
+        return self.move_ids.with_context(skip_electronic_pending_check=True).action_force_register_payment()

--- a/payment_retry/wizards/electronic_payment_pending_confirm.xml
+++ b/payment_retry/wizards/electronic_payment_pending_confirm.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="electronic_payment_pending_confirm_view_form" model="ir.ui.view">
+        <field name="name">electronic.payment.pending.confirm.view.form</field>
+        <field name="model">electronic.payment.pending.confirm</field>
+        <field name="arch" type="xml">
+            <form string="Electronic payment on course">
+                <field name="move_ids" invisible="1"/>
+                <div class="alert alert-warning mb-0" role="alert">
+                    <p class="mb-0">
+                        There is an electronic payment on course for this invoice. If the customer ends up
+                        paying it online, that payment will be registered too and the invoice will be paid twice.
+                    </p>
+                </div>
+                <footer>
+                    <button name="action_confirm" string="Register payment anyway" type="object" class="btn-primary"/>
+                    <button string="Discard" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/125617

The module was forcing an `electronic_pending` value on `account.move.payment_state` while a transaction was pending. That is the field the core checks to allow paying an invoice, so the "Register Payment" button and the outstanding credits widget disappeared and the invoice could not be reconciled by hand when the customer paid the open request by transfer.

The payment state is now left untouched: the electronic payment is exposed on `status_in_payment` and on a new `has_pending_transaction` field, read with `sudo()` because `payment.transaction` is only readable by settings users. Registering the payment by hand now asks for confirmation and logs a note, since paying it twice is possible if the customer also pays online. A `pre-migration` fixes the invoices already stamped with the removed value.

Also fixes `_has_to_be_paid`, which tested `tx.state in ("electronic_pending")` without a comma — a substring check that worked for `pending` and failed for `authorized`.

Tests: `payment_retry/tests/test_electronic_pending.py` (new, the module had none) — 5 cases covering pending, authorized and cancelled transactions plus the confirmation flow. They fail on `19.0` without this change.
