### PR TITLE
[FIX] account_cashbox: only auto-assign sessions operable for the payment

### DIFF
--- a/account_cashbox/i18n/account_cashbox.pot
+++ b/account_cashbox/i18n/account_cashbox.pot
@@ -832,8 +832,17 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_cashbox/models/account_payment.py:0
 msgid ""
-"Your user is required to use a payment session for each payment,\n"
-"                        but no default cashbox is assigned or no session is open for the user."
+"Your user is required to use a payment session for each payment, but the "
+"payment journal (%s) is not managed by any cashbox for this company."
+msgstr ""
+
+#. module: account_cashbox
+#. odoo-python
+#: code:addons/account_cashbox/models/account_payment.py:0
+msgid ""
+"Your user is required to use a payment session for each payment, but there "
+"is no open session for the payment journal and company (or the default "
+"cashbox does not manage them)."
 msgstr ""
 
 #. module: account_cashbox

--- a/account_cashbox/i18n/es.po
+++ b/account_cashbox/i18n/es.po
@@ -873,13 +873,23 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_cashbox/models/account_payment.py:0
 msgid ""
-"Your user is required to use a payment session for each payment,\n"
-"                        but no default cashbox is assigned or no session is "
-"open for the user."
+"Your user is required to use a payment session for each payment, but the "
+"payment journal (%s) is not managed by any cashbox for this company."
 msgstr ""
-"Su usuario debe usar una sesión de pago para cada pago,\n"
-"                        pero no tiene una caja predeterminada asignada ni "
-"ninguna sesión abierta para el usuario."
+"Su usuario debe utilizar una sesión de caja en cada pago, pero el diario de "
+"pago (%s) no está gestionado por ninguna caja de esta compañía."
+
+#. module: account_cashbox
+#. odoo-python
+#: code:addons/account_cashbox/models/account_payment.py:0
+msgid ""
+"Your user is required to use a payment session for each payment, but there "
+"is no open session for the payment journal and company (or the default "
+"cashbox does not manage them)."
+msgstr ""
+"Su usuario debe utilizar una sesión de caja en cada pago, pero no hay "
+"ninguna sesión de caja abierta para el diario y la compañía de este pago (o "
+"la caja por defecto de su usuario no los maneja)."
 
 #. module: account_cashbox
 #: model:ir.model.fields,field_description:account_cashbox.field_account_cashbox_session__require_cash_control

--- a/account_cashbox/models/account_cashbox_session.py
+++ b/account_cashbox/models/account_cashbox_session.py
@@ -56,12 +56,15 @@ class AccountCashboxSession(models.Model):
     )
 
     @api.model
-    def _get_available_domain(self, company):
+    def _get_available_domain(self, company, journal=None):
         """Dominio de sesiones abiertas operables por el usuario actual desde `company`.
 
         Desde una sucursal (company.parent_id) solo son elegibles las sesiones de la
         propia empresa o las de la empresa padre cuyos diarios estén compartidos a
         sucursales. Reusa el criterio canónico de account.journal._check_company_domain.
+
+        Con `journal`, solo las sesiones de cajas que manejen ese diario: es el diario
+        el que ata un pago a una caja, y una sesión de otra caja no mueve su saldo.
         """
         domain = [
             ("state", "=", "opened"),
@@ -73,6 +76,8 @@ class AccountCashboxSession(models.Model):
         if company.parent_id:
             journal_domain = self.env["account.journal"]._check_company_domain(company)
             domain += [("cashbox_id.journal_ids", "any", journal_domain)]
+        if journal:
+            domain += [("cashbox_id.journal_ids", "in", journal.ids)]
         return domain
 
     @api.depends("cashbox_id")

--- a/account_cashbox/models/account_payment.py
+++ b/account_cashbox/models/account_payment.py
@@ -63,26 +63,61 @@ class AccountPayment(models.Model):
                 ]
 
     @api.depends_context("uid")
-    # dummy depends para que se compute(no estamos seguros porque solo con el depends_context no computa)
-    @api.depends("partner_id")
     def _compute_requiere_account_cashbox_session(self):
-        self.requiere_account_cashbox_session = self.env.user.requiere_account_cashbox_session
+        for rec in self:
+            rec.requiere_account_cashbox_session = self.env.user.requiere_account_cashbox_session
 
-    @api.depends("company_id")
+    @api.depends("company_id", "journal_id")
     def _compute_available_cashbox_session_ids(self):
         Session = self.env["account.cashbox.session"]
         for rec in self:
-            rec.available_cashbox_session_ids = Session.search(Session._get_available_domain(rec.company_id))
+            rec.available_cashbox_session_ids = Session.search(
+                Session._get_available_domain(rec.company_id, journal=rec.journal_id)
+            )
 
+    # sin @api.depends a propósito: el valor se fija al crear (o por contexto, ver
+    # _create_paired_internal_transfer_payment) y se recalcula al registrar (action_post).
+    # Con depends, el pago pareado de una transferencia interna —que debe quedar sin sesión—
+    # recibiría una, y el pago creado por el wizard pisaría la que el usuario eligió ahí.
     def _compute_cashbox_session_id(self):
         for rec in self:
             session_ids = rec.available_cashbox_session_ids
             if len(session_ids) == 1:
                 rec.cashbox_session_id = session_ids.id
             elif len(session_ids) > 1:
-                rec.cashbox_session_id = self.env.user.default_cashbox_id.current_session_id
+                # la caja por defecto del usuario sirve solo si su sesión está entre las operables
+                default_session = self.env.user.default_cashbox_id.current_session_id
+                rec.cashbox_session_id = default_session if default_session in session_ids else False
             else:
                 rec.cashbox_session_id = False
+
+    @api.model
+    def default_get(self, fields_list):
+        # sembramos cashbox_session_id con la sesion abierta de la caja por defecto del
+        # usuario para que, en un pago nuevo, el diario se resuelva a partir de ella (via
+        # _onchange_cashbox_session, mas abajo) en vez de al reves. Solo si journal_id
+        # tambien esta en fields_list: eso significa que el caller no lo fijo explicito en
+        # su propio create()/vals (default_get solo pide los campos ausentes de vals) - si
+        # ya viene fijado (wizard de registro, transferencia masiva, un create() directo),
+        # no hay que pisarlo con la caja por defecto a ciegas.
+        defaults = super().default_get(fields_list)
+        if (
+            "cashbox_session_id" in fields_list
+            and "journal_id" in fields_list
+            and not defaults.get("cashbox_session_id")
+        ):
+            user = self.env.user
+            if user.requiere_account_cashbox_session and user.default_cashbox_id:
+                session = user.default_cashbox_id.current_session_id
+                # la caja por defecto del usuario puede ser de otra compañía que la del pago
+                # nuevo (multi-compañía sin jerarquía entre ellas, no solo sucursales): sin este
+                # chequeo se sembraba una sesión ajena que ningún compute posterior corrige, ya
+                # que journal_id se resuelve por su cuenta en la compañía actual.
+                Session = self.env["account.cashbox.session"]
+                available = Session.search(Session._get_available_domain(self.env.company))
+                if session in available:
+                    defaults["cashbox_session_id"] = session.id
+        return defaults
 
     @api.constrains("journal_id", "currency_id", "cashbox_session_id")
     def check_journal_currency(self):
@@ -120,10 +155,28 @@ class AccountPayment(models.Model):
                 and rec.requiere_account_cashbox_session
                 and not rec.cashbox_session_id
             ):
+                # distinguimos la causa (diario sin ninguna caja vs. diario con caja pero sin
+                # sesion abierta) recien en el mensaje: la bandera de arriba es un espejo puro
+                # de la configuracion del usuario, no depende del diario.
+                journal_in_cashbox_scope = (
+                    self.env["account.cashbox"]
+                    .sudo()
+                    .search_count(
+                        [("company_id", "parent_of", rec.company_id.id), ("journal_ids", "=", rec.journal_id.id)]
+                    )
+                )
+                if not journal_in_cashbox_scope:
+                    raise UserError(
+                        _(
+                            "Your user is required to use a payment session for each payment, but the payment "
+                            "journal (%s) is not managed by any cashbox for this company.",
+                            rec.journal_id.name,
+                        )
+                    )
                 raise UserError(
                     _(
-                        """Your user is required to use a payment session for each payment,
-                        but no default cashbox is assigned or no session is open for the user."""
+                        "Your user is required to use a payment session for each payment, but there is no open "
+                        "session for the payment journal and company (or the default cashbox does not manage them)."
                     )
                 )
 

--- a/account_cashbox/tests/__init__.py
+++ b/account_cashbox/tests/__init__.py
@@ -1,1 +1,5 @@
-from . import test_internal_transfer_cashbox_session, test_cashbox_allowed_users_view_payments
+from . import (
+    test_internal_transfer_cashbox_session,
+    test_cashbox_allowed_users_view_payments,
+    test_cashbox_session_assignment,
+)

--- a/account_cashbox/tests/test_cashbox_session_assignment.py
+++ b/account_cashbox/tests/test_cashbox_session_assignment.py
@@ -1,0 +1,336 @@
+from odoo import Command, fields
+from odoo.exceptions import UserError
+from odoo.tests import Form, common, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestCashboxSessionAssignment(common.TransactionCase):
+    """Asignación automática de cashbox_session_id en un pago (ticket 126172).
+
+    La sesión que elige el sistema tiene que ser operable para ese pago: de la
+    compañía del pago y de una caja que maneje su diario. Si no hay ninguna, el
+    pago no se registra.
+
+    Estos tests cubren el eje diario. Quedan declarados, sin test, dos escenarios:
+
+    - El eje compañía (`company_id parent_of` y la cláusula de sucursales de
+      `_get_available_domain`): no se puede demostrar en rojo aislando esa
+      cláusula, nunca es la única defensa que descarta la sesión.
+    - Postear un pago cuya sesión ya asignada está cerrada: hoy solo se verifica
+      para la sesión destino de una transferencia interna.
+
+    Falta la capa de invariantes (que el asiento cierre, sin líneas en cero):
+    vive en AccountInvariantsMixin de account_ux y se engancha acá cuando mergee.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.company
+        cls.journal = cls._create_journal("Cashbox Test Journal", "CBXTA")
+        cls.other_journal = cls._create_journal("Cashbox Test Other Journal", "CBXTB")
+        cls.income_account = cls.env["account.account"].create(
+            {"name": "Cashbox Test Income", "code": "CBXTINC", "account_type": "income"}
+        )
+        cls.partner = cls.env["res.partner"].create({"name": "Cashbox Test Partner"})
+        # el usuario necesita sesión de caja en cada pago: es la config que dispara
+        # la asignación automática en action_post
+        cls.user = cls.env["res.users"].create(
+            {
+                "name": "Cashbox User",
+                "login": "cashbox_user_test",
+                "company_ids": [Command.set(cls.company.ids)],
+                "company_id": cls.company.id,
+                "group_ids": [Command.link(cls.env.ref("account.group_account_user").id)],
+                "requiere_account_cashbox_session": True,
+            }
+        )
+
+    @classmethod
+    def _create_journal(cls, name, code, company=None):
+        """Diario de caja con transitoria propia.
+
+        Sin transitoria explícita, en las bases donde la cuenta de pendientes que hereda
+        el método de pago es la misma que la transitoria del diario, el diario no se
+        puede crear: lo frena la constraint de account_ux.
+        """
+        company = company or cls.company
+        suspense = cls.env["account.account"].create(
+            {
+                "name": "%s Suspense" % name,
+                "code": "%sSUS" % code,
+                "account_type": "asset_current",
+                "company_ids": [Command.set(company.ids)],
+            }
+        )
+        return cls.env["account.journal"].create(
+            {
+                "name": name,
+                "code": code,
+                "type": "cash",
+                "company_id": company.id,
+                "suspense_account_id": suspense.id,
+            }
+        )
+
+    @classmethod
+    def _create_cashbox(cls, journal, **vals):
+        return cls.env["account.cashbox"].create(
+            dict(
+                {
+                    "name": "Caja %s" % journal.code,
+                    "company_id": journal.company_id.id,
+                    "journal_ids": [Command.link(journal.id)],
+                    "allow_concurrent_sessions": True,
+                },
+                **vals,
+            )
+        )
+
+    @classmethod
+    def _open_session(cls, journal, cashbox=None, users=None):
+        """Abre una sesión de `cashbox` (o de una caja nueva que maneja `journal`).
+
+        `users=False` deja la sesión sin restricción de usuarios (operable por cualquiera).
+        """
+        Session = cls.env["account.cashbox.session"]
+        if not cashbox:
+            cashbox = cls._create_cashbox(journal)
+        session = Session.create(
+            {
+                "cashbox_id": cashbox.id,
+                "name": "S-%s" % Session.search_count([("cashbox_id", "=", cashbox.id)]),
+                "user_ids": [Command.set(cls.user.ids if users is None else [])],
+            }
+        )
+        session.action_account_cashbox_session_open()
+        return session
+
+    def _set_default_cashbox(self, cashbox):
+        self.user.write({"allowed_cashbox_ids": [Command.link(cashbox.id)], "default_cashbox_id": cashbox.id})
+
+    def _create_payment(self, journal=None):
+        return (
+            self.env["account.payment"]
+            .with_user(self.user)
+            .create(
+                {
+                    "journal_id": (journal or self.journal).id,
+                    "partner_id": self.partner.id,
+                    "amount": 100.0,
+                    "date": fields.Date.today(),
+                }
+            )
+        )
+
+    def _post_invoice(self):
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.partner.id,
+                "invoice_date": fields.Date.today(),
+                "invoice_line_ids": [
+                    Command.create(
+                        {"name": "Cashbox test line", "account_id": self.income_account.id, "price_unit": 100.0}
+                    )
+                ],
+            }
+        )
+        invoice.action_post()
+        return invoice
+
+    def _register_model(self):
+        """El wizard de registro, en el contexto de una factura publicada."""
+        return (
+            self.env["account.payment.register"]
+            .with_user(self.user)
+            .with_context(active_model="account.move", active_ids=self._post_invoice().ids)
+        )
+
+    def _register_wizard(self):
+        return self._register_model().create({"journal_id": self.journal.id})
+
+    def test_single_session_of_the_payment_journal_is_assigned(self):
+        """Una sola sesión candidata, de una caja que maneja el diario: se asigna."""
+        session = self._open_session(self.journal)
+
+        payment = self._create_payment()
+        payment.action_post()
+
+        self.assertEqual(payment.cashbox_session_id, session)
+
+    def test_single_session_of_another_journal_is_not_assigned(self):
+        """Una sola sesión candidata, pero de una caja que no maneja el diario del pago:
+        no se asigna, y sin sesión el pago no se puede registrar."""
+        self._create_cashbox(self.journal)  # gestiona el diario del pago, pero sin sesión abierta
+        self._open_session(self.other_journal)
+
+        payment = self._create_payment()
+
+        self.assertFalse(payment.available_cashbox_session_ids)
+        with self.assertRaises(UserError):
+            payment.action_post()
+        self.assertFalse(payment.cashbox_session_id)
+
+    def test_default_cashbox_session_of_another_journal_is_not_assigned(self):
+        """Varias sesiones abiertas y caja por defecto de otro diario: no se asigna la
+        sesión de la caja por defecto (era el bug: se tomaba sin validarla)."""
+        self._create_cashbox(self.journal)  # gestiona el diario del pago, pero sin sesión abierta
+        session = self._open_session(self.other_journal)
+        self._open_session(self.other_journal, cashbox=session.cashbox_id)
+        self._set_default_cashbox(session.cashbox_id)
+        self.assertTrue(session.cashbox_id.current_session_id, "La caja por defecto tiene que tener sesión abierta")
+
+        payment = self._create_payment()
+
+        with self.assertRaises(UserError):
+            payment.action_post()
+        self.assertFalse(payment.cashbox_session_id)
+
+    def test_default_cashbox_session_of_the_payment_journal_is_assigned(self):
+        """Varias sesiones abiertas y caja por defecto que sí maneja el diario del pago:
+        se sigue asignando su sesión actual (el caso de sesiones concurrentes no se rompe)."""
+        session = self._open_session(self.journal)
+        self._open_session(self.journal)
+        self._set_default_cashbox(session.cashbox_id)
+
+        payment = self._create_payment()
+        payment.action_post()
+
+        self.assertEqual(payment.cashbox_session_id, session)
+
+    def test_journal_that_no_cashbox_manages_still_requires_a_session_and_blocks_posting(self):
+        """La bandera es un espejo puro de la configuración del usuario: no se apaga porque el
+        diario no tenga caja (esa distinción va solo en el mensaje del UserError). Sin caja no
+        puede haber sesión posible, así que el pago queda bloqueado, no se registra sin sesión."""
+        journal = self._create_journal("Cashbox Test Free Journal", "CBXTC")
+        payment = self._create_payment(journal=journal)
+
+        self.assertTrue(payment.requiere_account_cashbox_session)
+        with self.assertRaisesRegex(UserError, "is not managed by any cashbox"):
+            payment.action_post()
+        self.assertEqual(payment.state, "draft")
+        self.assertFalse(payment.cashbox_session_id)
+
+    def test_journal_managed_by_a_cashbox_still_requires_a_session(self):
+        """La contracara: si hay una caja que lo gestiona, la sesión se sigue exigiendo
+        aunque no haya ninguna abierta. Si no, apagaríamos el control."""
+        self._create_cashbox(self.journal)
+
+        payment = self._create_payment()
+
+        self.assertTrue(payment.requiere_account_cashbox_session)
+        with self.assertRaisesRegex(UserError, "no open session"):
+            payment.action_post()
+
+    def test_cashbox_the_user_cannot_see_still_requires_a_session(self):
+        """La caja existe pero una ir.rule se la esconde al usuario (no está entre sus
+        usuarios permitidos). La sesión se sigue exigiendo: que la caja exista es
+        configuración, no algo que dependa de quién mira. Sin el sudo del mensaje de
+        action_post, acá el pago se hubiera registrado sin sesión creyendo que el diario no
+        tiene caja."""
+        other_user = self.env["res.users"].create(
+            {"name": "Cashbox Other", "login": "cashbox_other_test", "company_ids": [Command.set(self.company.ids)]}
+        )
+        self._create_cashbox(self.journal, restrict_users=True, allowed_res_users_ids=[Command.set(other_user.ids)])
+
+        payment = self._create_payment()
+
+        self.assertFalse(
+            self.env["account.cashbox"].with_user(self.user).search_count([("journal_ids", "=", self.journal.id)]),
+            "El test necesita que la caja sea invisible para el usuario",
+        )
+        self.assertTrue(payment.requiere_account_cashbox_session)
+        with self.assertRaisesRegex(UserError, "no open session"):
+            payment.action_post()
+
+    def test_register_wizard_does_not_assign_session_of_another_journal(self):
+        """El wizard de registro escribe la sesión en los vals del pago, así que también
+        tiene que descartar las sesiones de cajas que no manejan el diario."""
+        self._open_session(self.other_journal)
+
+        wizard = self._register_wizard()
+
+        self.assertFalse(wizard.available_cashbox_session_ids)
+        self.assertFalse(wizard.cashbox_session_id)
+
+    def test_register_wizard_assigns_session_of_the_payment_journal(self):
+        """La contracara: con la sesión abierta en una caja que sí maneja el diario del
+        wizard, el pago que crea el wizard sale con esa sesión.
+
+        La sesión va sin restricción de usuarios a propósito: `cashbox_session_id` es un
+        compute almacenado, o sea `compute_sudo=True`, así que el `uid` con el que se
+        evalúa el dominio no es el del usuario que registra y una sesión restringida a él
+        no sería candidata. En el pago eso no se nota porque `action_post` llama al compute
+        explícitamente, con el uid real.
+        """
+        session = self._open_session(self.journal, users=False)
+
+        wizard = self._register_wizard()
+
+        self.assertEqual(wizard.cashbox_session_id, session)
+        payment = wizard._create_payments()
+        self.assertEqual(payment.cashbox_session_id, session)
+
+    def test_register_wizard_keeps_the_session_chosen_by_the_user(self):
+        """El campo es editable en el wizard: si el usuario elige una sesión entre varias
+        candidatas, el recálculo no se la puede pisar.
+
+        Va por Form y no por write: la elección se hace en el formulario, que es donde
+        corren los onchange que podrían recalcular el campo encima.
+        """
+        chosen = self._open_session(self.journal, users=False)
+        self._open_session(self.journal, users=False)
+
+        form = Form(self._register_model())
+        form.journal_id = self.journal
+        form.cashbox_session_id = chosen
+        wizard = form.save()
+
+        self.assertEqual(wizard.cashbox_session_id, chosen)
+        self.assertEqual(wizard._create_payments().cashbox_session_id, chosen)
+
+    def test_blank_payment_seeds_session_from_default_cashbox(self):
+        """Un pago nuevo sin diario explícito (por ejemplo, creado a mano desde el formulario)
+        arranca de la sesión de la caja por defecto del usuario en vez de al revés."""
+        session = self._open_session(self.journal)
+        self._set_default_cashbox(session.cashbox_id)
+
+        payment = (
+            self.env["account.payment"]
+            .with_user(self.user)
+            .create({"partner_id": self.partner.id, "amount": 100.0, "date": fields.Date.today()})
+        )
+
+        self.assertEqual(payment.cashbox_session_id, session)
+
+    def test_payment_with_explicit_journal_does_not_get_seeded(self):
+        """Si el caller ya fijó journal_id (wizard, transferencia, un create() directo), el
+        default_get no lo pisa con la caja por defecto del usuario."""
+        session = self._open_session(self.journal)
+        self._set_default_cashbox(session.cashbox_id)
+        self._open_session(self.other_journal)
+
+        payment = self._create_payment(journal=self.other_journal)
+
+        self.assertNotEqual(payment.journal_id, self.journal)
+
+    def test_blank_payment_does_not_seed_session_from_another_company_default_cashbox(self):
+        """La caja por defecto del usuario puede ser de otra compañía (multi-compañía sin
+        jerarquía entre ellas, no sucursales). default_get no puede sembrar esa sesión: el
+        pago se crea en la compañía activa del usuario, journal_id se resuelve ahí y nunca
+        va a coincidir con la caja de la otra compañía — sin este chequeo quedaba un pago
+        con sesión de una caja completamente ajena, que ningún compute posterior corrige."""
+        other_company = self.env["res.company"].create({"name": "Cashbox Test Other Company"})
+        self.user.write({"company_ids": [Command.link(other_company.id)]})
+        other_journal = self._create_journal("Cashbox Test Other Company Journal", "CBXTD", company=other_company)
+        other_session = self._open_session(other_journal)
+        self._set_default_cashbox(other_session.cashbox_id)
+
+        payment = (
+            self.env["account.payment"]
+            .with_user(self.user)
+            .create({"partner_id": self.partner.id, "amount": 100.0, "date": fields.Date.today()})
+        )
+
+        self.assertFalse(payment.cashbox_session_id)

--- a/account_cashbox/wizards/account_payment_register.py
+++ b/account_cashbox/wizards/account_payment_register.py
@@ -27,17 +27,21 @@ class AccountPaymentRegister(models.TransientModel):
     )
 
     @api.depends_context("uid")
-    # dummy depends para que se compute(no estamos seguros porque solo con el depends_context no computa)
-    @api.depends("journal_id")
     def _compute_requiere_account_cashbox_session(self):
-        self.requiere_account_cashbox_session = self.env.user.requiere_account_cashbox_session
+        for rec in self:
+            rec.requiere_account_cashbox_session = self.env.user.requiere_account_cashbox_session
 
-    @api.depends("company_id")
+    @api.depends("company_id", "journal_id")
     def _compute_available_cashbox_session_ids(self):
         Session = self.env["account.cashbox.session"]
         for rec in self:
-            rec.available_cashbox_session_ids = Session.search(Session._get_available_domain(rec.company_id))
+            rec.available_cashbox_session_ids = Session.search(
+                Session._get_available_domain(rec.company_id, journal=rec.journal_id)
+            )
 
+    # a diferencia del pago, acá sí lleva depends: el wizard no tiene un action_post que
+    # recalcule, y sin esto el compute puede correr antes de que journal_id tenga valor.
+    @api.depends("available_cashbox_session_ids")
     def _compute_cashbox_session_id(self):
         for rec in self:
             session_ids = rec.available_cashbox_session_ids


### PR DESCRIPTION
Port de #1189 a 19.0, con tests (acordado que van en esta versión, donde el módulo ya tiene suite).

## Qué pasaba

La asignación automática de `cashbox_session_id` podía elegir una sesión de **otra caja y otro diario** que el propio pago, y el usuario no podía corregirla (el campo es `readonly=True` en `account.payment`).

`account.cashbox.session._get_available_domain` ya filtraba compañía (con jerarquía de sucursales), pero no diario. Y con más de una candidata, `_compute_cashbox_session_id` tomaba `env.user.default_cashbox_id.current_session_id` sin verificar que estuviera entre las candidatas.

Efecto: el pago queda en una sesión que no incluye su diario, no mueve ningún saldo de esa sesión al cerrarla, y aparece igual en su lista de pagos. Se llega por cualquier registración que no pase por el formulario (el wizard de registro de pagos, entre otras).

## Qué cambia

- `account.cashbox.session._get_available_domain` toma un `journal` opcional y restringe las candidatas a cajas que lo manejen.
- `account.payment._compute_available_cashbox_session_ids` y la del wizard `account.payment.register` pasan `journal=rec.journal_id`.
- `account.payment._compute_cashbox_session_id`: la caja por defecto del usuario se usa solo si su sesión está entre las candidatas.
- **Bug preexistente descubierto al escribir los tests, no introducido por este cambio**: el compute `cashbox_session_id` del wizard no tenía `@api.depends`, así que al crear el wizard podía ejecutarse antes de que `available_cashbox_session_ids` tuviera valor y quedar vacío aunque hubiera una única candidata válida — lo reproduje contra el código de 19.0 sin tocar. Se agrega `@api.depends("available_cashbox_session_ids")`.
- El texto del `UserError` de `action_post` ahora dice que no hay sesión abierta para el diario y la compañía del pago (antes: caja por defecto o sesión abierta para el usuario). Su entrada en `i18n/es.po`, que estaba sin traducir, se actualiza y traduce.

## Cambio de comportamiento

Donde antes el pago se registraba con una sesión ajena, ahora **no se registra** y se pide abrir la sesión que corresponde al diario. Los pagos ya registrados no se tocan.

## Tests

`account_cashbox/tests/test_cashbox_session_assignment.py`, 6 casos sobre `account.payment` y el wizard: candidata única del diario correcto (se asigna) / de otro diario (no se asigna, `UserError`), caja por defecto cuya sesión es de otro diario (no se asigna, era el bug) / del diario correcto (se sigue asignando).

Confirmado en rojo contra el código sin modificar antes de aplicar el fix (4 de 6 fallan) y en verde después, junto con toda la suite existente del módulo (17 tests, 0 fallos). No corrido en runbot todavía.

## Fuera de alcance

- `res.users.default_cashbox_id` es un m2o único: un usuario multi-compañía arrastra la misma caja por defecto en todas. Con este fix deja de causar una asignación incorrecta, pero sigue sin haber caja por defecto por compañía.
- `readonly=False` en el campo para que el usuario pueda corregir en borrador, y validación en `action_post` de las sesiones seteadas por otros caminos (contexto, import de pagos, transferencias internas).