### PR TITLE
[FIX] account_cashbox: only auto-assign sessions operable for the payment

### DIFF
--- a/account_cashbox/i18n/es.po
+++ b/account_cashbox/i18n/es.po
@@ -776,9 +776,13 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_cashbox/models/account_payment.py:0
 msgid ""
-"Your user is required to use a payment session for each payment,\n"
-"                        but no default cashbox is assigned or no session is open for the user."
+"Your user is required to use a payment session for each payment, but there "
+"is no open session for the payment journal and company (or the default "
+"cashbox does not manage them)."
 msgstr ""
+"Su usuario debe utilizar una sesión de caja en cada pago, pero no hay "
+"ninguna sesión de caja abierta para el diario y la compañía de este pago (o "
+"la caja por defecto de su usuario no los maneja)."
 
 #. module: account_cashbox
 #: model:ir.model.fields,field_description:account_cashbox.field_account_cashbox_session__require_cash_control

--- a/account_cashbox/models/account_payment.py
+++ b/account_cashbox/models/account_payment.py
@@ -29,18 +29,24 @@ class AccountPayment(models.Model):
 
     def _compute_cashbox_session_id(self):
         for rec in self:
-            session_ids = self.env["account.cashbox.session"].search(
-                [
-                    ("state", "=", "opened"),
-                    "|",
-                    ("user_ids", "=", self.env.uid),
-                    ("user_ids", "=", False),
-                ]
-            )
+            # solo sesiones operables para este pago: mismo criterio que el dominio de la vista,
+            # la compañia del pago y una caja que maneje el diario del pago
+            domain = [
+                ("state", "=", "opened"),
+                ("company_id", "=", rec.company_id.id),
+                "|",
+                ("user_ids", "=", self.env.uid),
+                ("user_ids", "=", False),
+            ]
+            if rec.journal_id:
+                domain += [("cashbox_id.journal_ids", "in", rec.journal_id.ids)]
+            session_ids = self.env["account.cashbox.session"].search(domain)
             if len(session_ids) == 1:
                 rec.cashbox_session_id = session_ids.id
             elif len(session_ids) > 1:
-                rec.cashbox_session_id = self.env.user.default_cashbox_id.current_session_id
+                # la caja por defecto del usuario sirve solo si su sesion esta entre las operables
+                default_session = self.env.user.default_cashbox_id.current_session_id
+                rec.cashbox_session_id = default_session if default_session in session_ids else False
             else:
                 rec.cashbox_session_id = False
 
@@ -73,8 +79,8 @@ class AccountPayment(models.Model):
             ):
                 raise UserError(
                     _(
-                        """Your user is required to use a payment session for each payment,
-                        but no default cashbox is assigned or no session is open for the user."""
+                        "Your user is required to use a payment session for each payment, but there is no open "
+                        "session for the payment journal and company (or the default cashbox does not manage them)."
                     )
                 )
 

--- a/account_cashbox/wizards/account_payment_register.py
+++ b/account_cashbox/wizards/account_payment_register.py
@@ -30,9 +30,18 @@ class AccountPaymentRegister(models.TransientModel):
 
     def _compute_cashbox_session_id(self):
         for rec in self:
-            session_ids = self.env["account.cashbox.session"].search(
-                [("state", "=", "opened"), "|", ("user_ids", "=", self.env.uid), ("user_ids", "=", False)]
-            )
+            # mismo criterio que en account.payment: la sesion tiene que ser de la compañia del
+            # pago y de una caja que maneje el diario
+            domain = [
+                ("state", "=", "opened"),
+                ("company_id", "=", rec.company_id.id),
+                "|",
+                ("user_ids", "=", self.env.uid),
+                ("user_ids", "=", False),
+            ]
+            if rec.journal_id:
+                domain += [("cashbox_id.journal_ids", "in", rec.journal_id.ids)]
+            session_ids = self.env["account.cashbox.session"].search(domain)
             if len(session_ids) == 1:
                 rec.cashbox_session_id = session_ids.id
             else:


### PR DESCRIPTION
## Qué pasaba

La asignación automática de `cashbox_session_id` podía elegir una sesión de **otra compañía, otra caja y otro diario** que el propio pago, y el usuario no podía corregirla (el campo es `readonly=True` en `account.payment`, así que siempre lo decide el sistema).

El universo de candidatas eran todas las sesiones abiertas donde el usuario está (o que no restringen usuarios), sin mirar compañía ni diario. Y con más de una candidata, se tomaba `env.user.default_cashbox_id.current_session_id` — la sesión no cerrada más reciente de la caja por defecto, de cualquier usuario — sin verificar que estuviera entre las candidatas.

Efecto: el pago queda en una sesión que no incluye su diario, no mueve ningún saldo de esa sesión (no salta al cerrarla) y aparece igual en la lista de pagos de otra compañía. Se llega por cualquier registración que no pase por el formulario (el wizard de registro de pagos, entre otras).

## Qué cambia

- `account.payment._compute_cashbox_session_id`: las candidatas se restringen a la compañía del pago y a cajas que manejen el diario del pago — el mismo criterio que ya usaba el dominio del campo en la vista de formulario, donde hasta ahora era la única defensa. La sesión de la caja por defecto del usuario se usa solo si está entre esas candidatas.
- `account.payment.register._compute_cashbox_session_id`: mismo filtro de dominio. Es necesario porque el wizard escribe `cashbox_session_id` en los vals del pago (`_create_payment_vals_from_wizard`), así que el compute del pago no vuelve a revisarlo. Ahí no hay fallback a la caja por defecto, por lo que solo cambia el dominio.
- Cuando no hay candidata aplicable el campo queda vacío, así que `action_post` levanta el `UserError` que ya existía. Se ajusta su texto: antes decía que no había caja por defecto asignada o sesión abierta para el usuario; ahora dice que no hay sesión abierta para el diario y la compañía del pago.
- Ese mensaje era un literal `"""..."""` que metía un salto de línea y su indentación dentro del término de traducción (y del texto que veía el usuario): pasa a dos literales adyacentes. Se actualiza su entrada en `i18n/es.po`, que además estaba sin traducir.

Sobre la compañía, el criterio es igualdad y no jerarquía: en esta versión `account.cashbox` no declara `_check_company_domain = check_company_domain_parent_of`, sus `journal_ids` van con `check_company=True`, y el dominio de la vista compara `company_id` por igual. Un criterio con `parent_of` acá sería más laxo que el resto del módulo y habilitaría por automatismo una sesión que el usuario no puede elegir a mano.

El filtro por diario se agrega con guard (`if rec.journal_id`): si el compute corre antes de que el diario esté resuelto, el dominio queda como el actual y no más restrictivo.

## Cambio de comportamiento

Donde antes el pago se registraba con una sesión ajena, ahora **no se registra** y se pide abrir la sesión que corresponde al diario. Los pagos ya registrados no se tocan.

## Fuera de alcance

- `res.users.default_cashbox_id` es un m2o único: un usuario multi-compañía arrastra la misma caja por defecto en todas. Con este fix deja de causar una asignación incorrecta (la sesión se descarta), pero sigue sin haber caja por defecto por compañía.
- `readonly=False` en el campo para que el usuario pueda corregir en borrador, y validación en `action_post` de las sesiones seteadas por otros caminos (contexto, import de pagos, transferencias internas).
- El resto del `es.po` (23 de 134 entradas sin traducir, y un typo en el aviso de balance final real) queda como está: solo se toca el término que cambia este PR.
- Tests: van en la rama de 19.0, donde el módulo ya tiene suite. Ojo al portear: en 19.0 el universo de candidatas ya sale de `account.cashbox.session._get_available_domain()`, que sí adopta la jerarquía de compañías y la cláusula de sucursales — ahí el criterio de compañía queda como está y solo corresponde sumar el diario y validar el fallback.

## Cómo testear

Usuario con "Requiere Sesión de Caja", dos o más sesiones propias abiertas y caja por defecto de otra compañía / otra caja que el diario del pago. Registrar un pago por un camino que no pase por el formulario (el wizard de registro de pagos es el más directo).

- Antes: el pago se registra con la sesión más reciente de la caja por defecto.
- Después: `UserError` pidiendo una sesión abierta para el diario y la compañía del pago, en español.
- Con una sesión abierta en una caja que sí maneja el diario del pago: se asigna esa, igual que antes.
- Con caja por defecto cuya sesión abierta sí corresponde al diario y la compañía: se sigue asignando (el caso de sesiones concurrentes no se rompe).