### PR TITLE
[FIX] l10n_latam_check_ux: use context_today for the check tests' date

### DIFF
--- a/l10n_latam_check_ux/tests/common.py
+++ b/l10n_latam_check_ux/tests/common.py
@@ -24,7 +24,7 @@ class LatamCheckCommon(AccountInvariantsMixin, TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.today = fields.Date.today()
+        cls.today = fields.Date.context_today(cls)
         cls.company = cls.env.company
         cls.company_currency = cls.company.currency_id
         cls.env = cls.env(context=dict(cls.env.context, allowed_company_ids=cls.company.ids))


### PR DESCRIPTION
## Qué pasaba

`l10n_latam_check_ux/tests/common.py` armaba `cls.today` con `fields.Date.today()` (fecha del servidor, sin contexto) mientras el resto del módulo — el wizard de rechazo, `res_partner`, las vistas — usa `fields.Date.context_today()`.

Entre las 23:41 y las 23:56 UTC eso rompe: la demo data pone `tz=Europe/Brussels` en OdooBot (uid=1, quien corre los tests), y en esa franja horaria el reloj de Bruselas ya cruzó al día siguiente. `self.today` queda un día atrás de `context_today()`, así que el `date` que el test le pasa al wizard de rechazo cae "antes" de la última operación real del cheque y dispara el guard `l10n_latam_check_warning_msg` (`ValidationError`), en cascada tumbando los dos asserts siguientes de `test_deposited_check_rejection_reopens_the_debt_and_a_new_check_closes_it`.

No es una regresión de código — el mismo test corrió verde en otro build de la misma tanda a las 01:55 UTC.

## Fix

Una línea: `cls.today = fields.Date.context_today(cls)`, alineado con el resto del módulo.

## Test plan

- [x] Pre-commit verde sobre el archivo modificado.
- [ ] Confirmar en runbot que la suite de `l10n_latam_check_ux` corre verde.
- [ ] Opcional para reproducir el flake a cualquier hora: setear el tz de OdooBot a `Pacific/Kiritimati` (+14) y correr los tests después de las 10:00 UTC.

Ticket 127077.