### PR TITLE
[FIX] account_cashbox: fix session auto-assignment and journal-blind requirement

### DIFF
--- a/account_cashbox/models/account_payment.py
+++ b/account_cashbox/models/account_payment.py
@@ -22,11 +22,12 @@ class AccountPayment(models.Model):
     )
 
     @api.depends_context("uid")
-    # dummy depends para que se compute(no estamos seguros porque solo con el depends_context no computa)
-    @api.depends("partner_id")
     def _compute_requiere_account_cashbox_session(self):
-        self.requiere_account_cashbox_session = self.env.user.requiere_account_cashbox_session
+        for rec in self:
+            rec.requiere_account_cashbox_session = self.env.user.requiere_account_cashbox_session
 
+    @api.depends_context("uid")
+    @api.depends("journal_id", "company_id")
     def _compute_cashbox_session_id(self):
         for rec in self:
             # solo sesiones operables para este pago: mismo criterio que el dominio de la vista,
@@ -41,7 +42,13 @@ class AccountPayment(models.Model):
             if rec.journal_id:
                 domain += [("cashbox_id.journal_ids", "in", rec.journal_id.ids)]
             session_ids = self.env["account.cashbox.session"].search(domain)
-            if len(session_ids) == 1:
+            if rec.cashbox_session_id in session_ids:
+                # ya elegida (a mano o por un compute anterior) y sigue siendo operable: no la
+                # pisamos. Sin esto, _onchange_cashbox_session ajustando journal_id como efecto
+                # de la eleccion manual del usuario retrigger este compute (depende de
+                # journal_id) y le borra la sesion que acaba de elegir.
+                rec.cashbox_session_id = rec.cashbox_session_id
+            elif len(session_ids) == 1:
                 rec.cashbox_session_id = session_ids.id
             elif len(session_ids) > 1:
                 # la caja por defecto del usuario sirve solo si su sesion esta entre las operables
@@ -49,6 +56,28 @@ class AccountPayment(models.Model):
                 rec.cashbox_session_id = default_session if default_session in session_ids else False
             else:
                 rec.cashbox_session_id = False
+
+    @api.model
+    def default_get(self, fields_list):
+        # sembramos cashbox_session_id con la sesion abierta de la caja por defecto del
+        # usuario para que, en un pago nuevo, el diario se resuelva a partir de ella (via
+        # _onchange_cashbox_session, mas abajo) en vez de al reves. Solo si journal_id
+        # tambien esta en fields_list: eso significa que el caller no lo fijo explicito en
+        # su propio create()/vals (default_get solo pide los campos ausentes de vals) - si
+        # ya viene fijado (wizard de registro, transferencia masiva, un create() directo),
+        # no hay que pisarlo con la caja por defecto a ciegas.
+        defaults = super().default_get(fields_list)
+        if (
+            "cashbox_session_id" in fields_list
+            and "journal_id" in fields_list
+            and not defaults.get("cashbox_session_id")
+        ):
+            user = self.env.user
+            if user.requiere_account_cashbox_session and user.default_cashbox_id:
+                session = user.default_cashbox_id.current_session_id
+                if session.state == "opened":
+                    defaults["cashbox_session_id"] = session.id
+        return defaults
 
     @api.constrains("journal_id", "currency_id", "cashbox_session_id")
     def check_journal_currency(self):
@@ -77,6 +106,17 @@ class AccountPayment(models.Model):
                 and rec.requiere_account_cashbox_session
                 and not rec.cashbox_session_id
             ):
+                journal_in_cashbox_scope = self.env["account.cashbox"].search_count(
+                    [("company_id", "=", rec.company_id.id), ("journal_ids", "=", rec.journal_id.id)]
+                )
+                if not journal_in_cashbox_scope:
+                    raise UserError(
+                        _(
+                            "Your user is required to use a payment session for each payment, but the payment "
+                            "journal (%s) is not managed by any cashbox for this company.",
+                            rec.journal_id.name,
+                        )
+                    )
                 raise UserError(
                     _(
                         "Your user is required to use a payment session for each payment, but there is no open "

--- a/account_cashbox/wizards/account_payment_register.py
+++ b/account_cashbox/wizards/account_payment_register.py
@@ -23,11 +23,12 @@ class AccountPaymentRegister(models.TransientModel):
     )
 
     @api.depends_context("uid")
-    # dummy depends para que se compute(no estamos seguros porque solo con el depends_context no computa)
-    @api.depends("journal_id")
     def _compute_requiere_account_cashbox_session(self):
-        self.requiere_account_cashbox_session = self.env.user.requiere_account_cashbox_session
+        for rec in self:
+            rec.requiere_account_cashbox_session = self.env.user.requiere_account_cashbox_session
 
+    @api.depends_context("uid")
+    @api.depends("journal_id", "company_id")
     def _compute_cashbox_session_id(self):
         for rec in self:
             # mismo criterio que en account.payment: la sesion tiene que ser de la compañia del
@@ -42,7 +43,10 @@ class AccountPaymentRegister(models.TransientModel):
             if rec.journal_id:
                 domain += [("cashbox_id.journal_ids", "in", rec.journal_id.ids)]
             session_ids = self.env["account.cashbox.session"].search(domain)
-            if len(session_ids) == 1:
+            if rec.cashbox_session_id in session_ids:
+                # ya elegida y sigue siendo operable: no la pisamos (ver account.payment)
+                rec.cashbox_session_id = rec.cashbox_session_id
+            elif len(session_ids) == 1:
                 rec.cashbox_session_id = session_ids.id
             else:
                 rec.cashbox_session_id = False


### PR DESCRIPTION
## Qué pasaba

Sigue de cerca a https://github.com/ingadhoc/account-payment/pull/1189 (ticket interno 126172): al auditar la misma zona aparecieron otros problemas en la asignación automática de `cashbox_session_id`.

**1) La sesión nunca se autocompletaba en un pago nuevo, ni con el diario correcto ya puesto.** `_compute_cashbox_session_id` no tenía `@api.depends` (a diferencia de `_compute_requiere_account_cashbox_session`, que sí). Sin `@api.depends`, el webclient nunca vuelve a correr el compute cuando cambia `journal_id` o `company_id` en el formulario.

**2) Y aunque se arregle (1), un pago nuevo en blanco sigue sin sesión.** El diario por defecto de un pago nuevo sale de la lógica genérica de `account.payment` (primer diario disponible / método de pago preferido del contacto), que no tiene por qué coincidir con el diario que maneja la caja del usuario. Con solo (1), `cashbox_session_id` queda vacío hasta que el usuario cambia el diario a mano al de su caja — lo cual, siendo `required` en `state == 'draft'`, bloquea guardar el borrador.

**3) `action_post` tira siempre el mismo mensaje, sea cual sea la causa.** Un usuario con `requiere_account_cashbox_session=True` que intenta postear en un diario que no está gestionado por ninguna `account.cashbox` (transferencias internas, diarios misceláneos) se encuentra con un mensaje que sugiere "no hay sesión abierta", cuando en realidad ese diario nunca va a tener una sesión posible — son dos causas distintas y el mensaje no las distingue.

**4) El `@api.depends` de (1) introdujo un loop de onchange propio.** `_compute_cashbox_session_id` (depende de `journal_id`) y `_onchange_cashbox_session` (ajusta `journal_id` cuando la sesión elegida no opera el diario actual) se retroalimentan: el usuario cambia el diario → se borra la sesión (esperado) → el usuario elige una sesión a mano → el onchange puede reajustar el diario → eso retrigger el compute → si la sesión recién elegida no es la de la caja default, se vuelve a borrar. El usuario queda sin poder fijar una sesión manual en un diario elegido a mano. Reproducido en video adjunto al ticket.

Los tres primeros confirmados con `odoo.tests.Form` (emulando el onchange real del webclient) contra `all_v18`; el cuarto reproducido por interfaz.

## Qué cambia

- `account.payment._compute_cashbox_session_id` y `account.payment.register._compute_cashbox_session_id`: se agrega el `@api.depends("journal_id", "company_id")` que faltaba (más `@api.depends_context("uid")`, ya presente en el compute vecino). Cierra (1).
- `account.payment.default_get`: si el caller no fijó `journal_id` explícitamente (o sea, todavía es un pago nuevo en blanco) y el usuario tiene una caja por defecto con sesión abierta, siembra `cashbox_session_id` con esa sesión. El `_onchange_cashbox_session` que ya existía resuelve `journal_id` a partir de esa sesión — mismo mecanismo que ya usa cuando el usuario elige la sesión a mano. El guard `"journal_id" in fields_list` evita pisar el diario cuando el caller ya lo fijó en su propio `create()` (wizard de registro, transferencia masiva de cheques, o cualquier `create()` directo con `journal_id` en los vals). Cierra (2).
- `account.payment.action_post`: cuando el posteo se bloquea por falta de sesión, distingue el mensaje según la causa — diario no gestionado por ninguna caja de la compañía vs. diario gestionado pero sin sesión abierta. Cierra (3).
- Ambos `_compute_cashbox_session_id` (modelo y wizard): si la sesión actual del pago ya es una candidata válida para el diario/compañía vigentes, se mantiene tal cual en vez de recalcularse desde cero. Esto rompe el ciclo con `_onchange_cashbox_session` — la elección manual del usuario deja de pisarse a sí misma. Cierra (4).

**Decisión de diseño, a pedido explícito:** se descartó la alternativa de que `requiere_account_cashbox_session` deje de aplicar cuando el diario está fuera del alcance de cualquier caja. Esa flexibilización abría una fuga: un usuario con la bandera activa podía esquivar el control de caja por completo simplemente posteando en un diario "misceláneo". La bandera del usuario sigue mandando siempre — solo cambia el mensaje de error para que sea claro cuál es la causa real del bloqueo.

El caso legítimo no cambia: diario gestionado por una caja pero sin sesión abierta sigue exigiendo el campo. Y un `create()` con diario explícito de una caja distinta a la del usuario sigue resolviendo la sesión de esa caja, no la del usuario (verificado — no se pisa).

## Test plan

Sin tests automatizados — mismo criterio que el PR predecesor (decisión del usuario). Verificado con repros en `odoo shell` contra `all_v18`, usando `Form()` para reproducir el onchange real del webclient (todo dentro de `SAVEPOINT`/`ROLLBACK`, sin persistir nada), y por interfaz para el punto 4:

- [x] Pago nuevo **en blanco** (sin tocar el diario), usuario con caja por defecto y sesión abierta → diario y sesión se completan solos.
- [x] Pago nuevo, diario de la caja por defecto elegido a mano, una sesión abierta candidata → `cashbox_session_id` se completa solo.
- [x] `create()` directo con diario explícito de **otra** caja (no la del usuario) → resuelve la sesión de esa otra caja, no se pisa con la caja por defecto del usuario.
- [x] Pago nuevo, diario fuera de cualquier caja, usuario con `requiere_account_cashbox_session=True` → sigue bloqueado, ahora con mensaje que indica que el diario no está gestionado por ninguna caja.
- [x] Control: diario gestionado por una caja, pero sin sesión abierta → sigue exigiendo el campo (comportamiento preservado).
- [x] Por interfaz: cambiar el diario a mano y elegir a mano una sesión que no sea la de la caja default → la sesión elegida se mantiene, no se vuelve a borrar.
- [x] Suite existente del módulo (`account_cashbox`, `account_cashbox_l10n_latam_check`) sigue en verde.
