### PR TITLE
[FIX] l10n_latam_check_ux: link check debit entry to its payment

### DIFF
--- a/l10n_latam_check_ux/wizards/account_check_action_wizard.py
+++ b/l10n_latam_check_ux/wizards/account_check_action_wizard.py
@@ -51,6 +51,10 @@ class AccountCheckActionWizard(models.TransientModel):
                 [("line_ids.name", "=", label), ("date", "=", self.date)], limit=1
             )
             if debit_move:
+                # Vinculamos el asiento al pago que emitió el cheque. Sin esto sus apuntes nacen sin
+                # payment_id y el filtro "Cliente/Proveedor" del tablero de conciliación los esconde:
+                # para las cuentas de pagos pendientes ese filtro exige payment_id distinto de vacío.
+                debit_move.origin_payment_id = check.payment_id
                 check.message_post(
                     body=f'El cheque nro "{check.name}" ha sido debitado. ' + debit_move._get_html_link()
                 )


### PR DESCRIPTION
- Set origin_payment_id on the debit move created by account.check.action.wizard.action_confirm, pointing to the payment that issued the check
- Write it after wizard.reconcile(), once the move is posted and numbered: setting it before would make _compute_name treat the move as a payment and number it with the journal payment sequence

Change note: Al conciliar el extracto bancario, el asiento del débito de un cheque propio ahora aparece entre los movimientos sugeridos sin tener que sacar el filtro "Cliente/Proveedor". Antes quedaba escondido detrás de ese filtro y había que quitarlo a mano para encontrarlo.