### PR TITLE
[IMP] l10n_latam_check_ux: hide Journal Entry button on the check form

### DIFF
--- a/l10n_latam_check_ux/views/l10n_latam_check_view.xml
+++ b/l10n_latam_check_ux/views/l10n_latam_check_view.xml
@@ -36,6 +36,11 @@
                         type="action"
                         class="oe_highlight"/>
             </xpath>
+            <!-- Con una línea de liquidez por cheque el asiento ya no es 1:1 con outstanding_line_id
+                 (task 70884): el botón deja de tener sentido, igual que lo saca el parche de core
+                 que este módulo reemplaza (odoo/odoo#248741). -->
+            <xpath expr="//button[@name='action_show_journal_entry']" position="replace"/>
+            <field name="outstanding_line_id" position="replace"/>
         </field>
     </record>
 


### PR DESCRIPTION
## Contexto

Task 70884: relocaliza a `l10n_latam_check_ux` el parche de core que Adhoc arrastraba (odoo/odoo#248741 en 19.0 / #248296 en 18.0) para poder correr un core Odoo vanilla. Ese parche, entre otras cosas, borra el botón "Journal Entry" (`action_show_journal_entry`) del form de `l10n.latam.check`, porque con una línea de liquidez por cheque el asiento deja de ser 1:1 con `outstanding_line_id`.

El puerto del resto del comportamiento va en #1166. Ese botón es el único punto que no se puede portar todavía: **con el core parcheado el botón ya no existe**, así que un xpath que lo saque hoy rompe la carga del módulo.

## Qué hace este PR

Agrega el override de vista (xpath sobre `l10n_latam_check.l10n_latam_check_view_form`) que oculta ese botón, para el momento en que el core vuelva a vanilla y el botón reaparezca.

## Secuencia — IMPORTANTE

Este PR depende de que primero se mergee **#1166** y se desparche el core de la imagen Adhoc (se vuelva a Odoo vanilla). **Hasta ese momento el CI de este PR va a estar en rojo** (el xpath apunta a un botón que no existe en el core parcheado que corre hoy). No mergear antes de esa secuencia.

El tripwire que ya está en el harness (`test_check_form_has_no_journal_entry_button`, en #1166) confirma esto: hoy pasa en verde porque el botón no existe; el día que el core se desparche sin este override, se pone en rojo.

## Test plan

- [ ] Mergear #1166 (port del resto del comportamiento)
- [ ] Desparchar el core de la imagen Adhoc
- [ ] Confirmar que `test_check_form_has_no_journal_entry_button` sigue en verde con este PR aplicado
- [ ] Mergear este PR