### PR TITLE
[IMP] account_payment_pro_receiptbook: simplify sequence gap computation for receiptbook moves

### DIFF
--- a/account_payment_pro_receiptbook/models/account_move.py
+++ b/account_payment_pro_receiptbook/models/account_move.py
@@ -58,40 +58,10 @@ class AccountMove(models.Model):
 
     @api.depends()
     def _compute_made_sequence_gap(self):
-        with_receiptbook = self.filtered(lambda move: move.receiptbook_id)
-        unposted_recceiptbook = with_receiptbook.filtered(
-            lambda move: move.sequence_number != 0 and move.state != "posted"
-        )
-        unposted_recceiptbook.made_sequence_gap = True
-
-        for (receiptbook, prefix), moves in (
-            (with_receiptbook - unposted_recceiptbook).grouped(lambda m: (m.receiptbook_id, m.sequence_prefix)).items()
-        ):
-            previous_numbers = set(
-                self.env["account.move"]
-                .sudo()
-                .search(
-                    [
-                        ("receiptbook_id", "=", receiptbook.id),
-                        ("sequence_prefix", "=", prefix),
-                        (
-                            "sequence_number",
-                            ">=",
-                            min(moves.mapped("sequence_number")) - 1,
-                        ),
-                        (
-                            "sequence_number",
-                            "<=",
-                            max(moves.mapped("sequence_number")) - 1,
-                        ),
-                    ]
-                )
-                .mapped("sequence_number")
-            )
-            for move in moves:
-                move.made_sequence_gap = move.sequence_number > 1 and (move.sequence_number - 1) not in previous_numbers
-
-        super(AccountMove, self - with_receiptbook)._compute_made_sequence_gap()
+        use_receiptbook_moves = self.filtered(lambda m: m.receiptbook_id)
+        use_receiptbook_moves.made_sequence_gap = False
+        if other_moves := self - use_receiptbook_moves:
+            super(AccountMove, other_moves)._compute_made_sequence_gap()
 
     def _must_check_constrains_date_sequence(self):
         # OVERRIDES sequence.mixin to skip date sequence check for receiptbook moves
@@ -99,3 +69,7 @@ class AccountMove(models.Model):
         if self.receiptbook_id:
             return False
         return super()._must_check_constrains_date_sequence()
+
+    def _set_next_made_sequence_gap(self, made_gap: bool):
+        if other_moves := self.filtered(lambda m: not m.receiptbook_id):
+            super(AccountMove, other_moves)._set_next_made_sequence_gap(made_gap)


### PR DESCRIPTION
Backport of the 19.0 fix (cherry-pick of cd655f33) to 18.0.

## Summary
- Simplifies `_compute_made_sequence_gap` for receiptbook moves: moves with a `receiptbook_id` are never flagged as a sequence gap, instead of being computed from a sliding window of `sequence_number` values.
- The window-based calculation was order-sensitive: multi-payments with a write-off adjustment but no withholding produced a different creation order than ones with a withholding, causing the move to fall outside the expected window and be incorrectly flagged as a gap (shown in red in the Journal Entries list), even though the numbering itself was correct.
- Also adds `_set_next_made_sequence_gap` override so the gap flag isn't propagated to neighboring receiptbook moves.

## Test plan
- [ ] Verify a receiptbook payment with adjustment and no withholding no longer shows in red in the Journal Entries list
- [ ] Verify a receiptbook payment with adjustment and withholding still behaves as before