### PR TITLE
[FIX] payment_retry: keep pending sends out of the post-process cron

### DIFF
--- a/payment_retry/models/payment_transaction.py
+++ b/payment_retry/models/payment_transaction.py
@@ -38,3 +38,29 @@ class PaymentTransaction(models.Model):
                 self.env.cr.commit()  # pragma pylint: disable=invalid-commit
         if len(tx_ids) > tx_limit:
             self.env.ref("payment_retry.payment_asynchronous_process")._trigger()
+
+    def _cron_post_process(self):
+        """Keep the transactions still waiting to be sent out of the post-processing sweep.
+
+        `payment`'s cron does not filter by state, so it also sweeps the draft transactions
+        `cron_asynchronous_process` is sending. Both update the same row and, under REPEATABLE
+        READ, the one committing last loses its whole transaction. A draft transaction has
+        nothing to post-process, and comes back here once it reaches a final state.
+        """
+        if self:
+            return super()._cron_post_process()
+        # Same domain as the overridden method, minus the transactions waiting to be sent.
+        retry_limit_date = datetime.now() - relativedelta.relativedelta(days=4)
+        txs_to_post_process = self.search(
+            [
+                ("is_post_processed", "=", False),
+                ("last_state_change", ">=", retry_limit_date),
+                "|",
+                ("asynchronous_process", "=", False),
+                ("state", "!=", "draft"),
+            ]
+        )
+        if not txs_to_post_process:
+            # An empty recordset makes the overridden method run its own unfiltered search.
+            return
+        return super(PaymentTransaction, txs_to_post_process)._cron_post_process()


### PR DESCRIPTION
- Override `_cron_post_process` so `payment`'s sweep runs on a domain that excludes the draft transactions `cron_asynchronous_process` still has to send: both crons were updating the same row and, under REPEATABLE READ, the one committing last lost its whole transaction, taking the provider reference of a debit that had already been registered against the customer
- Return early when the filtered domain matches nothing: the overridden method reads an empty recordset as "no records given" and falls back to its own unfiltered search, which would pick up the transactions just excluded
- The domain is a copy of the overridden one, so it has to be revisited whenever the core changes it

Change note: Corregimos un problema por el cual dos procesos automáticos podían trabajar sobre la misma transacción de pago al mismo tiempo y pisarse entre sí. Cuando eso pasaba, se perdía el número de referencia que el medio de pago ya le había asignado al débito: el cobro se ejecutaba igual contra el cliente pero quedaba sin registro en Odoo. Ahora el proceso que confirma los pagos ignora las transacciones que todavía están esperando ser enviadas, así los dos dejaron de cruzarse.