### PR TITLE
[FIX] l10n_latam_check_ux: order check operations by confirmation

### DIFF
--- a/l10n_latam_check_ux/models/account_payment.py
+++ b/l10n_latam_check_ux/models/account_payment.py
@@ -9,7 +9,7 @@ class AccountPayment(models.Model):
 
     l10n_latam_move_check_ids_operation_date = fields.Datetime(
         string="Operation Date",
-        default=fields.Datetime.now(),
+        default=fields.Datetime.now,
     )
 
     @api.constrains("l10n_latam_move_check_ids_operation_date", "state")
@@ -40,8 +40,31 @@ class AccountPayment(models.Model):
         for rec in self:
             if rec.l10n_latam_check_warning_msg:
                 raise ValidationError("%s" % rec.l10n_latam_check_warning_msg)
-            rec.l10n_latam_move_check_ids_operation_date = rec.create_date if rec.create_date else fields.Datetime.now()
+            rec.l10n_latam_move_check_ids_operation_date = rec._get_check_operation_date()
         super().action_post()
+
+    def _get_check_operation_date(self):
+        """Fecha que deja a este pago al final de la cadena de operaciones de sus cheques.
+
+        El orden de la cadena de un cheque —quien es su "ultima operacion"— sale de
+        ``l10n_latam_move_check_ids_operation_date``, y de ahi dependen el diario actual del cheque
+        (``_compute_current_journal``) y el bloqueo para restablecer un pago a borrador
+        (``action_draft``).
+
+        Anclar ese valor a una fecha suelta ordena mal en los dos sentidos: con la fecha de
+        confirmacion, re-confirmar un pago viejo lo manda al final de la cadena; con la fecha de
+        creacion, un borrador creado antes que el resto queda al principio aunque se confirme
+        ultimo, y ahi el cheque entregado sigue figurando en cartera. Por eso partimos de
+        ``create_date`` pero garantizamos que confirmar nunca deje al pago antes de una operacion
+        ya confirmada del mismo cheque.
+        """
+        self.ensure_one()
+        operation_date = self.create_date or fields.Datetime.now()
+        for check in self.l10n_latam_move_check_ids | self.l10n_latam_new_check_ids:
+            last_operation_date = check._get_last_operation().l10n_latam_move_check_ids_operation_date
+            if last_operation_date:
+                operation_date = max(operation_date, last_operation_date + timedelta(seconds=1))
+        return operation_date
 
     def _create_paired_internal_transfer_payment(self):
         """

--- a/l10n_latam_check_ux/models/l10n_latam_check.py
+++ b/l10n_latam_check_ux/models/l10n_latam_check.py
@@ -72,10 +72,12 @@ class l10nLatamAccountPaymentCheck(models.Model):
     def _get_last_operation(self):
         super()._get_last_operation()
         self.ensure_one()
+        # El desempate por id es necesario: sin el, dos operaciones con la misma fecha quedan en el
+        # orden en que las devolvio el recordset, que no es estable ni significativo.
         return (
             (self.payment_id + self.operation_ids)
             .filtered(lambda x: x.state not in ["draft", "canceled"] and x.l10n_latam_move_check_ids_operation_date)
-            .sorted(key=lambda payment: (payment.l10n_latam_move_check_ids_operation_date))[-1:]
+            .sorted(key=lambda payment: (payment.l10n_latam_move_check_ids_operation_date, payment._origin.id))[-1:]
         )
 
     @api.depends("payment_method_line_id.code", "payment_id.partner_id")

--- a/l10n_latam_check_ux/tests/__init__.py
+++ b/l10n_latam_check_ux/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_check_payment_journal_entry
 from . import test_own_check_automatic_debit
+from . import test_check_operation_order

--- a/l10n_latam_check_ux/tests/test_check_operation_order.py
+++ b/l10n_latam_check_ux/tests/test_check_operation_order.py
@@ -1,0 +1,180 @@
+# © ADHOC SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import Command, fields
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.exceptions import ValidationError
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestCheckOperationOrder(AccountTestInvoicingCommon):
+    """El orden de la cadena de operaciones de un cheque lo da la confirmación, no el borrador.
+
+    De ese orden dependen el diario actual del cheque (si sigue en cartera) y el bloqueo para
+    restablecer un pago a borrador. Cuando el orden se deduce de ``create_date``, una orden de pago
+    que estuvo un rato en borrador queda al principio de la cadena aunque se confirme última: el
+    cheque entregado sigue figurando disponible y la OP no se puede corregir (tickets 126339 y
+    126474).
+
+    El setup no usa ``L10nLatamCheckTest``: ese common arma una compañía argentina con
+    ``setup_other_company()``, y sobre una base con ``saas_client_account`` instalado eso choca
+    contra su constraint de moneda-vs-país. Armamos el diario acá, como ya hace
+    ``test_check_payment_journal_entry``.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Diario de efectivo con cheques de terceros: es el tipo de diario donde el core habilita
+        # estos métodos de pago, y liquidan contra una cuenta puente, no contra la de efectivo.
+        cls.check_journal = cls.env["account.journal"].create(
+            {
+                "name": "Third Party Checks Order",
+                "code": "TPCOR",
+                "type": "cash",
+                "company_id": cls.company_data["company"].id,
+                "inbound_payment_method_line_ids": [
+                    Command.create(
+                        {
+                            "payment_method_id": cls.env.ref(
+                                "l10n_latam_check.account_payment_method_new_third_party_checks"
+                            ).id,
+                            "payment_account_id": cls.inbound_payment_method_line.payment_account_id.id,
+                        }
+                    )
+                ],
+                "outbound_payment_method_line_ids": [
+                    Command.create(
+                        {
+                            "payment_method_id": cls.env.ref(
+                                "l10n_latam_check.account_payment_method_out_third_party_checks"
+                            ).id,
+                            "payment_account_id": cls.outbound_payment_method_line.payment_account_id.id,
+                        }
+                    )
+                ],
+            }
+        )
+        cls.in_check_line = cls.check_journal.inbound_payment_method_line_ids.filtered(
+            lambda line: line.code == "new_third_party_checks"
+        )
+        cls.out_check_line = cls.check_journal.outbound_payment_method_line_ids.filtered(
+            lambda line: line.code == "out_third_party_checks"
+        )
+
+    def _create_receipt(self, check_number="00000101"):
+        """Recibo de cliente donde nace el cheque de terceros."""
+        payment = self.env["account.payment"].create(
+            {
+                "partner_id": self.partner_a.id,
+                "payment_type": "inbound",
+                "journal_id": self.check_journal.id,
+                "payment_method_line_id": self.in_check_line.id,
+                "l10n_latam_new_check_ids": [
+                    Command.create(
+                        {
+                            "name": check_number,
+                            "payment_date": fields.Date.add(fields.Date.today(), months=1),
+                            "amount": 100.0,
+                        }
+                    )
+                ],
+            }
+        )
+        payment.action_post()
+        return payment
+
+    def _create_draft_delivery(self):
+        """Orden de pago a proveedor, todavía sin el cheque cargado."""
+        return self.env["account.payment"].create(
+            {
+                "partner_id": self.partner_a.id,
+                "payment_type": "outbound",
+                "amount": 100.0,
+                "journal_id": self.check_journal.id,
+                "payment_method_line_id": self.out_check_line.id,
+            }
+        )
+
+    def _force_create_date(self, payment, create_date):
+        """``create_date`` no es escribible por ORM y es justamente la variable del caso."""
+        self.env.cr.execute(
+            "UPDATE account_payment SET create_date = %s WHERE id = %s",
+            (create_date, payment.id),
+        )
+        payment.invalidate_recordset(["create_date"])
+
+    def _deliver_check_created_before_the_receipt(self, check_number="00000101"):
+        """Reproduce el flujo reportado: OP en borrador → recibo confirmado → OP confirmada."""
+        delivery = self._create_draft_delivery()
+        self._force_create_date(delivery, "2026-08-25 09:00:00")
+
+        receipt = self._create_receipt(check_number)
+        check = receipt.l10n_latam_new_check_ids
+        self._force_create_date(receipt, "2026-08-25 11:00:00")
+
+        delivery.l10n_latam_move_check_ids = [Command.set(check.ids)]
+        delivery.action_post()
+        return receipt, delivery, check
+
+    def test_delivery_confirmed_last_is_the_last_operation(self):
+        """Confirmar último deja al pago último en la cadena, aunque su borrador sea el más viejo."""
+        receipt, delivery, check = self._deliver_check_created_before_the_receipt("00000101")
+
+        self.assertEqual(
+            check._get_last_operation(),
+            delivery,
+            "La última operación del cheque debe ser la entrega, que fue lo último confirmado.",
+        )
+        self.assertGreater(
+            delivery.l10n_latam_move_check_ids_operation_date,
+            receipt.l10n_latam_move_check_ids_operation_date,
+            "La entrega se confirmó después del recibo, su fecha de operación debe ser posterior.",
+        )
+
+    def test_delivered_check_is_not_available_anymore(self):
+        """El síntoma de los tickets: el cheque entregado seguía disponible en la cartera."""
+        __, __, check = self._deliver_check_created_before_the_receipt("00000102")
+
+        self.assertFalse(
+            check.current_journal_id,
+            "El cheque entregado a un proveedor no debe seguir disponible en la cartera.",
+        )
+
+    def test_delivery_can_be_reset_to_draft(self):
+        """El otro síntoma: no dejaba corregir la OP porque la creía anterior al recibo."""
+        __, delivery, __ = self._deliver_check_created_before_the_receipt("00000103")
+
+        delivery.action_draft()
+
+        self.assertEqual(delivery.state, "draft")
+
+    def test_receipt_cannot_be_reset_to_draft_once_delivered(self):
+        """Contracara: con la cadena bien ordenada, el recibo ya no es la última operación.
+
+        Es lo que protege el caso del ticket 123455, donde re-confirmar el recibo lo mandaba al
+        final de la cadena y devolvía el cheque a la cartera.
+        """
+        receipt, __, __ = self._deliver_check_created_before_the_receipt("00000104")
+
+        with self.assertRaisesRegex(ValidationError, "not the last operation"):
+            receipt.action_draft()
+
+    def test_operations_confirmed_in_the_same_second_do_not_tie(self):
+        """Dos pagos creados en el mismo instante igual tienen que quedar ordenados."""
+        delivery = self._create_draft_delivery()
+        self._force_create_date(delivery, "2026-08-25 09:00:00")
+
+        receipt = self._create_receipt("00000105")
+        check = receipt.l10n_latam_new_check_ids
+        self._force_create_date(receipt, "2026-08-25 09:00:00")
+
+        delivery.l10n_latam_move_check_ids = [Command.set(check.ids)]
+        delivery.action_post()
+
+        self.assertNotEqual(
+            delivery.l10n_latam_move_check_ids_operation_date,
+            receipt.l10n_latam_move_check_ids_operation_date,
+            "Dos operaciones del mismo cheque no pueden compartir fecha de operación.",
+        )
+        self.assertEqual(check._get_last_operation(), delivery)

--- a/l10n_latam_check_ux/views/l10n_latam_check_view.xml
+++ b/l10n_latam_check_ux/views/l10n_latam_check_view.xml
@@ -62,8 +62,15 @@
         <field name="inherit_id" ref="l10n_latam_check.view_account_third_party_check_operations_tree"/>
         <field name="arch" type="xml">
             <field name="state" position="after">
-                <field name="l10n_latam_move_check_ids_operation_date" optional="hide"/>
+                <field name="l10n_latam_move_check_ids_operation_date" optional="show"/>
             </field>
+            <!-- La cadena de operaciones del cheque se ordena por su fecha de operacion, no por la
+                 fecha contable: dos operaciones del mismo dia caian en el desempate por id y la
+                 lista quedaba al reves del orden real. El desempate por id acompana al de
+                 _get_last_operation(), asi la primera fila es siempre la ultima operacion. -->
+            <list position="attributes">
+                <attribute name="default_order">l10n_latam_move_check_ids_operation_date desc, id desc</attribute>
+            </list>
         </field>
     </record>
 


### PR DESCRIPTION
## Problem

The order of a check's operation chain decides two things: whether the check is still
`current_journal_id` (i.e. on hand and reusable) and which payment may be reset to draft.
That order is derived from a single field, `l10n_latam_move_check_ids_operation_date`.

Since b2532ac that field is set from the payment's `create_date`. When the outbound payment's
draft is created *before* the receipt that gives birth to the check, the chain comes out
reversed:

| step | action | stored operation date |
|---|---|---|
| 09:00 | payment order created, left in draft | 09:00 |
| 11:00 | receipt created, check born, posted | 11:00 |
| 12:00 | check added to the payment order, posted | **09:00** |

The receipt then wins `_get_last_operation()`, so the delivered check goes back on hand and can
be handed to another vendor, and `action_draft()` refuses to reset the payment order because
"it is not the last operation". Re-posting the payment order does not help: `create_date` never
moves.

## Why not simply revert

The previous behaviour (`fields.Datetime.now()` at post time) fails the opposite way: re-posting
an older payment moves it to the *end* of the chain and puts a delivered check back on hand.
That is the case b2532ac was fixing. Neither timestamp is the right ordering key — this line has
been changed four times in a year, alternating between the two.

## Fix

`action_post()` no longer picks between the two timestamps. It keeps `create_date` as the base
but guarantees monotonicity: a payment being posted can never land before an operation of the
same check that is already posted. Both failure modes are covered by construction, no schema
change and no migration.

- `_get_check_operation_date()` on `account.payment` computes that date, and keeps a per-batch
  map so payments posted together on the same check do not share a date.
- `_get_last_operation()` gets a stable `id` tie-break; equal dates used to fall back to
  recordset order.
- The field default was `fields.Datetime.now()` **called** at import time, so every payment was
  born with the timestamp of the last server restart. Separate bug, same paragraph.

A follow-up worth considering (not in this PR): replacing the date with an explicit operation
sequence number assigned on post and released on draft. That would allow removing the
`timedelta` nudges in the mass transfer wizard and the paired internal transfer, but it needs a
new field and a migration script.

## Test plan

New `l10n_latam_check_ux/tests/test_check_operation_order.py` reproduces the exact flow above
(draft payment order -> receipt posted -> payment order posted) and asserts both reported
symptoms:

- the delivered check is no longer on hand
- the payment order can be reset to draft
- the receipt can no longer be reset to draft (covers the opposite case)
- two payments created in the same second do not tie

The 5 tests fail on 18.0 as it stands (4 failures + 1 error) and pass with this change. Full
`l10n_latam_check_ux` suite is green. `l10n_latam_check` has one pre-existing failure
(`TestOwnChecks.test_02_pay_with_own_check_and_cancel_payment`), unrelated and reproducible
without this change.

Internal task: https://www.adhoc.inc/odoo/project.task/73306